### PR TITLE
fix(ci): improve flake update workflow and remove pre-commit auto-update

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -1,5 +1,5 @@
 # Automated flake.lock updates
-# Runs Mon/Thu at 6 AM UTC to keep nix inputs current
+# Runs Mon/Thu/Sat at 6 AM UTC to keep nix inputs current
 # Creates PRs with 'dependencies' label for AI review workflow
 name: Update flake.lock
 
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: "0 6 * * 1" # Monday 6 AM UTC
     - cron: "0 6 * * 4" # Thursday 6 AM UTC
+    - cron: "0 6 * * 6" # Saturday 6 AM UTC
   workflow_dispatch: {} # Manual trigger
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,13 +79,3 @@ repos:
         files: '^modules/home-manager/ai-cli/claude/orchestrator-prompt\.txt$'
         types: [file]
         pass_filenames: false
-
-      # Flake input updates - run on .nix file changes
-      # Updates critical inputs to stay current with upstream
-      - id: update-flake-inputs
-        name: Update flake inputs (nixpkgs, ai-assistant-instructions, agent-os, nix-config-main)
-        entry: nix flake lock --update-input nixpkgs --update-input ai-assistant-instructions --update-input agent-os --update-input nix-config-main
-        language: system
-        files: \.nix$
-        types: [file]
-        pass_filenames: false


### PR DESCRIPTION
## Summary
- Add Saturday to flake update schedule (now Mon/Thu/Sat at 6 AM UTC)
- Remove pre-commit hook that auto-updated flake inputs on .nix changes

## Context
The Dec 18 workflow failure was caused by the defunct `rz1989s/claude-code-statusline` input, which has already been fixed in main (replaced with `Owloops/claude-powerline`).

The pre-commit flake update hook was removed because:
- Slow commits (network calls on every .nix change)
- Unpredictable behavior
- Flake updates should happen via GitHub Actions workflow, not locally

## Test plan
- [ ] Verify pre-commit hooks pass without flake update step
- [ ] Manually trigger "Update flake.lock" workflow after merge to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)