### PR TITLE
feat: add nixpkgs-unstable overlay for GUI apps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,6 +282,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1768875095,
+        "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agent-os": "agent-os",
@@ -297,6 +313,7 @@
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "mac-app-util": "mac-app-util",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "superpowers-marketplace": "superpowers-marketplace",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
     # Using stable nixpkgs-25.11 for reliability
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
 
+    # Using unstable nixpkgs for faster updates to GUI apps
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
     # Consolidated systems input for darwin-only configuration
     # All transitive dependencies should follow this to avoid duplicate systems entries
     systems.url = "github:nix-systems/default-darwin";
@@ -117,6 +120,7 @@
   outputs =
     {
       nixpkgs,
+      nixpkgs-unstable,
       darwin,
       home-manager,
       mac-app-util,
@@ -135,6 +139,12 @@
     let
       userConfig = import ./lib/user-config.nix;
       hmDefaults = import ./lib/home-manager-defaults.nix;
+
+      # Import nixpkgs-unstable for faster updates to GUI applications
+      unstablePkgs = import nixpkgs-unstable {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
 
       # Pure settings generator for CI (no derivations, cross-platform)
       # Reads permissions from unified ai-assistant-instructions structure
@@ -179,6 +189,7 @@
       # Pass external sources to home-manager modules
       extraSpecialArgs = {
         inherit
+          unstablePkgs
           claude-code-plugins
           claude-cookbooks
           claude-plugins-official
@@ -194,6 +205,7 @@
       # Define configuration once, assign to multiple names
       darwinConfig = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
+        specialArgs = { inherit unstablePkgs; };
         modules = [
           ./hosts/macbook-m4/default.nix
 

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  unstablePkgs,
   ...
 }:
 
@@ -35,6 +36,23 @@ in
   nixpkgs.overlays = [
     (import ../../overlays/python-packages.nix)
     (import ../../overlays/macos-apps.nix)
+    # GUI apps from nixpkgs-unstable for faster version updates
+    # Stable branches (25.11) only get security fixes, not version bumps
+    # This overlay ensures GUI apps stay current with upstream releases
+    (_final: _prev: {
+      inherit (unstablePkgs)
+        antigravity
+        bitwarden-desktop
+        chatgpt
+        code-cursor
+        ghostty-bin
+        obsidian
+        postman
+        rapidapi
+        raycast
+        swiftbar
+        ;
+    })
   ];
 
   # --- User Configuration ---

--- a/scripts/workflows/check-package-versions.sh
+++ b/scripts/workflows/check-package-versions.sh
@@ -6,7 +6,7 @@
 set -uo pipefail
 
 # Package definitions: name, priority
-# Priority: Security (security-critical) | AI Tool (AI tooling)
+# Priority: Security (security-critical) | AI Tool (AI tooling) | GUI App (desktop apps from unstable)
 PACKAGES=(
   "git:Security"
   "gnupg:Security"
@@ -16,6 +16,16 @@ PACKAGES=(
   "claude-monitor:AI Tool"
   "gemini-cli:AI Tool"
   "ollama:AI Tool"
+  "antigravity:GUI App"
+  "bitwarden-desktop:GUI App"
+  "chatgpt:GUI App"
+  "code-cursor:GUI App"
+  "ghostty-bin:GUI App"
+  "obsidian:GUI App"
+  "postman:GUI App"
+  "rapidapi:GUI App"
+  "raycast:GUI App"
+  "swiftbar:GUI App"
 )
 
 # Global counters for exit status


### PR DESCRIPTION
## Summary

Implements Phase 1 of the dependency update strategy to fix stale GUI applications. GUI apps from nixpkgs stable branches (e.g., 25.11-darwin) only receive security fixes, not version bumps. This overlay pulls GUI applications from nixpkgs-unstable for faster updates.

## Changes

- Add `nixpkgs-unstable` input to flake.nix
- Import unstablePkgs and pass via specialArgs to darwin and home-manager
- Create inline overlay in modules/darwin/common.nix pulling 10 GUI apps:
  * antigravity, bitwarden-desktop, chatgpt, code-cursor, ghostty-bin
  * obsidian, postman, rapidapi, raycast, swiftbar
- Add GUI apps to package version monitoring script
- Verify Renovate already tracks NixOS/nixpkgs (auto-tracks unstable too)

## Benefits

- RapidAPI and other GUI apps now update when new versions available in unstable
- GUI apps receive updates within 1-2 weeks instead of months on stable
- Renovate automatically tracks nixpkgs-unstable input
- Package monitoring now includes 18 packages (8 security + AI tools, 10 GUI apps)

## Test Plan

- [x] nix flake check passes all linting and formatting checks
- [x] nix build --dry-run succeeds (no build errors)
- [x] Flake metadata shows nixpkgs-unstable input correctly loaded
- [x] Pre-commit hooks pass all validations
- [x] Configuration parses without errors

## Verification

After merge, verify with:
\`\`\`bash
nix flake metadata | grep unstable
nix eval ".#darwinConfigurations.default.pkgs.rapidapi.version" --raw
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `nixpkgs-unstable` overlay for faster GUI app updates and updates monitoring script to track these apps.
> 
>   - **Behavior**:
>     - Adds `nixpkgs-unstable` input to `flake.nix` for faster GUI app updates.
>     - Imports `unstablePkgs` in `flake.nix` and passes via `specialArgs` to `darwin` and `home-manager`.
>     - Creates overlay in `modules/darwin/common.nix` for 10 GUI apps: `antigravity`, `bitwarden-desktop`, `chatgpt`, `code-cursor`, `ghostty-bin`, `obsidian`, `postman`, `rapidapi`, `raycast`, `swiftbar`.
>   - **Scripts**:
>     - Updates `check-package-versions.sh` to include GUI apps in version monitoring.
>   - **Misc**:
>     - Ensures Renovate tracks `nixpkgs-unstable` for automatic updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 22815144c22480c72c7f0a0a8cbdc8f7ebee86ce. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->