### PR TITLE
feat: always show branch and worktree in Claude status line

### DIFF
--- a/modules/home-manager/ai-cli/claude/statusline/powerline.nix
+++ b/modules/home-manager/ai-cli/claude/statusline/powerline.nix
@@ -8,7 +8,7 @@
 # - 5-hour billing block tracking with reset timer
 # - Session and daily cost tracking
 # - Full directory path display
-# - Git info (branch, SHA, stash count)
+# - Git info (branch, worktree, SHA, stash count, upstream)
 # - Context window usage
 # - 6 customizable color themes
 #
@@ -60,7 +60,7 @@ let
   themeName = themeMap.${powerlineStyle} or "dark";
 
   # Rich multi-line configuration for claude-powerline
-  # Displays: directory, git, model, session costs, 5-hour block, daily usage, context
+  # Displays: directory, git (branch, worktree, SHA, stash, upstream), model, session costs, 5-hour block, daily usage, context
   powerlineConfig = {
     theme = themeName;
     style = "powerline";
@@ -68,7 +68,7 @@ let
 
     display = {
       lines = [
-        # Line 1: Directory (full path), Git info, Model
+        # Line 1: Directory (full path), Git info (branch, worktree, SHA, stash, upstream), Model
         {
           segments = {
             directory = {
@@ -77,6 +77,8 @@ let
             };
             git = {
               enabled = true;
+              showBranch = true; # Always show current branch
+              showWorktree = true; # Show worktree name/path when in a worktree
               showSha = true;
               showStash = true;
               showUpstream = true;


### PR DESCRIPTION
## Summary
- Enable `showBranch` option to always display the current Git branch
- Enable `showWorktree` option to show worktree information when applicable
- Update documentation comments to reflect enhanced git information display

## Details
This PR addresses Issue #108 by configuring the Claude powerline statusline to always show the current Git branch and worktree context. Previously, the branch was only sometimes displayed, leading to confusion when working across multiple branches or worktrees.

The changes modify the `powerline.nix` configuration to explicitly enable:
- `showBranch = true` - ensures the current branch is always visible
- `showWorktree = true` - displays the worktree name/path when inside a worktree

These options integrate with the existing git segment which already shows SHA, stash count, and upstream information.

## Test plan
- [x] Verify configuration compiles without errors
- [x] Pre-commit hooks pass (Nix formatting, linting, deadnix)
- [ ] Test in a regular git repository to confirm branch is shown
- [ ] Test in a git worktree to confirm both branch and worktree are shown
- [ ] Confirm no interference with other status line elements

## Related Issues
Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)