### PR TITLE
chore(plugins): update jacobpevans-cc-plugins comment to reflect consolidation

### DIFF
--- a/modules/home-manager/ai-cli/claude/plugins/development.nix
+++ b/modules/home-manager/ai-cli/claude/plugins/development.nix
@@ -13,10 +13,6 @@ let
   # Dynamically discovers all plugin directories from the jacobpevans-cc-plugins
   # flake input using builtins.readDir. New plugins added to the repo are
   # automatically enabled after `nix flake update jacobpevans-cc-plugins`.
-  #
-  # Known plugins (8 consolidated from 15, for reference, not used for enablement):
-  #   ai-delegation, codeql-resolver, config-management, content-guards,
-  #   git-guards, git-workflows, github-workflows, infra-orchestration
   jacobpevansPlugins =
     let
       entries = builtins.readDir jacobpevans-cc-plugins;


### PR DESCRIPTION
## Summary
- Updates development.nix comment to reflect the 15→8 plugin consolidation from [claude-code-plugins#31](https://github.com/JacobPEvans/claude-code-plugins/pull/31)
- Flake.lock already points to the consolidation merge (`d36a028`), so no flake update needed
- Auto-discovery logic in Nix adapts automatically to the new plugin structure

## New Plugin Structure (8 consolidated plugins)

| Plugin | Type | Consolidated From |
|--------|------|-------------------|
| **git-guards** | hooks | git-permission-guard + main-branch-guard |
| **content-guards** | hooks | token-validator + markdown-validator + webfetch-guard + issue-limiter |
| **git-workflows** | skills | git-workflows + git-rebase-workflow + git-troubleshooting |
| **github-workflows** | skills | github-workflows + pr-review-toolkit |
| **ai-delegation** | skills | *(unchanged)* |
| **codeql-resolver** | command/agents/skills | *(unchanged)* |
| **config-management** | skills | *(unchanged)* |
| **infra-orchestration** | skills | *(unchanged)* |

## Test Plan
- [x] `nix flake check` passes
- [x] `darwin-rebuild switch` succeeds
- [ ] Restart Claude Code and verify all 8 plugins load
- [ ] Test skill invocations (pending session restart)

## Related
- Upstream: https://github.com/JacobPEvans/claude-code-plugins/pull/31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `development.nix` comment to reflect plugin consolidation from 15 to 8, with no flake.lock update needed.
> 
>   - **Comment Update**:
>     - Updates comment in `development.nix` to reflect consolidation of plugins from 15 to 8.
>   - **Flake.lock**:
>     - No update needed as it already points to the consolidation merge `d36a028`.
>   - **Auto-discovery**:
>     - Nix auto-discovery logic adapts to new plugin structure without changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 5ee8784414e59b5e3465f46011a5eafd09b54802. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->