### PR TITLE
polish: low-priority fixes from remediation plan

### DIFF
--- a/modules/darwin/file-associations.nix
+++ b/modules/darwin/file-associations.nix
@@ -54,8 +54,10 @@ in
   # Module Options
   # ==========================================================================
   options.system.fileAssociations = {
-    enable = lib.mkEnableOption "custom file type associations" // {
+    enable = lib.mkOption {
+      type = lib.types.bool;
       default = true;
+      description = "Whether to enable custom file type associations";
     };
 
     customExtensions = lib.mkOption {
@@ -74,10 +76,10 @@ in
               example = "public.tar-archive";
             };
 
-            description = lib.mkOption {
+            displayName = lib.mkOption {
               type = lib.types.str;
               default = "";
-              description = "Human-readable description of the file type";
+              description = "Human-readable display name for the file type";
               example = "Splunk archive";
             };
           };
@@ -88,12 +90,12 @@ in
         {
           extension = "spl";
           uti = "public.tar-archive";
-          description = "Splunk archive (tar.gz)";
+          displayName = "Splunk archive (tar.gz)";
         }
         {
           extension = "crbl";
           uti = "public.tar-archive";
-          description = "CRBL archive (tar.gz)";
+          displayName = "CRBL archive (tar.gz)";
         }
       ];
 
@@ -119,12 +121,12 @@ in
           {
             extension = "spl";
             uti = "public.tar-archive";
-            description = "Splunk archive";
+            displayName = "Splunk archive";
           }
           {
             extension = "myarchive";
             uti = "public.tar-archive";
-            description = "My custom archive format";
+            displayName = "My custom archive format";
           }
         ]
       '';
@@ -149,7 +151,7 @@ in
       ${lib.concatMapStringsSep "\n" (
         assoc:
         ''echo "  - .${assoc.extension} → ${assoc.uti}${
-          lib.optionalString (assoc.description != "") " (${assoc.description})"
+          lib.optionalString (assoc.displayName != "") " (${assoc.displayName})"
         }"''
       ) cfg.customExtensions}
       echo ""

--- a/modules/home-manager/ai-cli/claude/options.nix
+++ b/modules/home-manager/ai-cli/claude/options.nix
@@ -236,6 +236,11 @@ in
         type = types.listOf types.str;
         default = [ ];
         description = "Directories accessible to Claude Code without prompts";
+        example = [
+          "~/projects"
+          "~/Documents"
+          "~/.config"
+        ];
       };
 
       # Environment variables for Claude Code

--- a/modules/home-manager/ai-cli/claude/plugins.nix
+++ b/modules/home-manager/ai-cli/claude/plugins.nix
@@ -5,6 +5,23 @@
 #
 # Automatic cleanup: When a marketplace directory exists but should be a symlink,
 # it's automatically removed (with diff reporting). Only one backup is kept.
+#
+# ACTIVATION SCRIPT ORDERING (using home-manager DAG):
+#
+# 1. cleanupMarketplaceDirectories (entryBefore linkGeneration)
+#    - Runs BEFORE home-manager creates symlinks
+#    - Moves conflicting directories to .backup
+#    - Required to prevent "cannot overwrite directory" errors
+#
+# 2. linkGeneration (home-manager built-in)
+#    - Creates all symlinks defined in home.file
+#
+# 3. reportMarketplaceDiffs (entryAfter linkGeneration)
+#    - Runs AFTER symlinks are created
+#    - Shows diffs between backup and new Nix-managed content
+#    - Helps users verify marketplace transitions
+#
+# Do NOT change this ordering without understanding the dependencies.
 { config, lib, ... }:
 
 let


### PR DESCRIPTION
## Summary

Implements low-priority fixes L1, L2, L5, L8 from comprehensive remediation plan.
These are polish improvements: naming fixes, standardization, and documentation.

### Changes

**Code Quality (L1-L2)**:
- L1: Rename `description` option to `displayName` in file-associations.nix
  - Fixes naming collision where an option named "description" had an attribute also named "description"
- L2: Replace non-standard `mkEnableOption // {default=true}` with explicit `mkOption`
  - `mkEnableOption` is specifically for options that default to `false`

**Documentation (L5, L8)**:
- L5: Add examples to `additionalDirectories` option showing common directories
- L8: Document activation script DAG ordering dependencies in plugins.nix header

### Skipped Items

- L3 (sandbox command validation): Sandbox options don't exist in main yet
- L4 (MCP server health check): Deferred - MCP servers are currently disabled
- L6 (MCP disabled field doc): Already documented in mcpServerModule
- L7 (statusLine conflict doc): Already has assertion with detailed message

### Breaking Changes

⚠️ **L1 is a breaking change**:
- Option `system.fileAssociations.customExtensions.<name>.description`
- Renamed to `system.fileAssociations.customExtensions.<name>.displayName`
- Users must update their configurations (unlikely to affect many users)

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix fmt` applied
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Low-priority fixes include renaming `description` to `displayName`, standardizing option usage, and enhancing documentation.
> 
>   - **Code Quality**:
>     - Rename `description` to `displayName` in `file-associations.nix` to avoid naming collision.
>     - Replace `mkEnableOption // {default=true}` with `mkOption` in `file-associations.nix`.
>   - **Documentation**:
>     - Add examples to `additionalDirectories` in `options.nix`.
>     - Document activation script ordering in `plugins.nix`.
>   - **Breaking Changes**:
>     - Rename `system.fileAssociations.customExtensions.<name>.description` to `displayName`. Users must update configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 6e4fadd0df92f27405ed4a80b6a36b3a04cd16c0. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->