### PR TITLE
feat(darwin): add syslog forwarding to remote server

### DIFF
--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -89,6 +89,20 @@ in
   };
 
   # ==========================================================================
+  # Logging Configuration
+  # ==========================================================================
+  logging = {
+    syslog = {
+      # Remote syslog server for centralized log collection
+      # Logs are forwarded via macOS built-in syslogd to HAProxy -> Cribl Edge -> Splunk
+      server = "haproxy.jacobpevans.com";
+      port = 1514;
+      # Protocol: udp or tcp
+      protocol = "udp";
+    };
+  };
+
+  # ==========================================================================
   # Nix/NixOS Configuration
   # ==========================================================================
   nix = {

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -20,6 +20,7 @@ in
     ./homebrew.nix
     ./keyboard.nix
     ./launchd-bootstrap.nix
+    ./logging.nix # Syslog forwarding to remote server
     ./boot-activation.nix # Creates /run/current-system at boot
     ./auto-recovery.nix
     ./security.nix

--- a/modules/darwin/logging.nix
+++ b/modules/darwin/logging.nix
@@ -1,0 +1,77 @@
+# macOS Syslog Forwarding Configuration
+#
+# Configures macOS built-in syslogd to forward all logs to a remote server.
+# Uses /etc/syslog.conf which is the standard BSD syslog configuration.
+#
+# Log flow: macOS syslogd -> HAProxy (load balancer) -> Cribl Edge -> Splunk
+#
+# Configuration is centralized in lib/user-config.nix under logging.syslog
+# to allow easy modification of the syslog server without editing this module.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  userConfig = import ../../lib/user-config.nix;
+
+  # Build the remote server specification
+  # UDP: @server:port
+  # TCP: @@server:port
+  protocolPrefix = if userConfig.logging.syslog.protocol == "tcp" then "@@" else "@";
+
+  remoteServer = "${protocolPrefix}${userConfig.logging.syslog.server}:${toString userConfig.logging.syslog.port}";
+in
+{
+  # Create /etc/syslog.conf with remote forwarding configuration
+  # The *.* selector matches all facilities and all priorities
+  environment.etc."syslog.conf".text = ''
+    # macOS Syslog Configuration
+    # Managed by nix-darwin - do not edit manually
+    #
+    # Forward ALL logs to remote syslog server
+    # Server: ${userConfig.logging.syslog.server}
+    # Port: ${toString userConfig.logging.syslog.port}
+    # Protocol: ${userConfig.logging.syslog.protocol}
+
+    # Forward all facilities, all priorities to remote server
+    *.*		${remoteServer}
+
+    # Also keep local logging intact (default macOS behavior)
+    # These are the default macOS syslog rules
+    *.notice;authpriv,remoteauth,ftp,install,internal.none	/var/log/system.log
+    auth,authpriv.*;remoteauth.crit			/var/log/system.log
+    mail.*						/var/log/mail.log
+    install.*					/var/log/install.log
+  '';
+
+  # Reload syslogd after configuration changes
+  # syslogd re-reads its configuration when it receives SIGHUP
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] ============================================"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] Syslog Configuration"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] ============================================"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] Remote server: ${userConfig.logging.syslog.server}:${toString userConfig.logging.syslog.port} (${userConfig.logging.syslog.protocol})"
+
+    # Send HUP signal to syslogd to reload configuration
+    # syslogd is managed by launchd as com.apple.syslogd
+    if /usr/bin/pkill -HUP syslogd 2>/dev/null; then
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] Sent SIGHUP to syslogd - configuration reloaded"
+    else
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] [WARN] Could not signal syslogd (may not be running)" >&2
+    fi
+
+    # Verify syslogd is running
+    if /bin/launchctl print system/com.apple.syslogd >/dev/null 2>&1; then
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] syslogd service is running"
+    else
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] [WARN] syslogd service not found in launchd" >&2
+    fi
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] Syslog configuration complete"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] ============================================"
+  '';
+}


### PR DESCRIPTION
## Summary
- Add centralized syslog forwarding using macOS built-in syslogd
- Configure via high-level variables in `lib/user-config.nix` (server, port, protocol)
- Forward all logs (`*.*`) to HAProxy -> Cribl Edge -> Splunk pipeline
- Preserve local logging to system.log, mail.log, install.log

## Test plan
- [ ] Run `darwin-rebuild switch --flake .#jevans-mbp`
- [ ] Verify `/etc/syslog.conf` contains forwarding rule
- [ ] Check syslogd receives SIGHUP during activation
- [ ] Verify logs arrive at remote syslog server (port 1514)
- [ ] Confirm local logs still written to /var/log/system.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds syslog forwarding to a remote server on macOS using nix-darwin, configurable via `lib/user-config.nix`, while preserving local logs.
> 
>   - **Behavior**:
>     - Adds syslog forwarding to a remote server using macOS `syslogd`.
>     - Configurable via `lib/user-config.nix` with `server`, `port`, and `protocol`.
>     - Forwards all logs (`*.*`) to HAProxy -> Cribl Edge -> Splunk.
>     - Preserves local logging to `/var/log/system.log`, `/var/log/mail.log`, `/var/log/install.log`.
>   - **Configuration**:
>     - New `modules/darwin/logging.nix` for syslog configuration.
>     - Updates `modules/darwin/common.nix` to import `logging.nix`.
>   - **Activation**:
>     - Sends SIGHUP to `syslogd` to reload configuration after changes.
>     - Verifies `syslogd` is running post-activation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 8f1a589945da39582f2dc4f10b3799fee3e57e19. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->