### PR TITLE
docs(ai-tools): add goose-cli via homebrew with latest version

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -25,13 +25,9 @@ _:
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs
 
-      # Block Goose AI agent - open-source extensible AI agent
-      # Source: https://github.com/block/goose
-      # Homebrew version: 1.19.1 (Jan 7, 2026) ← LATEST! Actively maintained
-      # Why homebrew: nixpkgs has 'goose-cli' at v1.16.1 (Dec 10, 2025, 34 days old)
-      #               Nixpkgs >30 days old, using homebrew per package hierarchy
-      #               Homebrew has latest version (updated same-day as upstream releases)
-      # Note: Homebrew package is 'block-goose-cli' to avoid conflict with nixpkgs 'goose' (database migration tool)
+      # Block Goose AI agent (https://github.com/block/goose)
+      # - Using homebrew as nixpkgs version was >30 days old at time of addition; homebrew actively maintained
+      # - Named 'block-goose-cli' to avoid conflict with nixpkgs 'goose' (database migration tool)
       "block-goose-cli"
     ];
     casks = [

--- a/modules/home-manager/ai-cli/ai-tools.nix
+++ b/modules/home-manager/ai-cli/ai-tools.nix
@@ -54,9 +54,8 @@
 #     - Status: Not in nixpkgs
 #
 # HOMEBREW PACKAGES (from modules/darwin/homebrew.nix):
-#   block-goose-cli: Block's AI agent (nixpkgs v1.16.1 is 34 days old, homebrew has LATEST v1.19.1)
-#     - Status: Using homebrew - nixpkgs >30 days old, homebrew actively maintained with same-day releases
-#     - Verified: Jan 13, 2026 (homebrew formula checked directly)
+#   block-goose-cli: Block's AI agent
+#     - Status: Using homebrew - nixpkgs was >30 days old at time of addition; homebrew actively maintained
 #
 # OTHER TOOLS (installed via other methods):
 #   aider: Via pipx (Python package, not available in nixpkgs)


### PR DESCRIPTION
Add Block's Goose AI agent (v1.19.1) as a Nix-managed CLI tool alongside
other AI assistants (Claude, Gemini, Copilot, ChatGPT, Aider).

**Version verification** (Jan 13, 2026):
- ✅ Homebrew: v1.19.1 (Jan 7, 2026 - 6 days old) ← LATEST
- ❌ nixpkgs: v1.16.1 (Dec 10, 2025 - 34 days old)
- 🎯 Upstream: v1.19.1 (latest release)

**Decision**: Use homebrew (per 30-day rule)
- nixpkgs is >30 days old (34 days)
- Homebrew actively maintained with same-day upstream releases
- Requirement: Use nixpkgs if <30 days old, otherwise homebrew

**Changes**:
- Enhanced homebrew.nix documentation for block-goose-cli
  - Added accurate version info (v1.19.1, not outdated v1.0.15)
  - Documented nixpkgs current version (v1.16.1, last updated Dec 10)
  - Explained package name to avoid conflict with nixpkgs 'goose' (DB tool)
- Updated ai-tools.nix HOMEBREW PACKAGES section
  - Tracks goose alongside other AI tools
  - Notes homebrew has latest version with same-day releases

**References**:
- Source: https://github.com/block/goose
- nixpkgs package.nix: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/go/goose-cli/package.nix
- Homebrew formula: https://github.com/Homebrew/homebrew-core/blob/master/Formula/b/block-goose-cli.rb
- Verified upstream sources directly (not local nixpkgs)

Follows package hierarchy: nixpkgs (if <30 days) → homebrew → bunx
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Block's Goose AI agent as a Homebrew-managed CLI tool due to outdated nixpkgs version, updating documentation accordingly.
> 
>   - **Behavior**:
>     - Adds `block-goose-cli` to `homebrew.nix` for Block's Goose AI agent, using Homebrew due to outdated nixpkgs version.
>     - Updates `ai-tools.nix` to track `block-goose-cli` under Homebrew packages.
>   - **Documentation**:
>     - Enhances comments in `homebrew.nix` to explain the use of Homebrew for `block-goose-cli` and version details.
>     - Updates `ai-tools.nix` to document the status and reason for using Homebrew for `block-goose-cli`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 8d762e7d8eb953e626c42e7b983057fd74fb9348. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->