### PR TITLE
fix: improve BWS token validation and error handling

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -363,6 +363,10 @@ Error: Access token is not in a valid format: Doesn't contain a decryption key
 
 **Solution**:
 
+> **Note**: These instructions use the default keychain service name `bws-claude-automation`.
+> If you've customized this via `programs.claude.apiKeyHelper.keychainService` in your Nix
+> configuration, replace `bws-claude-automation` with your configured value throughout these steps.
+
 1. **Delete the corrupted token**:
 
    ```bash

--- a/modules/home-manager/ai-cli/claude/get-api-key.sh
+++ b/modules/home-manager/ai-cli/claude/get-api-key.sh
@@ -22,6 +22,16 @@ BWS_TOKEN=$(security find-generic-password -s "@keychainService@" -w) || {
   exit 1
 }
 
+# Check for required commands
+if ! command -v bws &> /dev/null; then
+  echo "ERROR: 'bws' command not found. Please ensure Bitwarden CLI is installed and in your PATH." >&2
+  exit 1
+fi
+if ! command -v jq &> /dev/null; then
+  echo "ERROR: 'jq' command not found. Please install 'jq' to parse JSON output." >&2
+  exit 1
+fi
+
 # Validate BWS token format (must be non-empty and not contain obvious corruption markers)
 if [[ -z "$BWS_TOKEN" || "$BWS_TOKEN" == "null" ]]; then
   echo "ERROR: BWS token is empty or null" >&2
@@ -34,30 +44,44 @@ fi
 
 # Fetch OAuth token from BWS
 export BWS_ACCESS_TOKEN="$BWS_TOKEN"
-if ! bws secret get "@bwsSecretId@" --output json 2>&1 | jq -r '.value' 2>&1; then
-  ERROR_OUTPUT=$(bws secret get "@bwsSecretId@" --output json 2>&1 || true)
-  echo "ERROR: Cannot retrieve OAuth token from BWS (secret: @bwsSecretId@)" >&2
 
-  # Check for invalid token format error
-  if echo "$ERROR_OUTPUT" | grep -q "not in a valid format"; then
-    echo "" >&2
-    echo "The BWS access token in your Keychain is invalid or corrupted." >&2
-    echo "Fix: Replace the token with a new Machine Account token:" >&2
-    echo "" >&2
-    echo "  1. Delete the corrupted entry:" >&2
-    echo "     security delete-generic-password -s \"@keychainService@\"" >&2
-    echo "" >&2
-    echo "  2. Get a new token from Bitwarden Secrets Manager:" >&2
-    echo "     https://vault.bitwarden.com" >&2
-    echo "" >&2
-    echo "  3. Add to keychain:" >&2
-    echo "     security add-generic-password -s \"@keychainService@\" -a \"\$USER\" -w \"NEW_TOKEN\"" >&2
-    echo "" >&2
-    echo "  4. Verify:" >&2
-    echo "     export BWS_ACCESS_TOKEN=\$(security find-generic-password -s \"@keychainService@\" -w)" >&2
-    echo "     bws secret list" >&2
-  else
-    echo "BWS error: $ERROR_OUTPUT" >&2
+# Run bws and capture all output (stdout and stderr) - only call once for efficiency
+BWS_OUTPUT=$(bws secret get "@bwsSecretId@" --output json 2>&1)
+BWS_EXIT_CODE=$?
+
+# If bws succeeded, try to parse the JSON
+if [[ $BWS_EXIT_CODE -eq 0 ]]; then
+  API_KEY=$(echo "$BWS_OUTPUT" | jq -r '.value' 2>/dev/null)
+  JQ_EXIT_CODE=$?
+  if [[ $JQ_EXIT_CODE -eq 0 && -n "$API_KEY" ]]; then
+    echo "$API_KEY"
+    exit 0
   fi
-  exit 1
+  # If we are here, jq failed or returned an empty key. Fall through to error handling.
 fi
+
+# Handle all errors here (bws failed or jq failed)
+echo "ERROR: Cannot retrieve OAuth token from BWS (secret: @bwsSecretId@)" >&2
+
+# Check for specific invalid token format error
+if echo "$BWS_OUTPUT" | grep -q "not in a valid format"; then
+  echo "" >&2
+  echo "The BWS access token in your Keychain is invalid or corrupted." >&2
+  echo "Fix: Replace the token with a new Machine Account token:" >&2
+  echo "" >&2
+  echo "  1. Delete the corrupted entry:" >&2
+  echo "     security delete-generic-password -s \"@keychainService@\"" >&2
+  echo "" >&2
+  echo "  2. Get a new token from Bitwarden Secrets Manager:" >&2
+  echo "     https://vault.bitwarden.com" >&2
+  echo "" >&2
+  echo "  3. Add to keychain:" >&2
+  echo "     security add-generic-password -s \"@keychainService@\" -a \"\$USER\" -w \"NEW_TOKEN\"" >&2
+  echo "" >&2
+  echo "  4. Verify:" >&2
+  echo "     export BWS_ACCESS_TOKEN=\$(security find-generic-password -s \"@keychainService@\" -w)" >&2
+  echo "     bws secret list" >&2
+else
+  echo "BWS error: $BWS_OUTPUT" >&2
+fi
+exit 1


### PR DESCRIPTION
## Summary

Fixes #173 - Enhances the `claude-api-key-helper` script to better detect and report invalid BWS access tokens before attempting to use them.

## Changes

- **Script improvements** (`get-api-key.sh`):
  - Add validation for empty/null BWS tokens
  - Detect "not in a valid format" errors from bws CLI
  - Provide detailed recovery instructions in error messages with step-by-step guidance
  
- **Documentation** (`TROUBLESHOOTING.md`):
  - Add new section "Invalid BWS Access Token" 
  - Document the problem, cause, impact, and solution
  - Include verification steps and prevention tips

## Problem

When the BWS access token stored in macOS Keychain becomes corrupted or invalid, the previous error message was generic:

```
ERROR: Cannot retrieve OAuth token from BWS (secret: ...)
```

This didn't indicate that the token itself was invalid, making it difficult to diagnose the root cause.

## Solution

Now when an invalid BWS token is detected, users get actionable guidance:

```
ERROR: Cannot retrieve OAuth token from BWS (secret: ...)

The BWS access token in your Keychain is invalid or corrupted.
Fix: Replace the token with a new Machine Account token:

  1. Delete the corrupted entry:
     security delete-generic-password -s "bws-claude-automation"

  2. Get a new token from Bitwarden Secrets Manager:
     https://vault.bitwarden.com

  3. Add to keychain:
     security add-generic-password -s "bws-claude-automation" -a "$USER" -w "NEW_TOKEN"

  4. Verify:
     export BWS_ACCESS_TOKEN=$(security find-generic-password -s "bws-claude-automation" -w)
     bws secret list
```

## Impact

- Auto-claude Slack notifications will work reliably
- Headless Claude authentication failures will be easier to diagnose
- Users can self-service BWS token issues without deep troubleshooting

## Test Plan

- [x] `nix flake check` passes
- [x] Pre-commit hooks pass (markdownlint, format, lint, deadnix)
- [ ] Manually test with corrupted BWS token (requires production keychain access)
- [ ] Verify error messages appear correctly when token is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)