### PR TITLE
fix: remove unavailable claude-code-statusline input (404)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,22 +80,6 @@
         "type": "github"
       }
     },
-    "claude-code-statusline": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1765965162,
-        "narHash": "sha256-8/f7Xbz3aV9hAg8J9SSys5HxPzIMXO44rOFWu5ynKXQ=",
-        "owner": "rz1989s",
-        "repo": "claude-code-statusline",
-        "rev": "68a6a18515813c87340ca2f8357f598160002aa4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rz1989s",
-        "repo": "claude-code-statusline",
-        "type": "github"
-      }
-    },
     "claude-cookbooks": {
       "flake": false,
       "locked": {
@@ -252,7 +236,6 @@
         "ai-assistant-instructions": "ai-assistant-instructions",
         "anthropic-skills": "anthropic-skills",
         "claude-code-plugins": "claude-code-plugins",
-        "claude-code-statusline": "claude-code-statusline",
         "claude-cookbooks": "claude-cookbooks",
         "claude-plugins-official": "claude-plugins-official",
         "darwin": "darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -76,14 +76,6 @@
       flake = false; # Not a flake, just fetch the repo
     };
 
-    # Claude Code Statusline - modular multi-line terminal statusline
-    # Provides git status, MCP monitoring, cost tracking, themes
-    # https://github.com/rz1989s/claude-code-statusline
-    claude-code-statusline = {
-      url = "github:rz1989s/claude-code-statusline";
-      flake = false; # Not a flake, just fetch the repo
-    };
-
     # Superpowers - comprehensive software development workflow system
     # Provides brainstorming, planning, execution, testing, and review skills
     # https://github.com/obra/superpowers
@@ -106,7 +98,6 @@
       anthropic-skills,
       agent-os,
       ai-assistant-instructions,
-      claude-code-statusline,
       superpowers-marketplace,
       ...
     }:
@@ -153,7 +144,6 @@
           anthropic-skills
           agent-os
           ai-assistant-instructions
-          claude-code-statusline
           superpowers-marketplace
           ;
       };

--- a/modules/home-manager/ai-cli/claude-config.nix
+++ b/modules/home-manager/ai-cli/claude-config.nix
@@ -11,7 +11,6 @@
   claude-plugins-official,
   anthropic-skills,
   ai-assistant-instructions,
-  claude-code-statusline,
   superpowers-marketplace,
   ...
 }:
@@ -22,11 +21,6 @@ let
   # Local repo path - ONLY used for autoClaude (needs writable git for commits)
   # All other ai-assistant-instructions content comes from Nix store (flake input)
   autoClaudeLocalRepoPath = userConfig.ai.instructionsRepo;
-
-  # Statusline configuration - flat TOML files (required format for statusline tool)
-  # Full config for local terminal, mobile config for SSH sessions
-  statuslineConfigFull = ./claude/statusline/config.toml;
-  statuslineConfigMobile = ./claude/statusline/config-mobile.toml;
 
   # Read permissions from ai-assistant-instructions
   # Helper to reduce repetition (DRY)
@@ -210,7 +204,7 @@ in
       # Model selection is dynamic (via /model command or shell env).
       # To set a default in this config, uncomment below.
       # ANTHROPIC_MODEL = "sonnet";  # Default model for new sessions.
-      CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-4-5-20250929";  # For sub-agents; full model ID required
+      CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-4-5-20250929"; # For sub-agents; full model ID required
       # ANTHROPIC_DEFAULT_OPUS_MODEL = "";
       # ANTHROPIC_DEFAULT_SONNET_MODEL = "";
       # ANTHROPIC_DEFAULT_HAIKU_MODEL = "";
@@ -252,13 +246,13 @@ in
   statusLine = {
     enable = true;
     enhanced = {
-      enable = true;
-      # Pulls from flake input - auto-updated via Dependabot
-      source = claude-code-statusline;
+      # Disabled: upstream repository no longer available (404)
+      # Repository: https://github.com/rz1989s/claude-code-statusline
+      enable = false;
       # Full config for local terminal
-      configFile = statuslineConfigFull;
+      # configFile = statuslineConfigFull;
       # Mobile config for SSH sessions (single-line, minimal)
-      mobileConfigFile = statuslineConfigMobile;
+      # mobileConfigFile = statuslineConfigMobile;
     };
   };
 }

--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -7,7 +7,6 @@
   claude-plugins-official,
   anthropic-skills,
   ai-assistant-instructions,
-  claude-code-statusline,
   superpowers-marketplace,
   ...
 }:
@@ -46,7 +45,6 @@ let
       claude-plugins-official
       anthropic-skills
       ai-assistant-instructions
-      claude-code-statusline
       superpowers-marketplace
       ;
   };
@@ -167,9 +165,8 @@ in
         export PATH="$HOME/.npm-packages/bin:$PATH"
         export NODE_PATH="$HOME/.npm-packages/lib/node_modules"
 
-        # Claude statusline SSH detection (must run before Claude starts)
-        # Switches between full and mobile configs based on session type
-        source ${./zsh/claude-statusline-switch.zsh}
+        # Claude statusline SSH detection (disabled - enhanced statusline unavailable)
+        # source ${./zsh/claude-statusline-switch.zsh}
 
         source ${./zsh/git-functions.zsh}
         source ${./zsh/docker-functions.zsh}


### PR DESCRIPTION
## Summary

Fixes critical CI/build failure caused by unavailable flake input `claude-code-statusline`.

The repository `github:rz1989s/claude-code-statusline` no longer exists (HTTP 404), blocking all `nix build` operations.

## Changes

- Removed `claude-code-statusline` flake input from `flake.nix`
- Disabled enhanced statusline feature in `claude-config.nix`
- Removed unused statusline config variables
- Commented out statusline SSH detection script in `common.nix`
- Updated `flake.lock` to remove the defunct input

## Impact

- Basic Claude Code statusline remains enabled
- Enhanced multi-line statusline feature is now disabled
- All `nix flake check` operations now pass without 404 errors

## Testing

- ✅ `nix flake check` passes
- ✅ All Nix quality checks pass (formatting, statix, deadnix)
- ✅ Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)