### PR TITLE
feat: enhance Claude statusline with worktree detection

### DIFF
--- a/modules/home-manager/ai-cli/claude/statusline/powerline.nix
+++ b/modules/home-manager/ai-cli/claude/statusline/powerline.nix
@@ -161,21 +161,22 @@ in
 
         # Detect and display worktree information
         worktree_info=""
-        if command -v git &> /dev/null && git rev-parse --git-dir &> /dev/null 2>&1; then
-          # Get the git directory path
-          git_dir=$(git rev-parse --git-dir 2>/dev/null)
-
-          # Check if this is a worktree (git-dir points to .git/worktrees/*)
-          if [[ "$git_dir" =~ \.git/worktrees/([^/]+)$ ]]; then
-            worktree_name="''${BASH_REMATCH[1]}"
-            # Format: [worktree: name]
-            worktree_info="[worktree: $worktree_name] "
+        if command -v git &> /dev/null; then
+          # Try to get the git directory path. This command will fail if not in a git repo.
+          if git_dir=$(git rev-parse --git-dir 2>/dev/null); then
+            # Check if this is a worktree (git-dir contains .git/worktrees/ anywhere in path)
+            # This handles both relative (.git/worktrees/name) and absolute (/path/.git/worktrees/name) paths
+            if [[ "$git_dir" =~ \.git/worktrees/([^/]+)$ ]]; then
+              worktree_name="''${BASH_REMATCH[1]}"
+              # Format: [worktree: name]
+              worktree_info="[worktree: $worktree_name] "
+            fi
           fi
         fi
 
         # If we have worktree info, display it before the powerline output
         if [[ -n "$worktree_info" ]]; then
-          echo -e "\033[1;36m$worktree_info\033[0m"
+          printf '\033[1;36m%s\033[0m\n' "$worktree_info"
         fi
 
         # Run claude-powerline with config


### PR DESCRIPTION
## Summary

Enhances the Claude powerline statusline to consistently display the current Git branch and show the active worktree identifier, addressing Issue #108.

## Changes

- **Git segment configuration**: Enabled `showRepoName` option to display repository name alongside branch information
- **Worktree detection**: Added intelligent worktree detection logic to the statusline wrapper script
- **Visual display**: When in a worktree, displays `[worktree: name]` in cyan before the powerline output
- **Pattern matching**: Detects worktrees by analyzing the `.git/worktrees/*` path structure

## Technical Details

The implementation modifies `/modules/home-manager/ai-cli/claude/statusline/powerline.nix`:

1. Enables `showRepoName` in the git segment to provide additional context
2. Enhances the wrapper script with bash logic to detect worktree environments
3. Uses regex pattern matching to extract worktree names from git directory paths
4. Outputs worktree information in a non-intrusive format that doesn't interfere with powerline formatting

## Testing

- ✅ `nix flake check` passes all checks
- ✅ Pre-commit hooks pass (formatting, linting, validation)
- ✅ Worktree detection logic tested with regex pattern matching

## Acceptance Criteria

- [x] Status line always displays the current Git branch when inside a repository
- [x] When a Git worktree is active, the worktree identifier is shown next to the branch
- [x] The new display does not interfere with other status line elements or existing configuration flags

## Related Issues

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)