### PR TITLE
feat(ci): daily flake updates with auto-merge for claude-code freshness

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -1,13 +1,12 @@
 # Automated flake.lock updates
-# Runs Mon/Thu/Sat at 6 AM UTC to keep nix inputs current
+# Runs daily at 6 AM UTC to keep nix inputs current (especially claude-code)
 # Creates PRs with 'dependencies' label for AI review workflow
+# Low-risk updates auto-merge via review-deps.yml
 name: Update flake.lock
 
 on:
   schedule:
-    - cron: "0 6 * * 1" # Monday 6 AM UTC
-    - cron: "0 6 * * 4" # Thursday 6 AM UTC
-    - cron: "0 6 * * 6" # Saturday 6 AM UTC
+    - cron: "0 6 * * *" # Daily at 6 AM UTC (10-11 PM PT)
   workflow_dispatch: {} # Manual trigger
 
 jobs:

--- a/.github/workflows/review-deps.yml
+++ b/.github/workflows/review-deps.yml
@@ -11,10 +11,8 @@ on:
 jobs:
   review:
     name: AI Dependency Review
-    # TEMPORARILY DISABLED - re-enable when ready
-    if: false
-    # Original condition:
-    # if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    # Only run on PRs with the 'dependencies' label
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/DEPENDENCY-MONITORING.md
+++ b/docs/DEPENDENCY-MONITORING.md
@@ -11,7 +11,7 @@ flake inputs and packages current while minimizing noise and maximizing safety:
 |------|------|----------|---------|----------|----------|
 | **Instant** | ai-assistant-instructions | On push to main | repository_dispatch | deps-update-ai-instructions.yml | `ai-instructions` |
 | **Daily** | Anthropic repos (4 inputs) | 6 AM UTC daily | Scheduled | deps-update-anthropic.yml | `anthropic` |
-| **Bi-weekly** | All flake inputs (11 total) | Mon/Thu 6 AM UTC | Scheduled | deps-update-flake.yml | `dependencies` |
+| **Daily** | All flake inputs (11 total) | 6 AM UTC daily | Scheduled | deps-update-flake.yml | `dependencies` |
 | **Tri-weekly** | Package versions (8 packages) | Mon 7am, Thu 7pm, Sat 7am | Scheduled | deps-monitor-packages.yml | `package-updates` |
 
 ## Workflows
@@ -54,13 +54,14 @@ Updates fast-moving Anthropic repositories daily to stay current with Claude Cod
 gh workflow run deps-update-anthropic.yml
 ```
 
-### 3. Bi-Weekly Full Update: All Inputs
+### 3. Daily Full Update: All Inputs
 
 **Workflow**: `.github/workflows/deps-update-flake.yml`
 
 Comprehensive update of all 11 flake inputs including nixpkgs, darwin, home-manager, and other dependencies.
+Changed from bi-weekly to daily to ensure fast-moving packages like `claude-code` stay current.
 
-**Schedule**: Monday and Thursday at 6 AM UTC
+**Schedule**: Daily at 6 AM UTC (10-11 PM PT previous day)
 
 **Manual trigger:**
 
@@ -224,22 +225,26 @@ schedule:
 If migrating from manual `nix flake update`:
 
 1. ✅ These workflows replace manual updates
-2. ✅ Existing bi-weekly schedule remains unchanged
-3. ✅ New: Daily Anthropic updates (more current tooling)
-4. ✅ New: Instant ai-instructions sync (immediate permission updates)
-5. ✅ New: Package version visibility (proactive monitoring)
+2. ✅ Daily flake updates (changed from bi-weekly for faster claude-code updates)
+3. ✅ Daily Anthropic updates (current tooling)
+4. ✅ Instant ai-instructions sync (immediate permission updates)
+5. ✅ Package version visibility (proactive monitoring)
+6. ✅ Auto-merge for low-risk updates (no manual PR approval needed)
 
-**No breaking changes** - the bi-weekly full update (deps-update-flake.yml) continues as before.
+**Daily workflow**: Updates flow overnight (6 AM UTC) → auto-merge → you pull and rebuild when ready.
 
 ## Future Enhancements
 
 Potential improvements to consider:
 
-- [ ] Add agent-os to daily fast-track (currently only in bi-weekly)
+- [x] ~~Daily nixpkgs updates for claude-code~~ (implemented)
+- [x] ~~Auto-merge for low-risk updates~~ (implemented)
+- [ ] Add agent-os to daily fast-track (currently only in daily full update)
 - [ ] Create security-specific workflow for CVE scanning
 - [ ] Add Slack/Discord notifications for HIGH risk updates
 - [ ] Expand package monitoring to more packages
 - [ ] Add performance metrics (build time tracking)
+- [ ] Optional launchd agent for automatic local rebuilds
 
 ## References
 


### PR DESCRIPTION
## Summary

- Change flake update workflow from tri-weekly (Mon/Thu/Sat) to **daily** at 6 AM UTC
- Re-enable AI-powered auto-merge for low-risk dependency updates (was disabled with `if: false`)
- Update documentation to reflect new daily update flow

## Why

Claude Code was 5 versions behind (2.0.69 vs 2.0.74 in nixpkgs) because:
1. Flake updates only ran tri-weekly
2. Auto-merge was disabled, requiring manual PR approval
3. No automatic mechanism to apply updates locally

## New Flow

```
6 AM UTC          GitHub Actions creates flake.lock update PR
                  ↓
                  AI review assesses risk (LOW/MEDIUM/HIGH)
                  ↓
LOW risk          Auto-merge enabled → PR merges automatically
MEDIUM/HIGH       Held for human review
                  ↓
Morning           User pulls main and rebuilds when ready
```

## Test plan

- [ ] Verify `deps-update-flake.yml` runs daily (can check cron or manual trigger)
- [ ] Verify `review-deps.yml` triggers on dependency PRs and auto-merges LOW risk
- [ ] Documentation accurately describes the new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)