### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1769583560,
-        "narHash": "sha256-VpiSB0YS8QQ0ihzc/6J+3unO1fh1WeE/4gfUsekCWtY=",
+        "lastModified": 1770060931,
+        "narHash": "sha256-O91KVVTUbkwUlKhhNwIaa2R6gENO8JSBb/MXusQ5TSU=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "73eddfd6404fb04e2899413e3a339513c7ebb76f",
+        "rev": "36d9ee2c2ee8ed06abe5d1ffe8ad6f9c40511385",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "claude-code-workflows": {
       "flake": false,
       "locked": {
-        "lastModified": 1768860507,
-        "narHash": "sha256-yYyxvCO3F5UBi6K/n6XcsukV61tO8eBz3UvdMQL9UwI=",
+        "lastModified": 1769997972,
+        "narHash": "sha256-mUF4bkoKtp/F9nSP7jCa5ucr9fl71AfhV9TnrG0kw5k=",
         "owner": "wshobson",
         "repo": "agents",
-        "rev": "1135ac606247648d9e4724f027280d4114282858",
+        "rev": "918a7709906163c456b77bc987e1616451458e4a",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1769541448,
-        "narHash": "sha256-eUqzLCAQdhpMmX6hI8FRztbPCdw28LqynL9+5wK4+P8=",
+        "lastModified": 1769816307,
+        "narHash": "sha256-miSHCWNnlSzd4Hnw1iLk1g5weX6pCgyYGEZkbtALceY=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "968fc1698b3f5fe0a1c67d2185d3264de4569d52",
+        "rev": "ce4c093127bb52ad79294bd433b2de5a19dab31f",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1768973887,
-        "narHash": "sha256-OxIrvISdHK/gULDc4alD4T4tivjfb5R6wBs/kUhVhiY=",
+        "lastModified": 1769730263,
+        "narHash": "sha256-hx8LNT3mnJs2RiwYMwC+T4CFXVOWQrZS7PLzgJO+rlY=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "e30768372b4150ca1bc0839d93283e8edc30d60d",
+        "rev": "27d2b86d72da27c64585150857cee8472ad47abb",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     "claude-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1768760789,
-        "narHash": "sha256-WDbk7Fkab6osz/xcXGvDxQ68N7Yic5vc4qB1XDtT2Bg=",
+        "lastModified": 1769936350,
+        "narHash": "sha256-VYzTVZ0Cja0BQn8vJjtW9P47VqOAaYFIXhXBCaSusO4=",
         "owner": "secondsky",
         "repo": "claude-skills",
-        "rev": "00430d3d9eff1cefc4ce9a1ea8eadc65f5ccccf9",
+        "rev": "13b88d16a65961bb92b5913355b76f94f76aa2b8",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769411457,
-        "narHash": "sha256-TbvPOG8U4+dXp84GR7F+Vc6RkEwhkvlu5JnDM5enQ/c=",
+        "lastModified": 1770044193,
+        "narHash": "sha256-rA0lm7KDi7q9CASAqj+iuVFqKReGV/tfz7pk6sMREzQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5db6fba5cac287d9a7aef07045876c888baa21f",
+        "rev": "12361153871cd4169867363007202a67c6252002",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1769527094,
-        "narHash": "sha256-xV20Alb7ZGN7qujnsi5lG1NckSUmpIb05H2Xar73TDc=",
+        "lastModified": 1770015011,
+        "narHash": "sha256-7vUo0qWCl/rip+fzr6lcMlz9I0tN/8m7d5Bla/rS2kk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afce96367b2e37fc29afb5543573cd49db3357b7",
+        "rev": "f08e6b11a5ed43637a8ac444dd44118bc7d273b9",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
     "superpowers-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1769198993,
-        "narHash": "sha256-NCc/u4ka4u1lBXWctGhx5ShB+QBAQ+BPooQySmt9dnw=",
+        "lastModified": 1769889643,
+        "narHash": "sha256-PjOZfxyNeUb1VR2scVR8L+4UjdC9TeQCm+E//9DduHc=",
         "owner": "obra",
         "repo": "superpowers-marketplace",
-        "rev": "84bd2efd0f5186baa54b440d215dbf2da70e0e44",
+        "rev": "14fb891be25c7c8d7fb22a07cc1b91eeb37b4a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updated flake inputs to latest versions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `flake.lock` to latest versions for several dependencies including `claude-code-plugins`, `nixpkgs`, and `superpowers-marketplace`.
> 
>   - **Dependencies**:
>     - Update `claude-code-plugins` to rev `36d9ee2c2ee8ed06abe5d1ffe8ad6f9c40511385`.
>     - Update `claude-code-workflows` to rev `918a7709906163c456b77bc987e1616451458e4a`.
>     - Update `claude-cookbooks` to rev `ce4c093127bb52ad79294bd433b2de5a19dab31f`.
>     - Update `claude-plugins-official` to rev `27d2b86d72da27c64585150857cee8472ad47abb`.
>     - Update `claude-skills` to rev `13b88d16a65961bb92b5913355b76f94f76aa2b8`.
>     - Update `nixpkgs` to rev `12361153871cd4169867363007202a67c6252002`.
>     - Update `nixpkgs-unstable` to rev `f08e6b11a5ed43637a8ac444dd44118bc7d273b9`.
>     - Update `superpowers-marketplace` to rev `14fb891be25c7c8d7fb22a07cc1b91eeb37b4a36`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for e079702b169716fbfb97004ca08323762d1b6451. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->