### PR TITLE
fix(auto-claude): add Slack channel validation and keychain error handling

### DIFF
--- a/modules/home-manager/ai-cli/claude/auto-claude-notify.py
+++ b/modules/home-manager/ai-cli/claude/auto-claude-notify.py
@@ -20,6 +20,7 @@ Secrets:
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -52,12 +53,28 @@ def validate_slack_channel_id(channel: str) -> bool:
     Returns:
         True if valid, False otherwise
     """
-    import re
-
     # Slack channel IDs must start with C, D, G, or S and contain only alphanumeric characters
     # Minimum 8 characters total (1 prefix + 7+ alphanumeric)
-    pattern = r'^[CDGS][A-Z0-9]{7,}$'
+    # Supports both uppercase and mixed case IDs
+    pattern = r'^[CDGS][A-Za-z0-9]{7,}$'
     return bool(re.match(pattern, channel))
+
+
+def check_channel_and_handle_error(channel: str) -> Optional[int]:
+    """
+    Validate Slack channel ID and print error message if invalid.
+
+    Args:
+        channel: The channel ID to validate
+
+    Returns:
+        1 if invalid (with error message printed), None if valid
+    """
+    if not validate_slack_channel_id(channel):
+        print(f"Error: Invalid Slack channel ID format: {channel}", file=sys.stderr)
+        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
+        return 1
+    return None
 
 
 def escape_slack_markdown(text: str) -> str:
@@ -359,10 +376,9 @@ def parse_log_file(log_path: str) -> dict:
 
 def cmd_run_started(args):
     """Handle run_started event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     blocks, text = blocks_run_started(args.repo, args.budget, args.run_id)
@@ -375,10 +391,9 @@ def cmd_run_started(args):
 
 def cmd_task_started(args):
     """Handle task_started event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     blocks, text = blocks_task_started(args.task, args.agent)
@@ -388,10 +403,9 @@ def cmd_task_started(args):
 
 def cmd_task_completed(args):
     """Handle task_completed event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     blocks, text = blocks_task_completed(args.task, args.pr, args.cost, args.duration)
@@ -401,10 +415,9 @@ def cmd_task_completed(args):
 
 def cmd_task_blocked(args):
     """Handle task_blocked event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     blocks, text = blocks_task_blocked(args.task, args.reason)
@@ -414,10 +427,9 @@ def cmd_task_blocked(args):
 
 def cmd_run_completed(args):
     """Handle run_completed event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
 
@@ -611,10 +623,9 @@ def blocks_cross_issue_update(
 
 def cmd_run_skipped(args):
     """Handle run_skipped event."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     blocks, text = blocks_run_skipped(args.repo, args.reason)
@@ -624,10 +635,9 @@ def cmd_run_skipped(args):
 
 def cmd_session_summary(args):
     """Handle session_summary event - posts to Slack thread, NOT GitHub."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     findings = [f.strip() for f in args.findings.split("|")] if args.findings else []
@@ -649,10 +659,9 @@ def cmd_session_summary(args):
 
 def cmd_cross_issue_update(args):
     """Handle cross_issue_update event - posts to Slack thread, NOT GitHub."""
-    if not validate_slack_channel_id(args.channel):
-        print(f"Error: Invalid Slack channel ID format: {args.channel}", file=sys.stderr)
-        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
-        return 1
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
 
     token = get_slack_token()
     issues = args.issues.split(",") if args.issues else []

--- a/modules/home-manager/ai-cli/claude/auto-claude.sh
+++ b/modules/home-manager/ai-cli/claude/auto-claude.sh
@@ -44,7 +44,7 @@ get_keychain_secret() {
   fi
 
   # Capture both stdout and stderr to detect actual errors
-  local output error_msg exit_code
+  local output exit_code
   output=$(security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$service_name" -w "$AUTOMATION_KEYCHAIN" 2>&1) || {
     exit_code=$?
     # Only log if it's a real error (not just "item not found" which is expected for optional secrets)


### PR DESCRIPTION
## Summary
- Add `validate_slack_channel_id()` function to validate Slack channel IDs
  (must start with C/D/G/S followed by 7+ alphanumeric characters)
- Add validation checks to all Slack notification commands
- Improve keychain secret retrieval to distinguish "item not found" (exit code 44)
  from actual errors
- Only log real errors, not expected missing optional secrets

## Why This Is Needed
1. **Slack validation**: Invalid channel IDs cause runtime errors that are hard to debug.
   Adding upfront validation provides clear error messages.

2. **Keychain handling**: The previous code logged errors for missing optional secrets
   (like Slack channel ID), creating noise in logs. Exit code 44 means "item not found"
   which is expected behavior for optional secrets.

## Test Plan
- [ ] auto-claude runs without Slack channel configured (no errors logged)
- [ ] auto-claude with invalid channel ID shows clear error message
- [ ] auto-claude with valid channel ID sends notifications correctly
- [ ] Keychain errors for unexpected failures are still logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Slack channel ID validation and improves keychain error handling in `auto-claude-notify.py` and `auto-claude.sh`.
> 
>   - **Slack Channel Validation**:
>     - Adds `validate_slack_channel_id()` in `auto-claude-notify.py` to ensure IDs start with C/D/G/S followed by 7+ alphanumeric characters.
>     - Integrates validation in `cmd_run_started`, `cmd_task_started`, `cmd_task_completed`, `cmd_task_blocked`, `cmd_run_completed`, `cmd_run_skipped`, `cmd_session_summary`, and `cmd_cross_issue_update`.
>   - **Keychain Error Handling**:
>     - Updates `get_keychain_secret()` in `auto-claude.sh` to log only real errors, ignoring 'item not found' (exit code 44) for optional secrets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 0d2609cab6c3bf68ec2365e573fa83c482bae08c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->