### PR TITLE
fix(ci): enable cache for PRs and remove invalid flakehub input

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Build home-manager configuration
         run: |
+          set -o pipefail
+
           # Build and capture output for warning analysis
           nix build .#ci.hmActivationPackage -o result-hm 2>&1 | tee /tmp/build-output.txt
 
@@ -90,7 +92,8 @@ jobs:
           FAIL_PATTERNS=("unable to download" "HTTP error" "permission denied")
           for pattern in "${FAIL_PATTERNS[@]}"; do
             if grep -qi "$pattern" /tmp/build-output.txt; then
-              echo "::error::Build warning detected: $pattern"
+              matched_line=$(grep -i "$pattern" /tmp/build-output.txt | head -1)
+              echo "::error::Build warning detected matching '$pattern': $matched_line"
               exit 1
             fi
           done


### PR DESCRIPTION
## Summary

- Remove `flakehub: false` from all `determinate-nix-action` steps (invalid input causing warnings)
- Enable Magic Nix Cache for ALL runs (was `main`-only)
- Add warning blocklist to fail on cache/network errors

## Problem

The CI was experiencing:
1. `Unexpected input(s) 'flakehub'` warnings on every run (API changed in v3)
2. `HTTP error 401` from cache.flakehub.com (no FlakeHub auth)
3. PRs downloading everything from `cache.nixos.org` (slow!)

## Root Cause

The Magic Nix Cache action had:
```yaml
if: github.ref == 'refs/heads/main'
```

This prevented PRs from even **reading** the cache seeded by main branch builds.

## Solution

1. Remove the invalid `flakehub: false` input (3 occurrences)
2. Remove the main-only condition so PRs can read from cache
3. Add warning blocklist to catch cache failures early

## Expected Results

- ✅ No more `flakehub` warnings
- ✅ No more 401 errors
- ✅ PRs use cached packages (faster builds)
- ✅ Cache/network failures fail fast

## Test plan

- [ ] CI workflow runs without `flakehub` warnings
- [ ] Build & Verify job shows cache hits
- [ ] Fewer `copying path from 'cache.nixos.org'` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)