### PR TITLE
fix(claude): improve flake-rebuild command reliability

### DIFF
--- a/.claude/commands/flake-rebuild.md
+++ b/.claude/commands/flake-rebuild.md
@@ -79,10 +79,10 @@ Push the branch:
 git push -u origin HEAD
 ```
 
-Create PR with the `dependencies` label (to skip Claude review) and enable auto-merge:
+Create PR with the `dependencies` label (to skip Claude review), or skip if PR already exists:
 
 ```bash
-gh pr create --fill --label dependencies
+gh pr view >/dev/null 2>&1 || gh pr create --fill --label dependencies
 ```
 
 Enable auto-merge (this will merge automatically when checks pass):

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,7 +8,7 @@ jobs:
   claude:
     name: Claude Code Review
     # Skip review for automated dependency updates (e.g., flake-rebuild command)
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'dependencies')"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Add pre-flight checks to ensure clean working state before making changes
- Create feature branch BEFORE making any changes (prevents accidental commits to main)
- Reuse existing branch if it exists (handles retries gracefully instead of failing)
- Use GitHub auto-merge (`gh pr merge --auto`) instead of manual merge
- Add `dependencies` label to skip Claude review for automated updates
- Update `claude.yml` workflow to skip review for PRs with `dependencies` label

## Problem Solved

The previous command had several issues that caused wasted time:
1. Would commit to main first, then fail on push due to branch protection
2. Would fail if a branch with the same date already existed
3. Would manually merge or wait for checks instead of using auto-merge
4. Claude review would run unnecessarily on automated dependency updates

## Test Plan

- [ ] Run `/flake-rebuild` command and verify it creates branch first
- [ ] Verify auto-merge is enabled on the created PR
- [ ] Verify `dependencies` label is applied
- [ ] Verify Claude review is skipped for PRs with `dependencies` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)