### PR TITLE
fix(vscode): disable auto-update and remove Continue extension

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -68,7 +68,8 @@ in {
     profiles.default = {
       # Disable VS Code's built-in update mechanism (Nix manages updates)
       enableUpdateCheck = false; # Sets update.mode = "none"
-      enableExtensionUpdateCheck = false; # Sets extensions.autoCheckUpdates = false
+      enableExtensionUpdateCheck =
+        false; # Sets extensions.autoCheckUpdates = false
       userSettings = {
         "editor.formatOnSave" = true;
       } // vscodeGeneralSettings // vscodeGithubCopilotSettings;

--- a/modules/home-manager/vscode/settings.nix
+++ b/modules/home-manager/vscode/settings.nix
@@ -24,8 +24,10 @@ in {
   #
   # NOTE: update.mode and extensions.autoCheckUpdates are set by home-manager module
   # options (enableUpdateCheck/enableExtensionUpdateCheck) in common.nix
-  "update.showReleaseNotes" = false; # Don't show release notes after Nix updates
-  "extensions.autoUpdate" = false; # Don't auto-update extensions (not covered by HM)
+  "update.showReleaseNotes" =
+    false; # Don't show release notes after Nix updates
+  "extensions.autoUpdate" =
+    false; # Don't auto-update extensions (not covered by HM)
 
   # === GIT INTEGRATION ===
 


### PR DESCRIPTION
## Summary

- Disable VS Code's built-in update mechanism (Nix manages updates via nixpkgs)
- Remove Continue extension settings (redundant with Copilot)

## Changes

### Update Settings Added
- `update.mode = "none"` - Completely disable update checks
- `update.showReleaseNotes = false` - Don't show release notes after Nix updates
- `extensions.autoUpdate = false` - Don't auto-update extensions
- `extensions.autoCheckUpdates = false` - Don't check for extension updates
- `enableUpdateCheck = false` and `enableExtensionUpdateCheck = false` at home-manager module level

### Continue Extension Removed
The Continue extension was causing a persistent "dirty" settings.json issue by auto-injecting `yaml.schemas` entries that Nix couldn't pre-declare. Since Copilot provides the same features, removing Continue eliminates this annoyance.

## Test plan

- [ ] Verify VS Code no longer prompts for updates
- [ ] Verify VS Code no longer tries to install helper tools
- [ ] Verify settings.json no longer shows as "dirty" (after uninstalling Continue extension in VS Code UI)
- [ ] Check settings via VS Code → Settings → search "update.mode"

## Manual action required

After merging, uninstall the Continue extension in VS Code:
1. Extensions (Cmd+Shift+X) → Search "Continue" → Uninstall
2. Restart VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)