### PR TITLE
fix: split README tagline to comply with line length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nix Configuration
 
-> Because "it works on my machine" should mean it works on every machine. Deterministic builds, reproducible environments, and the smug satisfaction of knowing exactly what's installed.
+> Because "it works on my machine" should mean it works on *every* machine.
+> Deterministic builds, reproducible environments, and the smug satisfaction of knowing exactly what's installed.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Markdown Lint](https://github.com/JacobPEvans/nix/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/JacobPEvans/nix/actions/workflows/markdownlint.yml)


### PR DESCRIPTION
## Summary

- Split README tagline across two lines to comply with 160-character line length limit
- Added emphasis to "*every*" for visual punch

Fixes #31

## Test Plan

- [x] `markdownlint-cli2 "**/*.md"` passes locally with 0 errors
- [x] Tagline maintains the same witty tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)