### PR TITLE
fix: add cryptography to home-manager Python environments

### DIFF
--- a/modules/home-manager/ai-cli/claude/auto-claude-reporting.nix
+++ b/modules/home-manager/ai-cli/claude/auto-claude-reporting.nix
@@ -21,6 +21,7 @@ let
     (ps.slack-sdk.overridePythonAttrs (_: {
       doCheck = false;
     }))
+    ps.cryptography # Cryptographic recipes and primitives (system-wide requirement)
     ps.keyring
   ]);
 

--- a/modules/home-manager/ai-cli/claude/auto-claude.nix
+++ b/modules/home-manager/ai-cli/claude/auto-claude.nix
@@ -23,6 +23,7 @@ let
     (ps.slack-sdk.overridePythonAttrs (_: {
       doCheck = false; # Disable tests - they fail in CI with connection/signal errors
     }))
+    ps.cryptography # Cryptographic recipes and primitives (system-wide requirement)
     ps.keyring # macOS Keychain access
     ps.pyyaml
   ]);


### PR DESCRIPTION
## Problem

Cryptography was added to `environment.systemPackages` in #563, but was not available when invoking `python3` because:

1. Home-manager's `/etc/profiles/per-user/jevans/bin/python3` comes first in PATH
2. The auto-claude module creates a `python3.withPackages` env for its scripts
3. This env is added to `home.packages`, shadowing the system python
4. The auto-claude env did NOT include cryptography

## Solution

Added `ps.cryptography` to both:
- `modules/home-manager/ai-cli/claude/auto-claude.nix` (pythonEnv)
- `modules/home-manager/ai-cli/claude/auto-claude-reporting.nix` (pythonWithDeps)

## Verification

```bash
$ python3 -c "import cryptography; print(cryptography.__version__)"
46.0.2
```

## Root Cause Analysis

The issue was PATH shadowing:
- System python: `/run/current-system/sw/bin/python3` → has cryptography ✅
- Home-manager python: `/etc/profiles/per-user/jevans/bin/python3` → missing cryptography ❌
- PATH order: home-manager comes first → shadowed system python

This is why multiple `darwin-rebuild switch` runs didn't fix it - the system was correct, but home-manager was shadowing it.

Closes #563
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `cryptography` to home-manager Python environments in `auto-claude.nix` and `auto-claude-reporting.nix` to resolve PATH shadowing issue.
> 
>   - **Behavior**:
>     - Adds `ps.cryptography` to `pythonEnv` in `auto-claude.nix` and `pythonWithDeps` in `auto-claude-reporting.nix` to ensure availability in home-manager Python environments.
>   - **Root Cause**:
>     - PATH shadowing caused home-manager Python to take precedence over system Python, missing `cryptography`.
>     - System Python at `/run/current-system/sw/bin/python3` had `cryptography`, but home-manager Python at `/etc/profiles/per-user/jevans/bin/python3` did not.
>   - **Verification**:
>     - Running `python3 -c "import cryptography; print(cryptography.__version__)"` confirms `cryptography` is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 1e2a63c4fcc54ce100aef806285c6ee005e3e1cb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->