### PR TITLE
feat(claude): enable agent teams and use default model

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -73,6 +73,14 @@ with pkgs;
   aws-vault # Secure AWS credential storage (uses OS keychain)
 
   # ==========================================================================
+  # Terminal Multiplexer
+  # ==========================================================================
+  # Required for Claude Code agent teams split-pane mode.
+  # Ghostty does not natively support agent team split panes.
+  # See: https://code.claude.com/docs/en/agent-teams
+  tmux
+
+  # ==========================================================================
   # HTTP & API Tools
   # ==========================================================================
   # Tools for testing and working with HTTP APIs and web services.

--- a/modules/home-manager/ai-cli/claude-config.nix
+++ b/modules/home-manager/ai-cli/claude-config.nix
@@ -94,9 +94,12 @@ in
     # scriptPath default: .local/bin/claude-api-key-helper
   };
 
+  # Agent teams display mode (direct settings.json property)
+  teammateMode = "auto";
+
   # Auto-Claude: Scheduled autonomous maintenance
   # ENABLED - Uses Haiku model for cost-efficiency (via per-repo CLAUDE_MODEL env var)
-  # Interactive sessions use Sonnet (via ANTHROPIC_MODEL), autoClaude overrides to Haiku
+  # Interactive sessions use the default model, autoClaude overrides to Haiku
   # Resource limits: max 10 PRs, max 50 issues, max 1 analysis per item per run
   autoClaude = {
     enable = true;

--- a/modules/home-manager/ai-cli/claude/options.nix
+++ b/modules/home-manager/ai-cli/claude/options.nix
@@ -190,6 +190,23 @@ in
       };
     };
 
+    # Agent teams: coordinate multiple Claude Code instances
+    # See: https://code.claude.com/docs/en/agent-teams
+    teammateMode = mkOption {
+      type = types.enum [
+        "auto"
+        "in-process"
+        "tmux"
+      ];
+      default = "auto";
+      description = ''
+        Display mode for agent team teammates.
+        - "auto": split panes if already in tmux, in-process otherwise
+        - "in-process": all teammates in main terminal (Shift+Up/Down to navigate)
+        - "tmux": force split-pane mode (requires tmux)
+      '';
+    };
+
     # Settings
     settings = {
       # Extended thinking mode

--- a/modules/home-manager/ai-cli/claude/settings.nix
+++ b/modules/home-manager/ai-cli/claude/settings.nix
@@ -43,6 +43,7 @@ let
   settings = {
     "$schema" = cfg.settings.schemaUrl;
     inherit (cfg.settings) alwaysThinkingEnabled cleanupPeriodDays;
+    inherit (cfg) teammateMode;
 
     # Permissions
     permissions = {


### PR DESCRIPTION
## Summary
- Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var in Claude Code settings to allow coordinating multiple Claude Code instances as a team
- Remove the explicit `ANTHROPIC_MODEL=sonnet` override so Claude Code uses its built-in default model selection (kept commented for easy re-enable)

## References
- [Agent Teams docs](https://code.claude.com/docs/en/agent-teams)

## Test plan
- [ ] Run `darwin-rebuild switch --flake .` and verify settings.json includes the new env var
- [ ] Verify `ANTHROPIC_MODEL` is no longer set in generated settings.json
- [ ] Start Claude Code and verify agent teams feature is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable agent teams in Claude Code and use default model by setting environment variable and removing model override.
> 
>   - **Behavior**:
>     - Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` in `claude-config.nix` to coordinate multiple Claude Code instances.
>     - Remove `ANTHROPIC_MODEL=sonnet` override in `claude-config.nix` to use default model.
>   - **Packages**:
>     - Add `tmux` to `modules/common/packages.nix` for agent teams split-pane mode.
>   - **Options**:
>     - Add `teammateMode` option in `claude/options.nix` with modes `auto`, `in-process`, and `tmux`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for c323a2fa0d7791907080df0f95c451703260f7eb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->