### PR TITLE
chore(deps): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1767361428,
-        "narHash": "sha256-VEqd0ubN9/TEAzYZomfNBKoCg+zNIg+sfMHeFADsKC8=",
+        "lastModified": 1767390281,
+        "narHash": "sha256-z/U7uktODfQFinniI7+r3BCrOCl3qvkcHFiqW1MER30=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "8365ec154d04e298e793fd09bf06304057971625",
+        "rev": "0c1d91c126480018a5e7b2e39fce433df2d96c82",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767104570,
-        "narHash": "sha256-GKgwu5//R+cLdKysZjGqvUEEOGXXLdt93sNXeb2M/Lk=",
+        "lastModified": 1767391542,
+        "narHash": "sha256-qHXxJuFkQhggyeao/kQb6KcOjgz0Ky+ArfowRX1MHaE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4e78a2cbeaddd07ab7238971b16468cc1d14daf",
+        "rev": "2f06b726061b7e1aa69f718e943da9ffcecd6397",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1767363856,
-        "narHash": "sha256-sZpMX0+XwXHJqnM9GEJq4beH67HvOsOq9dKqPn4lvX0=",
+        "lastModified": 1767364726,
+        "narHash": "sha256-/Ei2HXEVFjFhKEXyVHptrY8BSIRMojTBzricW9XBFBs=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "713fadfb0867e4f1da027ce28a17cc2119ebe370",
+        "rev": "9c0c01e8557f9987153a992fdc093ffa2229385b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `flake.lock` to use latest versions of `ai-assistant-instructions`, `home-manager`, and `llm-agents.nix`.
> 
>   - **Dependencies Updated**:
>     - `ai-assistant-instructions`: Updated `lastModified`, `narHash`, and `rev`.
>     - `home-manager`: Updated `lastModified`, `narHash`, and `rev`.
>     - `llm-agents.nix`: Updated `lastModified`, `narHash`, and `rev`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 3470bc2794448a5e228484e1e424e9abafddb53d. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->