### PR TITLE
feat(aws): add terraform-bedrock and iam-user profiles

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -51,48 +51,52 @@ let
   # Default values for all profiles (change here to update all)
   defaultRegion = "us-east-2";
   defaultOutput = "json";
-in
-{
-  # ~/.aws/config - AWS CLI configuration
-  ".aws/config".text = ''
-    # Default profile - used when no --profile is specified
-    [default]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
 
-    # Development environment
-    [profile dev]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
+  # A single list to define all profiles
+  profiles = [
+    {
+      name = "default";
+      comment = "Default profile - used when no --profile is specified";
+    }
+    {
+      name = "dev";
+      comment = "Development environment";
+    }
+    {
+      name = "test";
+      comment = "Test environment";
+    }
+    {
+      name = "terraform";
+      comment = "Terraform automation";
+    }
+    {
+      name = "cribl";
+      comment = "Cribl environment";
+    }
+    {
+      name = "splunk";
+      comment = "Splunk environment";
+    }
+    {
+      name = "terraform-bedrock";
+      comment = "Terraform with Bedrock";
+    }
+    {
+      name = "iam-user";
+      comment = "IAM user profile";
+    }
+  ];
 
-    # Test environment
-    [profile test]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
-
-    # Terraform automation
-    [profile terraform]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
-
-    # Cribl environment
-    [profile cribl]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
-
-    # Splunk environment
-    [profile splunk]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
-
-    # Terraform with Bedrock
-    [profile terraform-bedrock]
-    region = ${defaultRegion}
-    output = ${defaultOutput}
-
-    # IAM user profile
-    [profile iam-user]
+  # A function to generate a single profile block from a definition
+  generateProfile = profile: ''
+    # ${profile.comment}
+    [${if profile.name == "default" then "default" else "profile ${profile.name}"}]
     region = ${defaultRegion}
     output = ${defaultOutput}
   '';
+in
+{
+  # ~/.aws/config - AWS CLI configuration
+  ".aws/config".text = builtins.concatStringsSep "\n\n" (map generateProfile profiles);
 }


### PR DESCRIPTION
## Summary
- Add `terraform-bedrock` profile for Terraform with Bedrock workflows
- Add `iam-user` profile for IAM user workflows
- Both profiles use standard defaults (us-east-2, json output)

## Test plan
- [x] `nix flake check` passes
- [x] `darwin-rebuild switch` successful
- [x] Verified `~/.aws/config` contains new profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `terraform-bedrock` and `iam-user` AWS CLI profiles to `config.nix` with default settings.
> 
>   - **Profiles**:
>     - Add `terraform-bedrock` profile for Terraform with Bedrock workflows.
>     - Add `iam-user` profile for IAM user workflows.
>     - Both profiles use default region `us-east-2` and output `json`.
>   - **Configuration**:
>     - Update `config.nix` to include new profiles in the `profiles` list.
>     - Use `generateProfile` function to apply default settings to new profiles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for e1f8967566c932205301be02894c4b40e1702aac. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->