### PR TITLE
chore(deps): update ai-assistant-instructions for grep/echo permissions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1768148095,
-        "narHash": "sha256-0qJs99tO60uiVnrKHPqLasbsx8tU9bntorRPX3GZnVg=",
+        "lastModified": 1768184546,
+        "narHash": "sha256-uFllFdtu9bQrdwhCrVrPO5Lt0rKvX4dfF9OKaDeX5iU=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "d79fdc6538d3ab43572d3e7b0f35c99c27f866cd",
+        "rev": "9714c47c1f0e7d0d9f0c397793f0e644dd6f9c25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates flake input to include grep/echo permission changes
- Allow 'grep' command (previously denied)
- 'echo' already allowed

## Related
- Upstream PR: https://github.com/JacobPEvans/ai-assistant-instructions/pull/419 (merged)

Fixes Bash permission errors when using grep in pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ai-assistant-instructions` in `flake.lock` to allow `grep` command, fixing permission errors.
> 
>   - **Dependencies**:
>     - Update `ai-assistant-instructions` in `flake.lock` to revision `9714c47c1f0e7d0d9f0c397793f0e644dd6f9c25`.
>   - **Permissions**:
>     - Allow `grep` command in `ai-assistant-instructions` (previously denied).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for a2ebdfc0dd01b5fa53b36927346cd5242ca16388. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->