### PR TITLE
fix(statusline): add early Darwin platform check

### DIFF
--- a/modules/home-manager/ai-cli/claude/statusline/default.nix
+++ b/modules/home-manager/ai-cli/claude/statusline/default.nix
@@ -22,6 +22,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -30,7 +31,7 @@ let
 
   # Platform detection: Check if we're on Darwin (macOS)
   # The statusline packages use BSD stat which only works on Darwin
-  inherit (lib.systems.elaborate config.nixpkgs) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
   imports = [
@@ -53,7 +54,7 @@ in
           Darwin-specific. Linux support would require updating the scripts to
           detect and use GNU stat syntax (stat -c "%Y") instead.
 
-          Current platform: ${config.nixpkgs.system}
+          Current platform: ${pkgs.stdenv.hostPlatform.system}
           Required: *-darwin (e.g., aarch64-darwin, x86_64-darwin)
         '';
       }


### PR DESCRIPTION
## Summary

Implements medium-priority fix M3 from remediation plan:

### Changes
- **Add platform detection** - Use `inherit (lib.systems.elaborate config.nixpkgs) isDarwin`
- **Early assertion** - Fail fast before attempting to build Darwin-only packages
- **Clear error message** - Explain why Darwin is required and how to add Linux support

### Problem

Statusline packages use BSD stat command (`stat -f "%m"`) which only exists on macOS/Darwin. Without this check, Linux users would encounter confusing build errors deep in the package compilation process.

### Solution

Added early platform assertion in the module's config section that:
- Checks if the system is Darwin using `lib.systems.elaborate`
- Provides clear error message explaining the BSD stat dependency
- Shows current platform and required platforms (*-darwin)
- Suggests how to add Linux support (detect and use GNU stat syntax)

### Error Message Example

```
programs.claudeStatusline requires macOS/Darwin.

The statusline packages use BSD stat command (stat -f "%m") which is
Darwin-specific. Linux support would require updating the scripts to
detect and use GNU stat syntax (stat -c "%Y") instead.

Current platform: x86_64-linux
Required: *-darwin (e.g., aarch64-darwin, x86_64-darwin)
```

## Test plan

- [x] `nix flake check` passes (no evaluation errors)
- [x] `nix fmt` applied
- [x] Statix linting passes (using proper `inherit` pattern)
- [ ] Test on Darwin: module enables successfully
- [ ] Test on Linux: assertion fails with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds early platform check for Darwin in `default.nix` to prevent build errors due to BSD `stat` dependency, with clear error messaging and conflict prevention.
> 
>   - **Platform Detection**:
>     - Adds `isDarwin` check in `default.nix` to detect if the system is Darwin (macOS).
>     - Uses `inherit (pkgs.stdenv.hostPlatform) isDarwin` for platform detection.
>   - **Assertions**:
>     - Adds assertion in `config` to fail if not on Darwin, with a clear error message.
>     - Error message explains BSD `stat` dependency and suggests using GNU `stat` for Linux support.
>     - Displays current and required platforms in the error message.
>   - **Misc**:
>     - Prevents conflicts with old statusline modules by adding an assertion to disable `programs.claude.statusLine.enhanced` if both are enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for d9a37ea2238b9829f2b33a8bf4b297d23d745582. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->