### PR TITLE
fix(mcp): reorganize external MCP plugins and enable Context7

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -226,7 +226,7 @@ in
           -s "github-pat" -a "${userConfig.user.name}" -w 2>/dev/null || echo "")"}
         # Context7 - for context7@claude-plugins-official MCP server
         export CONTEXT7_API_KEY=''${CONTEXT7_API_KEY:-"$(security find-generic-password \
-          -s "context7-api-key" -a "${userConfig.user.name}" -w 2>/dev/null || echo "")"}
+          -s "CONTEXT7_API_KEY" -a "${userConfig.user.name}" -w 2>/dev/null || echo "")"}
 
 
         # Claude statusline SSH detection (disabled - enhanced statusline unavailable)


### PR DESCRIPTION
## Summary

Reorganizes MCP plugin configuration to fix failing GitHub/Slack plugins and enable Context7 documentation server.

## Changes

### Plugin Organization
- Create dedicated `external.nix` module for all third-party MCP plugins
- Document all 13 external plugins from `claude-plugins-official`
- Move external plugin config out of `official.nix` for better separation
- Update `default.nix` to import and merge the new external module

### MCP Configuration
- **Context7**: Enabled (up-to-date library documentation)
- **GitHub**: Disabled (use gh CLI instead - more reliable)
- **Slack**: Disabled (not needed)
- All other external plugins: Available but disabled by default

### Environment Setup
- Add `CONTEXT7_API_KEY` export via zsh initContent
- Add `GITHUB_PERSONAL_ACCESS_TOKEN` export for future use
- Both fetch from macOS Keychain at runtime

### Files Changed
- `modules/home-manager/ai-cli/claude/plugins/external.nix` (new)
- `modules/home-manager/ai-cli/claude/plugins/default.nix`
- `modules/home-manager/ai-cli/claude/plugins/official.nix`
- `modules/home-manager/common.nix`

## External Plugins Available

| Plugin | Status | Description |
|--------|--------|-------------|
| context7 | ✅ enabled | Up-to-date library documentation |
| asana | disabled | Task/project management |
| linear | disabled | Issue tracking |
| github | disabled | GitHub API integration |
| gitlab | disabled | GitLab integration |
| greptile | disabled | AI codebase search |
| firebase | disabled | Firebase backend |
| supabase | disabled | Supabase backend |
| stripe | disabled | Payment processing |
| playwright | disabled | Browser automation |
| laravel-boost | disabled | Laravel framework |
| slack | disabled | Slack communication |
| serena | disabled | AI memory |

## Test Plan

- [x] `darwin-rebuild switch` completes successfully
- [x] Pre-commit hooks pass (nixfmt, statix, deadnix)
- [ ] Open new terminal to load env vars
- [ ] Verify Context7 API key loads: `echo $CONTEXT7_API_KEY | head -c 10`
- [ ] Restart Claude Code
- [ ] Check MCP menu - should show Context7, no errors
- [ ] Test Context7: "use context7 to explain React hooks"

## Related

- Fixes failing MCP plugin errors shown in "Manage MCP servers" menu
- Source: https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reorganizes MCP plugin configuration, enabling Context7 and disabling GitHub/Slack, with new `external.nix` module and environment setup changes.
> 
>   - **Plugin Organization**:
>     - Create `external.nix` for third-party MCP plugins.
>     - Move external plugin config from `official.nix`.
>     - Update `default.nix` to import `external.nix`.
>   - **MCP Configuration**:
>     - Enable Context7 plugin.
>     - Disable GitHub and Slack plugins.
>   - **Environment Setup**:
>     - Export `CONTEXT7_API_KEY` and `GITHUB_PERSONAL_ACCESS_TOKEN` in `common.nix`.
>     - Fetch keys from macOS Keychain.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 502b5ad8c23d0ba060af9977bfda8201d5071d9e. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->