### PR TITLE
feat: Phase 2 - Application migration and zsh enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Calendar Versioning](https://calver.org/) using YYY
 
 ### Added
 
+- **Phase 2: Application Migration**
+  - Added `ripgrep` (v15.1.0) to system packages - fast grep alternative
+  - Added `raycast` (v1.103.2) to system packages - productivity launcher (replaces native install)
+  - Configured Oh My Zsh via `programs.zsh.oh-my-zsh` with plugins: git, docker, macos, z, colored-man-pages
+  - Added zsh enhancements: autosuggestions, syntax highlighting, completion, 100k history
+
 - **Nix-Managed Git Configuration**: Full git configuration via home-manager `programs.git`
   - GPG signing enabled by default (`commit.gpgsign = true`, `tag.gpgSign = true`)
   - Created `home/user-config.nix` for centralized user variables (name, email, GPG key ID)
-  - Created `home/git-aliases.nix` with 20 common git aliases (st, ll, lg, co, etc.)
+  - Created `home/git-aliases.nix` with 20 common git aliases (st, lo, lg, co, etc.)
   - Created `home/shell-aliases.nix` with macOS-specific shell aliases
   - Migrated to new `programs.git.settings` syntax (from deprecated `extraConfig`)
   - Comprehensive git settings: histogram diff, rerere, fetch pruning, rebase on pull
@@ -36,6 +42,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) using YYY
   - `d-r` alias for `sudo darwin-rebuild switch --flake ~/.config/nix#default`
 
 ### Changed
+
+- **PR Review Fixes**:
+  - Renamed git alias `ll` to `lo` to avoid conflict with shell `ll` alias
+  - Updated `ss` alias from deprecated `stash save` to modern `stash push` (Git 2.16+)
+  - Removed redundant `home` attribute from `user-config.nix` (use `config.home.homeDirectory`)
 
 - **Permission Accuracy Improvements**:
   - Split `fileCommands` into `fileReadCommands` (read-only) + `fileCreationCommands` (mkdir, touch)

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -23,12 +23,14 @@
 - [x] Document sudo requirements in TROUBLESHOOTING.md
 - [x] Test signed commits (verified via PR)
 
-### Phase 2: Application Migration (NEXT)
-- [ ] Migrate ripgrep to nixpkgs
-- [ ] Migrate raycast (evaluate: nixpkgs vs homebrew cask)
-- [ ] Migrate oh-my-zsh to `programs.zsh.oh-my-zsh`
+### Phase 2: Application Migration ✅ COMPLETE
+- [x] Migrate ripgrep to nixpkgs
+- [x] Migrate raycast to nixpkgs (v1.103.2)
+- [x] Migrate oh-my-zsh to `programs.zsh.oh-my-zsh`
+- [x] Add zsh enhancements (autosuggestions, syntax highlighting, history)
+- [x] Fix PR review comments (ll alias conflict, stash push, redundant home attr)
 
-### Phase 3: macOS Customization Audit
+### Phase 3: macOS Customization Audit (NEXT)
 - [ ] Review all System Preferences changes
 - [ ] Audit backup/ directory for missed configs
 - [ ] Add customizations to `system.defaults`

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -13,13 +13,18 @@
   # System packages from nixpkgs
   # All packages should come from nixpkgs - homebrew is fallback only
   environment.systemPackages = with pkgs; [
+    # CLI tools
     gemini-cli      # Google's Gemini CLI
     gh              # GitHub CLI
-    tree
     git
     gnupg
     nodejs_latest   # Node.js runtime
+    ripgrep         # Fast grep alternative (rg)
+    tree
     vim
+
+    # GUI applications
+    raycast         # Productivity launcher (replaces Spotlight)
     vscode          # Visual Studio Code editor
   ];
 

--- a/home/git-aliases.nix
+++ b/home/git-aliases.nix
@@ -6,7 +6,7 @@
 {
   # Status & info
   st = "status -sb";              # Short status with branch info
-  ll = "log --oneline -20";       # Quick log view
+  lo = "log --oneline -20";       # Quick log view (renamed from ll to avoid shell alias conflict)
   lg = "log --graph --oneline --decorate --all";  # Visual branch graph
   last = "log -1 HEAD --stat";    # Show last commit with stats
 
@@ -35,7 +35,7 @@
   undo = "reset --soft HEAD~1";   # Undo last commit, keep changes staged
 
   # Stash shortcuts
-  ss = "stash save";
+  ss = "stash push";              # Modern syntax (stash save deprecated since Git 2.16)
   sp = "stash pop";
   sl = "stash list";
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -43,6 +43,32 @@ in
     # Shell aliases - see shell-aliases.nix for full list and sudo requirements
     shellAliases = shellAliases;
 
+    # Shell enhancements
+    autosuggestion.enable = true;     # Fish-like autosuggestions
+    syntaxHighlighting.enable = true; # Syntax highlighting for commands
+    enableCompletion = true;          # Tab completion
+    history = {
+      size = 100000;                  # Large history for better recall
+      save = 100000;
+      ignoreDups = true;              # Don't save duplicate commands
+      ignoreAllDups = true;           # Remove older duplicates
+      ignoreSpace = true;             # Don't save commands starting with space
+    };
+
+    # Oh My Zsh - framework for managing zsh configuration
+    # Provides themes, plugins, and helper functions
+    oh-my-zsh = {
+      enable = true;
+      theme = "robbyrussell";  # Default theme, clean and informative
+      plugins = [
+        "git"           # Git aliases and functions (ga, gc, gp, etc.)
+        "docker"        # Docker command completion
+        "macos"         # macOS utilities (ofd, cdf, etc.)
+        "z"             # Jump to frequently used directories
+        "colored-man-pages"  # Colorize man pages for readability
+      ];
+    };
+
     # Source modular shell functions
     # NOTE: session-logging.zsh MUST be last (takes over terminal)
     initContent = ''

--- a/home/user-config.nix
+++ b/home/user-config.nix
@@ -16,8 +16,8 @@
     # System username (matches macOS account)
     name = "jevans";
 
-    # Home directory path
-    home = "/Users/jevans";
+    # NOTE: Home directory path removed - use config.home.homeDirectory instead
+    # This avoids duplication with darwin/configuration.nix
 
     # Full name for git commits and other identity purposes
     fullName = "JacobPEvans";


### PR DESCRIPTION
## Summary

- Add ripgrep and raycast to Nix-managed system packages
- Configure Oh My Zsh with useful plugins via home-manager
- Add zsh enhancements: autosuggestions, syntax highlighting, history settings
- Address PR review comments from previous PRs

## Changes

### New Packages
- `ripgrep` (v15.1.0) - Fast grep alternative
- `raycast` (v1.103.2) - Productivity launcher (replaces native /Applications install)

### Shell Enhancements
- Oh My Zsh with plugins: git, docker, macos, z, colored-man-pages
- Autosuggestions (fish-like suggestions)
- Syntax highlighting for commands
- History: 100k entries, ignore duplicates and space-prefixed commands

### PR Review Fixes
- Renamed git alias `ll` to `lo` (conflicts with shell `ll` alias)
- Updated `ss` alias from `stash save` to `stash push` (modern Git 2.16+ syntax)
- Removed redundant `home` attribute from `user-config.nix`

## Test plan

- [ ] Run `sudo darwin-rebuild switch --flake ~/.config/nix#default`
- [ ] Verify ripgrep: `which rg && rg --version`
- [ ] Verify raycast in /Applications/Nix Apps/
- [ ] Verify oh-my-zsh theme loads (robbyrussell prompt)
- [ ] Test autosuggestions by typing partial commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)