### PR TITLE
fix: reorder dock apps, add Quotio docs, and document trampoline permissions

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,3 +18,8 @@ https://raw.githubusercontent.com/nix-darwin/.*
 
 # Local file references that won't exist in CI
 file://.*
+
+# API key pages with authentication restrictions
+https://console.anthropic.com/.*
+https://aistudio.google.com/.*
+https://platform.openai.com/.*

--- a/docs/QUOTIO-INSTALLATION.md
+++ b/docs/QUOTIO-INSTALLATION.md
@@ -1,0 +1,136 @@
+# Quotio Installation Guide
+
+Quotio is an AI usage monitor menu bar app that provides unified quota tracking and smart
+auto-failover across multiple AI providers (Claude, Gemini, OpenAI, and more).
+
+## Overview
+
+- **GitHub**: <https://github.com/nguyenphutrong/quotio>
+- **Website**: <https://www.quotio.dev/>
+- **Latest Release**: <https://github.com/nguyenphutrong/quotio/releases>
+
+## Features
+
+- Multi-provider tracking (Claude, Gemini, OpenAI, Qwen, Copilot, Vertex AI)
+- Menu bar display with at-a-glance quota status (e.g., `G:95% C:42% CP:88%`)
+- Real-time dashboard for monitoring requests, tokens, and success rates
+- Smart failover to auto-switch between accounts when quotas hit limits
+- One-click agent auto-config for Claude Code, OpenCode, and Gemini CLI
+
+## Installation (Manual)
+
+Quotio is not available in Homebrew or nixpkgs. Install manually:
+
+1. Download the latest `.dmg` from [Quotio Releases](https://github.com/nguyenphutrong/quotio/releases)
+2. Mount the DMG and drag Quotio.app to `/Applications/`
+3. The app is unsigned, so you may need to bypass Gatekeeper:
+
+   ```bash
+   xattr -cr /Applications/Quotio.app
+   ```
+
+4. Launch Quotio from `/Applications/Quotio.app`
+5. Configure API keys for your AI providers (see Configuration below)
+
+## Configuration
+
+On first launch, Quotio will prompt you to configure API keys for AI providers:
+
+1. Open Quotio preferences (menu bar icon → Preferences)
+2. Add API keys for providers you use:
+   - **Claude**: Anthropic API key
+   - **Gemini**: Google AI Studio API key
+   - **OpenAI**: OpenAI API key
+   - **Others**: See Quotio documentation for additional providers
+
+API keys can be retrieved from:
+
+- **Anthropic**: <https://console.anthropic.com/>
+- **Google AI Studio**: <https://aistudio.google.com/apikey>
+- **OpenAI**: <https://platform.openai.com/api-keys>
+
+## Launch at Startup (Optional)
+
+To launch Quotio automatically at login:
+
+1. Open System Preferences → Users & Groups → Login Items
+2. Click the `+` button and add `/Applications/Quotio.app`
+
+Alternatively, create a LaunchAgent:
+
+```bash
+# Create ~/Library/LaunchAgents/dev.quotio.app.plist
+cat > ~/Library/LaunchAgents/dev.quotio.app.plist <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.quotio.app</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>/Applications/Quotio.app</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+</dict>
+</plist>
+EOF
+
+# Load the LaunchAgent
+launchctl load ~/Library/LaunchAgents/dev.quotio.app.plist
+```
+
+## Future: Nix Derivation
+
+A Nix derivation for Quotio could be created to automate the installation process:
+
+```nix
+# Example derivation (not yet implemented)
+quotio = pkgs.stdenv.mkDerivation rec {
+  pname = "quotio";
+  version = "0.4.4";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/nguyenphutrong/quotio/releases/download/v${version}/Quotio-${version}.dmg";
+    sha256 = "..."; # Calculate with: nix-prefetch-url <url>
+  };
+
+  nativeBuildInputs = [ pkgs.undmg ];
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r Quotio.app $out/Applications/
+  '';
+
+  # Handle unsigned app
+  postInstall = ''
+    xattr -cr $out/Applications/Quotio.app
+  '';
+};
+```
+
+This derivation would require:
+
+1. Calculating the SHA256 hash for each release
+2. Testing with `nix-build` to ensure proper DMG extraction
+3. Adding to `home.packages` or `environment.systemPackages`
+
+## Known Issues
+
+1. **Unsigned App**: Quotio is not Apple-signed, so Gatekeeper will block it on first launch.
+   Use `xattr -cr` to bypass (see Installation above).
+
+2. **API Key Storage**: Quotio stores API keys locally. Ensure you trust the application
+   before adding production API keys.
+
+3. **Auto-updates**: Manual installations require checking GitHub releases for updates.
+   A Nix derivation would require version bumps in the configuration.
+
+## Related
+
+- [Issue #461](https://github.com/JacobPEvans/nix/issues/461) - Add Quotio app
+- [Quotio Documentation](https://www.quotio.dev/)

--- a/docs/TRAMPOLINE-PERMISSIONS.md
+++ b/docs/TRAMPOLINE-PERMISSIONS.md
@@ -1,0 +1,144 @@
+# Trampoline App Permissions
+
+This document describes the limitations and known issues with trampoline-style app launchers
+in Nix on macOS, particularly regarding macOS TCC (Transparency, Consent, Control) permissions.
+
+## Problem Overview
+
+Trampoline apps create wrapper scripts in stable paths (e.g., `/Applications/Nix Apps/`) that
+launch binaries from the Nix store. However, macOS TCC grants permissions to **specific binary
+paths**, not wrapper scripts. This creates several user experience issues.
+
+## Symptoms
+
+1. **Generic Dock Icon**: Trampoline apps show a generic script icon in the dock instead of
+   the application's actual icon
+
+2. **Dual Dock Icons**: Launching a trampoline creates a NEW dock icon with the correct icon,
+   pointing to `/nix/store/xxx-app/Applications/`
+
+3. **Ephemeral Permissions**: App Management permissions are granted to Nix store paths, which
+   change on every rebuild when package versions or dependencies update
+
+4. **Repeated Permission Prompts**: After every `darwin-rebuild switch`, macOS prompts for
+   permissions again because the binary path has changed
+
+## Root Cause
+
+macOS TCC (Transparency, Consent, Control) grants permissions to **specific binary paths**.
+The trampoline pattern was designed to provide stable paths in `/Applications/Nix Apps/`, but
+macOS still tracks (and grants permissions to) the underlying Nix store binary.
+
+```text
+Before rebuild: /nix/store/abc123-ghostty-1.2.3/...  ← Permission granted
+After rebuild:  /nix/store/def456-ghostty-1.2.4/...  ← NEW path, needs permission again
+```
+
+Nix store paths are content-addressed. Any change to the package (version bump, dependency
+update, rebuild) generates a new hash, resulting in a new path.
+
+## Current Solution: copyApps
+
+This repository migrated from `mac-app-util` trampolines to Home Manager's `copyApps` feature
+for user-managed applications. This resolves the issue for apps managed by Home Manager.
+
+### How copyApps Works
+
+Instead of creating symlinks or trampolines, `copyApps` creates **real `.app` bundles** at
+stable paths under `~/Applications/Home Manager Apps/`:
+
+```nix
+# In hosts/macbook-m4/home.nix
+home.copyApps = true;
+```
+
+Result:
+
+- Apps are copied to `~/Applications/Home Manager Apps/` (stable path)
+- macOS TCC grants permissions to this stable path
+- Permissions persist across `darwin-rebuild switch`
+- Dock shows correct app icons
+
+### Affected Apps
+
+The following apps now use `copyApps` and no longer experience permission issues:
+
+- Ghostty (terminal emulator)
+- Visual Studio Code
+- RapidAPI (removed from dock per #438)
+- Postman (removed from dock per #438)
+- Other user-level apps managed by Home Manager
+
+## Remaining Limitations
+
+### System-Level Packages
+
+Apps installed via nix-darwin's `environment.systemPackages` still use trampolines because
+`copyApps` is a Home Manager feature, not a nix-darwin feature.
+
+System-level apps that may still experience permission issues:
+
+- Bitwarden (managed via `environment.systemPackages`)
+- OrbStack (managed via `environment.systemPackages`)
+- Obsidian (managed via `environment.systemPackages`)
+
+### Workarounds for System Apps
+
+1. **Migrate to Home Manager**: Move apps to `home.packages` and enable `copyApps`
+
+2. **Manual Permission Grants**: Re-grant permissions after each rebuild (tedious but works)
+
+3. **Full Disk Access**: Add `/Applications/Nix Apps/` to Full Disk Access
+   - **Security risk**: Grants broad permissions to all Nix apps
+   - Not recommended for production systems
+
+4. **Homebrew Casks**: For apps that need stable TCC permissions, consider using Homebrew
+   casks instead of nixpkgs (Homebrew installs to `/Applications/` as real copies)
+
+### Programmatic Permission Management (tccutil)
+
+Apple provides `tccutil` for managing TCC permissions programmatically, but it has limitations:
+
+- Requires Full Disk Access for the script running `tccutil`
+- No official API for granting permissions (only resetting)
+- Undocumented behavior and format changes between macOS versions
+
+Example (untested):
+
+```bash
+# Reset permissions for an app (requires Full Disk Access)
+sudo tccutil reset All /Applications/Nix Apps/Ghostty.app
+
+# Grant permission (no official API, would require TCC database manipulation)
+# Not recommended - TCC database format is undocumented and may change
+```
+
+## Testing Strategy
+
+When adding new apps that require TCC permissions (screen recording, accessibility, camera,
+microphone, etc.), test the following:
+
+1. **Initial Launch**: Verify app launches and permission prompts appear
+2. **Permission Grant**: Grant permissions via System Preferences → Privacy & Security
+3. **Rebuild Test**: Run `darwin-rebuild switch` and verify:
+   - Permissions persist (for `copyApps` apps)
+   - Permissions must be re-granted (for trampoline apps)
+4. **Dock Icon**: Check dock shows correct app icon (not generic script icon)
+
+## Recommendations
+
+1. **Prefer Home Manager with copyApps**: For user-level apps that need TCC permissions
+2. **Use Homebrew for TCC-sensitive system apps**: If you can't use Home Manager
+3. **Document permission requirements**: When adding new apps, note if they need TCC permissions
+4. **Monitor upstream issues**: Watch for nix-darwin improvements to system-level app handling
+
+## Related Issues
+
+- [nix-darwin#1255](https://github.com/nix-darwin/nix-darwin/issues/1255) - LaunchDaemon bootstrap
+- [home-manager#5189](https://github.com/nix-community/home-manager/issues/5189) - Trampoline apps
+- [Issue #424](https://github.com/JacobPEvans/nix/issues/424) - Trampoline permissions invalidated on rebuild
+
+## Additional Context
+
+See `docs/boot-failure/root-cause.md` for related information about App Management permissions
+and activation script failures.

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -33,26 +33,23 @@ in
       "/Applications/Toggl Track.app"
 
       # Communication
-      "/System/Applications/Messages.app"
       "/Applications/Shortwave.app" # AI-powered email client (homebrew cask)
       "/Applications/Slack.app"
+      "/System/Applications/Messages.app"
       "${homeDir}/Applications/zoom.us.app" # Manual install (Nix package was broken)
       "/Applications/Webex.app"
 
       # AI Assistants
-      "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
       "/Applications/Claude.app" # Anthropic Claude desktop app (homebrew cask)
+      "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
 
       # Knowledge & Notes
       "/Applications/Nix Apps/Obsidian.app"
       # Note: Additional note-taking apps may be installed locally
 
       # Development & Tools
-      "${homeDir}/Applications/Home Manager Apps/RapidAPI.app"
-      "${homeDir}/Applications/Home Manager Apps/Postman.app"
       "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
       "${homeDir}/Applications/Home Manager Apps/Ghostty.app"
-      "/Applications/Nix Apps/Bitwarden.app"
       "/Applications/Nix Apps/OrbStack.app"
 
       # Browsers
@@ -62,6 +59,7 @@ in
       # NOTE: Ollama runs headless via LaunchAgent, no dock icon needed.
       # NOTE: Additional AI tools (Antigravity, ChatGPT, Cursor) can be found in
       # ~/Applications/Home Manager Apps/ but are not pinned to the Dock.
+      # NOTE: RapidAPI, Postman, and Bitwarden removed from dock per #438
     ];
 
     # ========================================================================


### PR DESCRIPTION
## Summary

- Update dock configuration to reorder apps per #438
- Document Quotio installation (manual, not in Homebrew) per #461
- Document trampoline permission limitations per #424

## Changes

### Dock Configuration (#438)

Updated `modules/darwin/dock/persistent-apps.nix`:

- **New order**: Toggl, Shortwave, Slack, Messages, Zoom, Webex, Claude, Gemini, Obsidian
- **Removed from dock**: RapidAPI, Postman, Bitwarden
- Apps remain installed but not pinned to dock

### Quotio Documentation (#461)

Created `docs/QUOTIO-INSTALLATION.md`:

- Manual installation guide (not available in Homebrew/nixpkgs)
- API key configuration instructions
- LaunchAgent setup for auto-start
- Future Nix derivation template for potential automation

### Trampoline Permissions (#424)

Created `docs/TRAMPOLINE-PERMISSIONS.md`:

- Root cause analysis of macOS TCC permission issues
- Explanation of copyApps solution for Home Manager apps
- System-level package workarounds and recommendations
- Testing strategy for TCC-sensitive applications

### Link Checker Updates

Updated `.lycheeignore`:

- Added API key pages (Anthropic, Google, OpenAI) to ignore patterns
- These pages require authentication and return 403 errors in CI

## Test Plan

- [x] `nix flake check` passes
- [x] Pre-commit hooks pass
- [x] Dock configuration syntax is valid
- [x] Documentation links are valid
- [ ] Test dock configuration after rebuild (will test manually)

## Related Issues

Closes #461
Closes #438
Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders dock apps, adds Quotio installation docs, and documents trampoline permissions in macOS.
> 
>   - **Dock Configuration**:
>     - Updated `persistent-apps.nix` to reorder dock apps: Toggl, Shortwave, Slack, Messages, Zoom, Webex, Claude, Gemini, Obsidian.
>     - Removed RapidAPI, Postman, Bitwarden from dock.
>   - **Quotio Documentation**:
>     - Added `QUOTIO-INSTALLATION.md` for manual installation, API key setup, and LaunchAgent configuration.
>   - **Trampoline Permissions**:
>     - Added `TRAMPOLINE-PERMISSIONS.md` detailing macOS TCC permission issues and solutions using `copyApps`.
>   - **Misc**:
>     - Updated `.lycheeignore` to ignore API key pages requiring authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for a7cf17c2b613a931e20c753cac1f140bb1eee9f5. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->