### PR TITLE
fix(ci): prevent Merge Gate false failures from cancelled runs

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -77,9 +77,9 @@ jobs:
           COMMIT_MSG: ${{ github.event.pull_request.title }}
         run: |
           # Skip nix-build only if:
-          # 1. Author is jacobpevans-github-actions (Renovate bot)
+          # 1. Author is jacobpevans-github-actions (Renovate bot, with or without [bot] suffix)
           # 2. Commit message starts with "chore(deps)"
-          if [[ "$AUTHOR" == "jacobpevans-github-actions" && "$COMMIT_MSG" == chore\(deps\)* ]]; then
+          if [[ "$AUTHOR" == "jacobpevans-github-actions"* && "$COMMIT_MSG" == chore\(deps\)* ]]; then
             echo "is-deps-only=true" >> $GITHUB_OUTPUT
           else
             echo "is-deps-only=false" >> $GITHUB_OUTPUT
@@ -126,7 +126,7 @@ jobs:
   gate:
     name: Merge Gate
     needs: [changes, nix-build, nix-validate, markdown-lint, claude-settings, file-size]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check all results


### PR DESCRIPTION
## Summary
Fixes two issues preventing PR merges when CI runs are cancelled by concurrency group:

1. **Gate job false failures from cancelled runs**
   - Changed `if: always()` to `if: !cancelled()` on the Merge Gate job
   - Prevents stale failure check runs when concurrency group cancels duplicate workflows
   - This is the standard GitHub Actions pattern for merge gates
   - Fixes PR #589 being blocked by a cancelled run posting a failed check

2. **Deps-only bot detection never worked**
   - GitHub App login is `jacobpevans-github-actions[bot]`, not `jacobpevans-github-actions`
   - Updated glob pattern to match both variations using `*` suffix
   - Enables skipping expensive macOS builds (~7-8min) on dep-update PRs

## Root Cause (PR #589)
Two CI Gate runs triggered for the same commit. The concurrency group cancelled the first run, but the gate job's `if: always()` caused it to run anyway — it saw all other jobs as skipped and reported failure. GitHub branch protection sees both Merge Gate results (failed + passed) and blocks the PR.

## Test Plan
- [x] Pre-commit hooks passed
- [ ] CI passes on this PR
- [ ] After merge, re-run or re-trigger PR #589 CI to unblock it
- [ ] Future `chore(deps)` PRs from bot should skip `nix-build` and pass faster

## Related
- Fixes #589 merge gate failure
- Optimizes CI runtime for automated dependency PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes false failures in Merge Gate from cancelled runs and corrects bot detection for dependency-only commits in `ci-gate.yml`.
> 
>   - **Behavior**:
>     - Change `if: always()` to `if: !cancelled()` in `gate` job in `ci-gate.yml` to prevent false failures from cancelled runs.
>     - Update bot detection logic to match `jacobpevans-github-actions` with or without `[bot]` suffix in `ci-gate.yml`.
>   - **Root Cause**:
>     - Two CI Gate runs for the same commit caused a cancelled run to report failure due to `if: always()` condition.
>   - **Test Plan**:
>     - Ensure CI passes on this PR and re-run PR #589 to verify fix.
>     - Future `chore(deps)` PRs should skip `nix-build` and pass faster.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 6b6e4ad17fc8891c42a4e612b5cae731554a4c85. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->