### PR TITLE
chore(deps): update flake inputs, move Obsidian to homebrew

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771043024,
-        "narHash": "sha256-O1XDr7EWbRp+kHrNNgLWgIrB0/US5wvw9K6RERWAj6I=",
+        "lastModified": 1771116921,
+        "narHash": "sha256-CID/eq9RDzCECT6acXMb9Nu1I/kaYS00gvQxwECYbv8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3aadb7ca9eac2891d52a9dec199d9580a6e2bf44",
+        "rev": "5225070d41b4be8ed48a2ba1bf823b1d57bb2677",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770843696,
-        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
+        "lastModified": 1771147098,
+        "narHash": "sha256-jpfPdBjKO232s5NueoNEvvVzpndiUzPLNYcH4/Ov0gY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
+        "rev": "e3cb16bccd9facebae3ba29c6a76a4cc1b73462a",
         "type": "github"
       },
       "original": {

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -45,7 +45,6 @@ in
         chatgpt
         code-cursor
         ghostty-bin
-        obsidian
         ollama
         postman
         rapidapi
@@ -105,7 +104,7 @@ in
       bitwarden-desktop # Password manager desktop app
       # NOTE: ghostty-bin moved to home.packages for TCC permission persistence
       # See hosts/macbook-m4/home.nix for details
-      obsidian # Knowledge base / note-taking (Markdown)
+      # NOTE: Obsidian moved to homebrew cask for faster beta updates (user pays for beta)
       # NOTE: OrbStack managed via programs.orbstack module for system-level
       # installation. See modules/darwin/apps/orbstack.nix and
       # hosts/macbook-m4/default.nix for configuration.

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -44,7 +44,7 @@ in
       "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
 
       # Knowledge & Notes
-      "/Applications/Nix Apps/Obsidian.app"
+      "/Applications/Obsidian.app"
       # Note: Additional note-taking apps may be installed locally
 
       # Development & Tools

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -64,6 +64,7 @@ _:
       # not symlinks to /nix/store), so macOS TCC permissions (camera, mic, screen
       # recording) persist across darwin-rebuild. This is different from nixpkgs
       # apps which require copyApps workaround in home-manager.
+      "obsidian" # Knowledge base / note-taking - brew for faster beta updates
       "shortwave" # AI-powered email client
       "claude" # Anthropic Claude desktop app (not in nixpkgs for Darwin)
       "claude-code" # Anthropic Claude Code CLI (version 2.1.3)


### PR DESCRIPTION
## Summary
- Update nixpkgs and nixpkgs-unstable to 2026-02-15
- Move Obsidian from nixpkgs to homebrew cask for faster beta updates
- Update dock persistent-apps path accordingly

## Test plan
- [x] `nix flake check` passes
- [x] `darwin-rebuild switch` succeeds
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Nix inputs and move Obsidian to Homebrew for faster updates, adjusting dock path accordingly.
> 
>   - **Dependencies**:
>     - Update `nixpkgs` and `nixpkgs-unstable` to 2026-02-15 in `flake.lock`.
>     - Move `Obsidian` from `nixpkgs` to Homebrew cask in `homebrew.nix` for faster beta updates.
>   - **Configuration**:
>     - Update `modules/darwin/dock/persistent-apps.nix` to change `Obsidian` path from `/Applications/Nix Apps/Obsidian.app` to `/Applications/Obsidian.app`.
>   - **Testing**:
>     - `nix flake check` passes.
>     - `darwin-rebuild switch` succeeds.
>     - All pre-commit hooks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 73494bd5c0acfc3436993d493ad4b933f3fcf3b4. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->