### PR TITLE
fix: Remove bypassPermissions from auto-claude for security

### DIFF
--- a/modules/home-manager/ai-cli/claude/auto-claude.sh
+++ b/modules/home-manager/ai-cli/claude/auto-claude.sh
@@ -381,10 +381,13 @@ elif command -v timeout &>/dev/null; then
   TIMEOUT_CMD="timeout 3600"
 fi
 
+# SECURITY: Uses default permission mode which respects the curated allowlist
+# in ~/.claude/settings.json (managed by ai-assistant-instructions flake input).
+# The orchestrator prompt instructs Claude to use only pre-approved commands.
+# Commands not in the allowlist will fail rather than prompting (since running unattended).
 $TIMEOUT_CMD claude -p "$ORCHESTRATOR_PROMPT" \
   --output-format stream-json \
   --verbose \
-  --permission-mode bypassPermissions \
   --max-budget-usd "$MAX_BUDGET_USD" \
   --no-session-persistence \
   2>&1 | tee "$LOG_FILE"

--- a/modules/home-manager/ai-cli/claude/orchestrator-prompt.txt
+++ b/modules/home-manager/ai-cli/claude/orchestrator-prompt.txt
@@ -336,6 +336,17 @@ SAFETY CONSTRAINTS
 - Never create PRs when open PR count >= 10 (clear backlog first)
 - Never work on issues with 'ai-created' label (human review required)
 
+PERMISSION CONSTRAINTS (CRITICAL)
+This session runs with a curated permission allowlist (not bypassPermissions).
+Only commands in ~/.claude/settings.json permissions.allow are permitted.
+
+- Commands not in the allowlist will FAIL (no prompt in unattended mode)
+- Use standard git, gh, nix, and Unix commands from the allowlist
+- If a command fails with permission error, try an alternative approach
+- Sub-agents inherit the same permission constraints
+- The allowlist includes 300+ pre-approved commands for typical development tasks
+- See ai-assistant-instructions flake input for the complete allowlist
+
 AI-CREATED ISSUE WORKFLOW
 Issues created by AI agents require human review before work begins:
 


### PR DESCRIPTION
## Summary
Fixes #154 - Removes the security risk of `--permission-mode bypassPermissions` from auto-claude.sh

## Changes
- **Removed** `--permission-mode bypassPermissions` flag from Claude CLI invocation
- **Added** security documentation explaining the permission model
- **Updated** orchestrator prompt with PERMISSION CONSTRAINTS section
- Auto-claude now respects the curated 300+ command allowlist from `~/.claude/settings.json`

## Security Impact
**Before**: Auto-claude bypassed ALL permission checks, allowing unrestricted system access

**After**: Auto-claude uses the curated permission allowlist from ai-assistant-instructions flake input
- Commands not in allowlist will fail instead of bypassing checks
- Maintains autonomous operation while enforcing security boundaries
- No interactive prompts (runs unattended via launchd)

## Test Plan
- [x] `nix flake check` passes
- [x] Pre-commit hooks pass
- [ ] Manual test: Run auto-claude and verify it respects permission boundaries
- [ ] Verify commands from allowlist work correctly
- [ ] Verify disallowed commands fail gracefully

## Related
- Issue #154: [Security] Auto-Claude bypasses all permission checks
- Permission allowlist managed via `ai-assistant-instructions` flake input
- Settings deployed to `~/.claude/settings.json` via Nix

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)