### PR TITLE
feat(claude): add token optimization env vars and model config

### DIFF
--- a/.claude/commands/flake-rebuild.md
+++ b/.claude/commands/flake-rebuild.md
@@ -17,7 +17,17 @@ Update all flake inputs and rebuild nix-darwin.
 
 ## Steps
 
-### 1. Pre-flight Checks
+### 1. Sync Repository First
+
+**IMPORTANT**: Before starting, run `/git-refresh` to:
+
+- Merge any pending PRs that are ready
+- Sync local main with remote
+- Clean up stale worktrees
+
+This ensures you're working with the latest code and avoids conflicts.
+
+### 2. Pre-flight Checks
 
 Ensure you're on main and it's clean:
 
@@ -29,7 +39,7 @@ git status
 
 If there are uncommitted changes, **STOP** and report to the user.
 
-### 2. Switch to Feature Branch
+### 3. Switch to Feature Branch
 
 Check if the branch already exists. If it does, switch to it. If not, create it.
 
@@ -39,7 +49,7 @@ Branch name format: `chore/flake-update-YYYY-MM-DD` (replace with today's date)
 git checkout chore/flake-update-YYYY-MM-DD 2>/dev/null || git checkout -b chore/flake-update-YYYY-MM-DD
 ```
 
-### 3. Update Flake Inputs
+### 4. Update Flake Inputs
 
 ```bash
 nix flake update
@@ -47,23 +57,23 @@ nix flake update
 
 **On failure**: Switch back to main and report the error.
 
-### 4. Check for Changes
+### 5. Check for Changes
 
 ```bash
 git status
 ```
 
 - If flake.lock is **unchanged**: Switch back to main, report "All flake inputs already up to date" and **STOP**.
-- If flake.lock **changed**: Continue to step 5.
+- If flake.lock **changed**: Continue to step 6.
 
-### 5. Commit the Update
+### 6. Commit the Update
 
 ```bash
 git add flake.lock
 git commit -m "chore(deps): update flake.lock"
 ```
 
-### 6. Rebuild nix-darwin
+### 7. Rebuild nix-darwin
 
 ```bash
 sudo darwin-rebuild switch --flake .
@@ -71,7 +81,7 @@ sudo darwin-rebuild switch --flake .
 
 **On failure**: Report the error but continue to create the PR (the CI will also catch issues).
 
-### 7. Push and Create PR with Auto-Merge
+### 8. Push and Create PR with Auto-Merge
 
 Push the branch:
 
@@ -91,7 +101,7 @@ Enable auto-merge (this will merge automatically when checks pass):
 gh pr merge --auto --squash --delete-branch
 ```
 
-### 8. Return to Main
+### 9. Return to Main
 
 Switch back to main while waiting for auto-merge:
 
@@ -99,7 +109,7 @@ Switch back to main while waiting for auto-merge:
 git checkout main
 ```
 
-### 9. Report Summary
+### 10. Report Summary
 
 Tell the user:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,6 @@
 
 **Strict guidance for AI agents modifying this nix-darwin configuration.**
 
-## Table of Contents
-
-- [Scope of This Document](#scope-of-this-document)
-- [Enforced Git Development Workflow](#enforced-git-development-workflow)
-- [Command Execution Preferences](#command-execution-preferences)
-- [Critical Requirements](#critical-requirements)
-- [Task Management Workflow](#task-management-workflow)
-- [Common Mistakes to Avoid](#common-mistakes-to-avoid)
-- [Claude Code Permission Management](#claude-code-permission-management)
-- [Gemini CLI Permission Management](#gemini-cli-permission-management)
-- [GitHub Copilot CLI Permission Management](#github-copilot-cli-permission-management)
-- [VS Code GitHub Copilot Configuration](#vs-code-github-copilot-configuration)
-- [AI CLI Tools Comparison](#ai-cli-tools-comparison)
-- [Pull Request Workflow](#pull-request-workflow)
-- [Workflow](#workflow)
-- [Anthropic Ecosystem Integration](#anthropic-ecosystem-integration)
-- [Agent OS Integration](#agent-os-integration)
-- [Permission Reference](#permission-reference-load-last-for-context-freshness)
-
-**Navigation Note**: Use this TOC to jump to specific sections. Referenced docs
-([TESTING.md](TESTING.md), [RUNBOOK.md](RUNBOOK.md),
-[docs/ANTHROPIC-ECOSYSTEM.md](docs/ANTHROPIC-ECOSYSTEM.md)) each have their own TOC.
-You do not need to read entire files - navigate via TOC links to relevant sections.
-
----
-
 ## Scope of This Document
 
 This file contains **AI-specific instructions only** - rules and patterns that AI agents need beyond their base training. It should NOT contain:
@@ -39,6 +13,25 @@ This file contains **AI-specific instructions only** - rules and patterns that A
 - Future plans (belongs in PLANNING.md)
 
 **Rule**: If information is useful for humans reading project docs, it belongs in README.md or other project files, not here.
+
+## Session Startup Behavior
+
+**On every session start**, immediately announce:
+
+1. Current model in use (check system info or `/model` command)
+2. Quick status summary
+
+**Format**:
+
+```text
+📊 Session Status
+Model: [current model name]
+Reminder: Switch to Opus (/model opus) for complex architectural decisions,
+multi-file refactoring, or tasks requiring deep reasoning.
+```
+
+**Why**: Default model is Sonnet for cost efficiency. User needs visibility to
+consciously choose Opus when the task warrants it.
 
 ## Enforced Git Development Workflow
 

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1765510851,
-        "narHash": "sha256-qIktaQtWtHl4oTyFUykzskGa7lGd6MO7LhsNPeFADPE=",
+        "lastModified": 1765638060,
+        "narHash": "sha256-Gg4IEYz8dumCGcUyTHTzREysVDAsQcYeybW4vMmqRpE=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "b4e154673d1407b5c65564209744217fe3415ac2",
+        "rev": "4b8960dd1a6e8bf8e24b3235e734f9a7ef7efaff",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1765502985,
-        "narHash": "sha256-7cC4SLj4M+cHmVXd9oDLw+XFYODvKccTB0EOy0QRH/E=",
+        "lastModified": 1765587595,
+        "narHash": "sha256-X9uJaRMr8FtHX2CQ5/15rO2HjH2bKitmWpv/BmxDXAA=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "2192c86c208b39aa262ada534d89f72f65708a8e",
+        "rev": "eb872450105745e9489c6f6d73fa2fb4ff5a1e9a",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1764877727,
-        "narHash": "sha256-YiJkIQKOZxA/sWKOuNr+uWH46Y9I+yIuouhoU3Cee5o=",
+        "lastModified": 1765568404,
+        "narHash": "sha256-/GHJQ8IKMChaJgjh3VPctnQgsYKvXygM2PQ0ygUVYTs=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "ba29cb59194a34d8a99ae170c6c16482dc8afb9c",
+        "rev": "ef506bc3de0d76f154cafb4dbb0f6a259c896ba2",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1764633782,
-        "narHash": "sha256-VdH4H0HSz5Eca2bUVX5c8fQ2KBMGqf/QDrhSF+3XRWE=",
+        "lastModified": 1765587137,
+        "narHash": "sha256-BRW7bHQrnu9C1EtNKaUW+jKc22wUj0M855roesDCg0Y=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "22d3def39e4a6ad96d4fffff7fce5fb28c8d6215",
+        "rev": "19a119f97e361ebdec475cd2bf5667cc4e48e64b",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765480374,
-        "narHash": "sha256-HlbvQAqLx7WqZFFQZ8nu5UUJAVlXiV/kqKbyueA8srw=",
+        "lastModified": 1765606130,
+        "narHash": "sha256-KOP4QnkiRwiD5KEOr6ceF67rfTP1OqPmCCft6xDC3k4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39cb677ed9e908e90478aa9fe5f3383dfc1a63f3",
+        "rev": "d787ec69c3216ea33be1c0424fe65cb23aa8fb31",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/ai-cli/claude-config.nix
+++ b/modules/home-manager/ai-cli/claude-config.nix
@@ -156,12 +156,43 @@ in {
   }) cookbookAgents;
 
   settings = {
+    # Extended thinking enabled with token budget controlled via env vars
+    alwaysThinkingEnabled = true;
+
+    # Session cleanup (upstream default is 30)
+    cleanupPeriodDays = 14;
+
+    # Environment variables for model config and token optimization
+    # See: https://code.claude.com/docs/en/settings
+    # See: https://code.claude.com/docs/en/model-config
+    env = {
+      # Model selection (defaults to Sonnet for cost efficiency)
+      ANTHROPIC_MODEL = "sonnet";
+      CLAUDE_CODE_SUBAGENT_MODEL = "opus";
+      # ANTHROPIC_DEFAULT_OPUS_MODEL = "";
+      # ANTHROPIC_DEFAULT_SONNET_MODEL = "";
+      # ANTHROPIC_DEFAULT_HAIKU_MODEL = "";
+
+      # Token budgets
+      MAX_THINKING_TOKENS = "16384";
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS = "16384";
+      BASH_MAX_OUTPUT_LENGTH = "65536";
+      MAX_MCP_OUTPUT_TOKENS = "25000";
+      SLASH_COMMAND_TOOL_CHAR_BUDGET = "16000";
+
+      # Timeouts
+      BASH_DEFAULT_TIMEOUT_MS = "300000";
+      BASH_MAX_TIMEOUT_MS = "600000";
+    };
+
+    # Permissions from ai-assistant-instructions repo
     permissions = {
       allow = claudeAllowJson.permissions;
       deny = claudeDenyJson.permissions;
       ask = claudeAskJson.permissions;
     };
 
+    # Additional directories accessible to Claude Code without prompts
     additionalDirectories = [ "~/" "~/.claude/" "~/.config/" ];
   };
 

--- a/modules/home-manager/ai-cli/claude/options.nix
+++ b/modules/home-manager/ai-cli/claude/options.nix
@@ -186,31 +186,76 @@ in {
 
     # Settings
     settings = {
+      # Extended thinking mode
       alwaysThinkingEnabled = mkOption {
         type = types.bool;
         default = true;
+        description = ''
+          Enable Claude's extended thinking capability by default.
+          When enabled, Claude can reason through complex problems step-by-step.
+          Token budget controlled by MAX_THINKING_TOKENS in env.
+        '';
       };
+
+      # Session management
+      cleanupPeriodDays = mkOption {
+        type = types.int;
+        default = 14;
+        description = ''
+          Sessions inactive longer than this period are deleted.
+          Default upstream is 30, we use 14 to reduce storage.
+        '';
+      };
+
+      # Permissions
       permissions = {
         allow = mkOption {
           type = types.listOf types.str;
           default = [ ];
+          description = "Commands and operations to auto-approve without prompting";
         };
         deny = mkOption {
           type = types.listOf types.str;
           default = [ ];
+          description = "Commands and operations to permanently block";
         };
         ask = mkOption {
           type = types.listOf types.str;
           default = [ ];
+          description = "Commands and operations requiring user confirmation";
         };
       };
+
       additionalDirectories = mkOption {
         type = types.listOf types.str;
         default = [ ];
+        description = "Directories accessible to Claude Code without prompts";
       };
+
+      # Environment variables for Claude Code
+      # See: https://code.claude.com/docs/en/settings
+      env = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = ''
+          Environment variables passed to Claude Code.
+          Common variables:
+          - MAX_THINKING_TOKENS: Extended thinking token budget (e.g., "16000")
+          - CLAUDE_CODE_MAX_OUTPUT_TOKENS: Max output tokens (e.g., "16000")
+          - BASH_MAX_OUTPUT_LENGTH: Max bash output chars (e.g., "64000")
+          - BASH_DEFAULT_TIMEOUT_MS: Default bash timeout (e.g., "120000")
+          - DISABLE_PROMPT_CACHING: Disable caching ("1" to disable)
+        '';
+        example = {
+          MAX_THINKING_TOKENS = "16000";
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS = "16000";
+        };
+      };
+
       schemaUrl = mkOption {
         type = types.str;
         default = "https://json.schemastore.org/claude-code-settings.json";
+        description = "JSON schema URL for settings validation";
       };
     };
 


### PR DESCRIPTION
## Summary

- Add comprehensive environment variables to Claude Code settings for model and token optimization
- Update flake inputs (home-manager, claude-code-plugins, claude-cookbooks, claude-plugins-official)
- Update `/flake-rebuild` command to run `/git-refresh` first
- Add session startup behavior instruction to CLAUDE.md

## Changes

### Model Configuration
- **ANTHROPIC_MODEL**: `sonnet` (default for cost efficiency)
- **CLAUDE_CODE_SUBAGENT_MODEL**: `opus` (for complex subagent tasks)

### Token Budgets
- **MAX_THINKING_TOKENS**: `16384`
- **CLAUDE_CODE_MAX_OUTPUT_TOKENS**: `16384`
- **BASH_MAX_OUTPUT_LENGTH**: `65536`
- **MAX_MCP_OUTPUT_TOKENS**: `25000`
- **SLASH_COMMAND_TOOL_CHAR_BUDGET**: `16000`

### Timeouts
- **BASH_DEFAULT_TIMEOUT_MS**: `300000` (5 min)
- **BASH_MAX_TIMEOUT_MS**: `600000` (10 min)

### Other Settings
- **cleanupPeriodDays**: `14` (reduced from default 30)
- **alwaysThinkingEnabled**: `true` (with controlled budget via MAX_THINKING_TOKENS)

### Flake Input Updates
- `ai-assistant-instructions`: 2025-12-12 → 2025-12-13
- `claude-code-plugins`: 2025-12-12 → 2025-12-13
- `claude-cookbooks`: 2025-12-04 → 2025-12-12
- `claude-plugins-official`: 2025-12-02 → 2025-12-13
- `home-manager`: 2025-12-11 → 2025-12-13

## Test Plan
- [x] `darwin-rebuild switch --flake .` succeeds
- [x] Verify `~/.claude/settings.json` contains all env vars
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)