### PR TITLE
feat(packages): add claude-monitor to development tools

### DIFF
--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -66,6 +66,7 @@ in
       # Development tools
       # ========================================================================
       claude-code # Anthropic's agentic coding CLI
+      claude-monitor # Real-time Claude Code usage monitor
       gemini-cli # Google's Gemini CLI
       gh # GitHub CLI
       mas # Mac App Store CLI (search: mas search <app>, install: mas install <id>)


### PR DESCRIPTION
## Summary

Added `claude-monitor` (v3.1.0) - Real-time Claude Code usage monitor to the development tools section in darwin/common.nix, positioned next to claude-code for easy discoverability.

## Changes

- Added `claude-monitor` to modules/darwin/common.nix in the Development tools section
- Positioned alongside `claude-code` for related tool grouping

## Test Plan

- [x] Pre-commit hooks pass (nixfmt, statix, deadnix, etc.)
- [x] Flake validation passes (`nix flake check`)
- Build and deploy changes to verify installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>