### PR TITLE
chore(deps): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1766357876,
-        "narHash": "sha256-wWnz2CfYrMGjC/kcZL+5o72Le8uZb4O4IFgJDYwvRIM=",
+        "lastModified": 1766536169,
+        "narHash": "sha256-SenSl+lF73czvCbfK/I2YWUUh1b1v2L/jxlcMWcOw84=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "00a0cb241d9a9e2835b2747861e576cb62c10035",
+        "rev": "eb267041dd3a7cc11d6c6d702fe360744b531bbe",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766038392,
-        "narHash": "sha256-ht/GuKaw5NT3M12xM+mkUtkSBVtzjJ8IHIy6R/ncv9g=",
+        "lastModified": 1766524813,
+        "narHash": "sha256-N/sxS27+t9nGvGWqwwAceSMW/Y5ddcypS/aiTnZ7ScA=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "5fb45ece6129bd7ad8f7310df0ae9c00bae7c562",
+        "rev": "c2b36207f2c396c79dbed9d40536db221bd4e363",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766387499,
-        "narHash": "sha256-AjK3/UKDzeXFeYNLVBaJ3+HLE9he1g5UrlNd4/BM3eA=",
+        "lastModified": 1766553851,
+        "narHash": "sha256-hHKQhHkXxuPJwLkI8wdu826GLV5AcuW9/HVdc9eBnTU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "527ad07e6625302b648ed3b28c34b62a79bd103e",
+        "rev": "7eca7f7081036a7b740090994c9ec543927f89a7",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766314097,
-        "narHash": "sha256-laJftWbghBehazn/zxVJ8NdENVgjccsWAdAqKXhErrM=",
+        "lastModified": 1766532406,
+        "narHash": "sha256-acLU/ag9VEoKkzOD202QASX25nG1eArXg5A0mHjKgxM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "306ea70f9eb0fb4e040f8540e2deab32ed7e2055",
+        "rev": "8142186f001295e5a3239f485c8a49bf2de2695a",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
     "superpowers-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1766300387,
-        "narHash": "sha256-2O0UZmYNIrd283QIiUxA4ArWdlV+n3b28f3iR3XHAa4=",
+        "lastModified": 1766561038,
+        "narHash": "sha256-iRQ+nAqIMoL+YNQ/RoJePMY5rmR/6+eSGrln1esKio0=",
         "owner": "obra",
         "repo": "superpowers-marketplace",
-        "rev": "95b4dad5265f488bdfa368d39c9f9c1dcffa3608",
+        "rev": "b720af296ca840f291ba6cd424bd1e28dd934b4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Updates all flake inputs to latest versions.

### Updated Inputs

| Input | From | To |
|-------|------|-----|
| nixpkgs | 2025-12-21 | 2025-12-23 |
| darwin | 2025-12-18 | 2025-12-23 |
| home-manager | 2025-12-22 | 2025-12-24 |
| ai-assistant-instructions | 2025-12-21 | 2025-12-24 |
| superpowers-marketplace | 2025-12-21 | 2025-12-24 |

### Notable Changes

- **Claude Code**: 2.0.74 → 2.0.76

### Test Plan

- [x] `nix flake update` completed successfully
- [x] `darwin-rebuild switch --flake .` builds successfully
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)