### PR TITLE
feat: add modules/dev/ for development environment packages

### DIFF
--- a/modules/dev/cloud/aws.nix
+++ b/modules/dev/cloud/aws.nix
@@ -1,0 +1,10 @@
+# AWS Cloud Tools
+#
+# AWS CLI and credential management tools for cloud infrastructure work.
+
+{ pkgs }:
+
+with pkgs; [
+  awscli2     # AWS CLI v2 - unified tool to manage AWS services
+  aws-vault   # Secure AWS credential storage (uses OS keychain)
+]

--- a/modules/dev/default.nix
+++ b/modules/dev/default.nix
@@ -1,0 +1,52 @@
+# Development Environment Packages
+#
+# Base development packages shared across all dev profiles.
+# This module collects packages from all subdirectories.
+#
+# Structure:
+#   cloud/     - Cloud provider tools (AWS, etc.)
+#   git/       - Git workflow tools (delta, gh, pre-commit)
+#   linters/   - Code linting tools
+#   node/      - Node.js runtime
+#   security/  - Credential management tools
+#   tools/     - Miscellaneous dev CLI tools
+#   profiles/  - Profile-specific additions (work, personal)
+#
+# Usage:
+#   Import this file and call with { inherit pkgs; } to get package list
+#   Or import individual subdirectory files for specific categories
+
+{ pkgs }:
+
+let
+  # Import all category packages
+  awsPackages = import ./cloud/aws.nix { inherit pkgs; };
+  gitTools = import ./git/tools.nix { inherit pkgs; };
+  linters = import ./linters/common.nix { inherit pkgs; };
+  nodePackages = import ./node/packages.nix { inherit pkgs; };
+  securityTools = import ./security/bitwarden.nix { inherit pkgs; };
+  cliTools = import ./tools/cli.nix { inherit pkgs; };
+in
+{
+  # Base dev packages (all profiles get these)
+  basePackages =
+    awsPackages ++
+    gitTools ++
+    linters ++
+    nodePackages ++
+    securityTools ++
+    cliTools;
+
+  # Profile-specific packages
+  workPackages = import ./profiles/work.nix { inherit pkgs; };
+  personalPackages = import ./profiles/personal.nix { inherit pkgs; };
+
+  # Convenience functions for shells
+  allWorkPackages = pkgs:
+    (import ./default.nix { inherit pkgs; }).basePackages ++
+    (import ./profiles/work.nix { inherit pkgs; });
+
+  allPersonalPackages = pkgs:
+    (import ./default.nix { inherit pkgs; }).basePackages ++
+    (import ./profiles/personal.nix { inherit pkgs; });
+}

--- a/modules/dev/git/tools.nix
+++ b/modules/dev/git/tools.nix
@@ -1,0 +1,12 @@
+# Git Development Tools
+#
+# Enhanced git tooling for development workflows.
+# These complement the base git package in darwin/packages/git.nix
+
+{ pkgs }:
+
+with pkgs; [
+  delta       # Better git diff viewer with syntax highlighting
+  gh          # GitHub CLI for PR/issue management
+  pre-commit  # Framework for managing git pre-commit hooks
+]

--- a/modules/dev/linters/common.nix
+++ b/modules/dev/linters/common.nix
@@ -1,0 +1,21 @@
+# Common Linters
+#
+# Linting tools used across most projects.
+# Support pre-commit hooks and CI/CD pipelines.
+
+{ pkgs }:
+
+with pkgs; [
+  # Shell
+  shellcheck          # Shell script static analysis (POSIX, bash)
+  shfmt               # Shell script formatter
+
+  # Documentation
+  markdownlint-cli2   # Markdown linter (README, docs)
+
+  # CI/CD
+  actionlint          # GitHub Actions workflow linter
+
+  # Nix
+  nixfmt-classic      # Nix code formatter
+]

--- a/modules/dev/node/packages.nix
+++ b/modules/dev/node/packages.nix
@@ -1,0 +1,10 @@
+# Node.js Packages
+#
+# Node.js runtime with npm and npx.
+# Uses stable nixpkgs versions (updates on nix flake update).
+
+{ pkgs }:
+
+with pkgs; [
+  nodejs      # Node.js runtime (includes npm and npx)
+]

--- a/modules/dev/profiles/personal.nix
+++ b/modules/dev/profiles/personal.nix
@@ -1,0 +1,16 @@
+# Personal Development Profile
+#
+# Additional packages and configuration for personal projects.
+# Inherits all base dev packages plus personal tools.
+#
+# Usage: Used by dev-personal shell in flake.nix
+
+{ pkgs }:
+
+with pkgs; [
+  # Add personal project packages here
+  # Examples:
+  # hugo            # Static site generator
+  # imagemagick     # Image manipulation
+  # ffmpeg          # Video/audio processing
+]

--- a/modules/dev/profiles/work.nix
+++ b/modules/dev/profiles/work.nix
@@ -1,0 +1,16 @@
+# Work Development Profile
+#
+# Additional packages and configuration for work projects.
+# Inherits all base dev packages plus work-specific tools.
+#
+# Usage: Used by dev-work shell in flake.nix
+
+{ pkgs }:
+
+with pkgs; [
+  # Add work-specific packages here
+  # Examples:
+  # terraform       # Infrastructure as code
+  # kubectl         # Kubernetes CLI
+  # postgresql      # PostgreSQL client
+]

--- a/modules/dev/security/bitwarden.nix
+++ b/modules/dev/security/bitwarden.nix
@@ -1,0 +1,9 @@
+# Security Tools
+#
+# Password management and credential tools for development workflows.
+
+{ pkgs }:
+
+with pkgs; [
+  bitwarden-cli   # CLI for Bitwarden password manager (bw command)
+]

--- a/modules/dev/tools/cli.nix
+++ b/modules/dev/tools/cli.nix
@@ -1,0 +1,13 @@
+# Development CLI Tools
+#
+# Miscellaneous CLI tools useful for development.
+
+{ pkgs }:
+
+with pkgs; [
+  gemini-cli  # Google's Gemini CLI for AI assistance
+  htop        # Interactive process viewer (better top)
+  mas         # Mac App Store CLI (search/install apps)
+  ncdu        # NCurses disk usage analyzer
+  tldr        # Simplified, community-driven man pages
+]


### PR DESCRIPTION
## Summary
Create hierarchical development environment structure that separates dev-specific packages from system essentials.

**Depends on:** #13

## New Structure
```
modules/dev/
├── default.nix           # Base dev packages (combines all below)
├── profiles/
│   ├── work.nix          # Work-specific additions
│   └── personal.nix      # Personal-specific additions
├── cloud/
│   └── aws.nix           # awscli2, aws-vault
├── git/
│   └── tools.nix         # delta, gh, pre-commit
├── linters/
│   └── common.nix        # shellcheck, shfmt, markdownlint, actionlint, nixfmt
├── node/
│   └── packages.nix      # nodejs (stable)
├── security/
│   └── bitwarden.nix     # bitwarden-cli
└── tools/
    └── cli.nix           # gemini-cli, htop, mas, ncdu, tldr
```

## Package Count
- Base packages: 17 total
- Work profile: inherits base + work-specific
- Personal profile: inherits base + personal-specific

## Test plan
- [ ] `nix eval --impure --expr 'let pkgs = import <nixpkgs> {}; dev = import ./modules/dev { inherit pkgs; }; in builtins.length dev.basePackages'` returns 17
- [ ] Module imports without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)