### PR TITLE
docs: document homebrew update philosophy and limitations

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -195,7 +195,7 @@ certain brew commands. There is no background daemon.
 |--------|---------|--------------|
 | darwin-rebuild | `sudo darwin-rebuild switch --flake .` | Upgrades all packages (primary method) |
 | Manual update | `brew update && brew upgrade` | Immediate update when needed |
-| Passive auto-update | Running `brew install/upgrade/etc` | Index updated if >5min stale |
+| Passive auto-update | Running `brew install/upgrade/etc` | Index updated if >5 minutes stale |
 
 **Our configuration** in `modules/darwin/homebrew.nix`:
 
@@ -228,7 +228,7 @@ sudo darwin-rebuild switch --flake ~/.config/nix
 Renovate cannot automatically update homebrew packages because:
 
 1. nix-darwin's `homebrew.brews/casks` contain only package names, not versions
-2. Homebrew doesn't support version pinning for standard formulas/casks
+2. Homebrew lacks declarative version pinning within configuration files
 3. Renovate's homebrew manager only works with Ruby Formula files
 
 The `darwin-rebuild switch` workflow is the correct approach for keeping homebrew packages current.

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -12,7 +12,7 @@
 # Our configuration:
 #   - onActivation.autoUpdate = false  → Keeps rebuilds fast (no 45MB index download)
 #   - onActivation.upgrade = true      → Packages updated when you run darwin-rebuild
-#   - Passive auto-update: Enabled     → 5-min trigger on command invocation
+#   - Passive auto-update: Enabled     → >5 minutes trigger on command invocation
 #
 # == How Packages Get Updated ==
 #
@@ -23,7 +23,7 @@
 # == Why Renovate Can't Help ==
 #
 # nix-darwin homebrew config contains only package names, not versions.
-# Homebrew itself doesn't support version pinning for formulas/casks.
+# Homebrew lacks declarative version pinning within configuration files.
 # Renovate's homebrew manager only works with Ruby Formula files.
 #
 # NOTE: nix-darwin does NOT support version pinning for individual homebrew packages.
@@ -38,7 +38,7 @@ _:
     enable = true;
     onActivation = {
       # Don't download 45MB index on every rebuild - keeps rebuilds fast and deterministic.
-      # Homebrew's passive auto-update still works (triggers on command invocation after 5min).
+      # Homebrew's passive auto-update still works (triggers on command invocation after >5 minutes).
       autoUpdate = false;
       cleanup = "none"; # Don't remove manually installed packages
       # Upgrade packages to latest available when darwin-rebuild switch runs.


### PR DESCRIPTION
## Summary

- Document that Homebrew has NO native background auto-update mechanism
- Clarify the three ways homebrew packages stay current (darwin-rebuild, manual update, passive auto-update)
- Explain why Renovate cannot track homebrew package versions in nix-darwin configurations
- Add inline documentation to `homebrew.nix` explaining configuration choices

## Changes

**`modules/darwin/homebrew.nix`**:
- Added "Update Philosophy" section explaining Homebrew's actual behavior
- Documented why `autoUpdate = false` and `upgrade = true` are correct settings
- Explained why Renovate can't help with homebrew packages

**`RUNBOOK.md`**:
- Expanded "Update Homebrew Packages" section with table of update methods
- Added standard workflow vs emergency/immediate update instructions
- Documented Renovate limitations for homebrew

## Test plan

- [x] `nix flake check --no-build` passes
- [ ] Review documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Document Homebrew update philosophy, limitations, and Renovate incompatibility in `homebrew.nix` and `RUNBOOK.md`.
> 
>   - **Documentation**:
>     - Added "Update Philosophy" section in `modules/darwin/homebrew.nix` explaining Homebrew's lack of native background auto-update and configuration choices (`autoUpdate = false`, `upgrade = true`).
>     - Explained why Renovate cannot track Homebrew package versions due to lack of version info in `nix-darwin` config and Homebrew's non-declarative version pinning.
>   - **RUNBOOK.md**:
>     - Expanded "Update Homebrew Packages" section with methods for keeping packages current and why Renovate is not suitable for Homebrew.
>     - Added instructions for standard and emergency update workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for ba3cc71774b42a02a9a3bd10daba64e215340c6c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->