### PR TITLE
fix: correct bash date comparison in EOL check workflow

### DIFF
--- a/.github/workflows/ci-eol-check.yml
+++ b/.github/workflows/ci-eol-check.yml
@@ -58,14 +58,18 @@ jobs:
           TODAY=$(date +%Y-%m-%d)
           echo "Today's date: $TODAY"
 
-          # String comparison works for ISO 8601 dates (YYYY-MM-DD)
-          if [[ "$TODAY" > "$EOL_DATE" ]]; then
+          # Use sort -V for proper date comparison (ISO 8601: YYYY-MM-DD)
+          # Check if TODAY is after EOL_DATE
+          SORTED=$(printf '%s\n%s\n' "$EOL_DATE" "$TODAY" | sort -V | head -1)
+          if [[ "$SORTED" == "$EOL_DATE" && "$TODAY" != "$EOL_DATE" ]]; then
             echo "::error file=lib/versions.nix,line=7::NixOS $STABLE_VERSION reached end-of-life on $EOL_DATE. Update lib/versions.nix to a supported version."
             echo ""
             echo "Available versions:"
             for version in "${!EOL_DATES[@]}"; do
               eol="${EOL_DATES[$version]}"
-              if [[ "$TODAY" <= "$eol" ]]; then
+              # Check if TODAY is before or equal to eol
+              SORTED_EOL=$(printf '%s\n%s\n' "$TODAY" "$eol" | sort -V | head -1)
+              if [[ "$SORTED_EOL" == "$TODAY" ]]; then
                 echo "  - $version (supported until $eol)"
               fi
             done | sort


### PR DESCRIPTION
## Summary
- Fixes bash syntax error in `.github/workflows/ci-eol-check.yml` affecting all PRs
- Replaces problematic `>` and `<=` operators with `sort -V` based comparison
- Unblocks PRs #124, #122, and #121

## Problem
The EOL check workflow was using `if [[ "$TODAY" > "$EOL_DATE" ]]` which caused syntax errors, preventing all PRs from passing CI checks.

## Solution
Use `sort -V` for proper date comparison (same approach used in nixos-release-check.yml). This handles ISO 8601 date format (YYYY-MM-DD) correctly.

## Test Plan
- [x] Pre-commit hooks pass
- [ ] CI checks pass on this PR
- [ ] Verify all blocked PRs (#124, #122, #121) pass EOL check after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)