### PR TITLE
refactor: migrate check-jsonschema to ephemeral nix shell usage

### DIFF
--- a/.claude/commands/test-perms.md
+++ b/.claude/commands/test-perms.md
@@ -8,7 +8,7 @@ allowed-tools:
   - "Glob(**)"
   - "Grep(**)"
   - "Bash(jq:*)"
-  - "Bash(check-jsonschema:*)"
+  - "Bash(nix shell:*)"
   - "Bash(whoami:*)"
   - "Bash(date:*)"
   - "Bash(pwd:*)"
@@ -44,7 +44,7 @@ Verify Claude Code settings and test that allowed commands run without prompts.
 
 1. **Check Settings File**: Read `~/.claude/settings.json`, verify valid JSON, confirm `permissions.allow` has 100+ entries
 
-2. **Validate Schema**: Run `check-jsonschema` against `https://json.schemastore.org/claude-code-settings.json`
+2. **Validate Schema**: Run `nix shell nixpkgs#check-jsonschema -c check-jsonschema` against `https://json.schemastore.org/claude-code-settings.json`
 
 3. **Test Single Command**: Run one command from this file's allowed-tools list
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,10 +59,10 @@ repos:
         exclude: ^worktrees/
         pass_filenames: false
 
-      # Claude Code settings validation - check-jsonschema installed via nix
+      # Claude Code settings validation - check-jsonschema via nix shell
       - id: validate-claude-settings
         name: Validate Claude settings
-        entry: check-jsonschema --schemafile https://json.schemastore.org/claude-code-settings.json
+        entry: nix shell nixpkgs#check-jsonschema -c check-jsonschema --schemafile https://json.schemastore.org/claude-code-settings.json
         language: system
         files: '\.claude/settings(\.local)?\.json$'
         types: [json]

--- a/modules/home-manager/scripts/validate-claude-settings.sh
+++ b/modules/home-manager/scripts/validate-claude-settings.sh
@@ -26,12 +26,7 @@ if [ ! -f "$SETTINGS" ]; then
   exit 0
 fi
 
-if ! command -v check-jsonschema > /dev/null 2>&1; then
-  echo "Note: check-jsonschema not found, skipping Claude settings validation" >&2
-  exit 0
-fi
-
-# Run validation - warn but don't fail activation
-check-jsonschema --schemafile "$SCHEMA_URL" "$SETTINGS" || {
+# Run validation using ephemeral nix shell - warn but don't fail activation
+nix shell nixpkgs#check-jsonschema -c check-jsonschema --schemafile "$SCHEMA_URL" "$SETTINGS" || {
   echo "Warning: Claude Code settings.json validation failed" >&2
 }


### PR DESCRIPTION
## Summary

- Migrated all `check-jsonschema` usage to ephemeral `nix shell nixpkgs#check-jsonschema`
- Updated pre-commit hook to fetch on-demand instead of expecting permanent installation
- Simplified validation script by removing existence check
- Updated test-perms command documentation

## Motivation

The permanent installation in `packages.nix` wasn't working reliably, but the GitHub Actions workflow already demonstrates that ephemeral usage via `nix shell` works perfectly. This change:

1. Aligns with flakes-first philosophy
2. Matches existing GitHub Actions pattern
3. Reduces system closure size
4. Maintains reproducibility via flake.lock

## Changes

### `.pre-commit-config.yaml`
- Updated hook entry to use `nix shell nixpkgs#check-jsonschema -c check-jsonschema`

### `modules/home-manager/scripts/validate-claude-settings.sh`
- Removed command existence check (lines 29-32)
- Direct usage of `nix shell` wrapper
- Simplified from 9 lines to 4 lines

### `.claude/commands/test-perms.md`
- Updated allowed-tools: `Bash(check-jsonschema:*)` → `Bash(nix shell:*)`
- Updated step description to reflect new command syntax

## Testing

- [ ] Pre-commit hook runs successfully with Claude settings changes
- [ ] Validation script executes during home-manager activation
- [ ] No permission prompts when running via `nix shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)