### PR TITLE
fix(claude): add marketplace cache integrity verification

### DIFF
--- a/modules/home-manager/ai-cli/claude/orphan-cleanup.nix
+++ b/modules/home-manager/ai-cli/claude/orphan-cleanup.nix
@@ -135,7 +135,7 @@ in
       verifyCacheIntegrity = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
         ${logHelper}
         log_info "Verifying marketplace cache integrity..."
-        ${verifyCacheIntegrityScript} "${homeDir}"
+        $DRY_RUN_CMD ${verifyCacheIntegrityScript} "${homeDir}"
       '';
     };
   };


### PR DESCRIPTION
## Summary
- Detect stale plugin cache entries when Nix updates marketplace symlinks to new `/nix/store` paths
- After `nix flake update`, marketplace symlinks may point to different store paths while the cache still references old data, causing Claude Code to load outdated plugin versions
- Adds `verify-cache-integrity.sh` that tracks store path hashes and purges cache directories on mismatch
- Runs as Phase 3 activation script in `orphan-cleanup.nix` after `linkGeneration`

## Test plan
- [ ] `nix flake check` passes
- [ ] `darwin-rebuild switch` completes without errors
- [ ] After `nix flake update` that changes marketplace inputs, verify stale cache dirs are purged
- [ ] Verify `~/.claude/plugins/cache/.nix-store-hashes` file is created/updated

Refs: anthropics/claude-code#17361
Partial: #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds cache integrity verification for Claude Code plugins to handle stale entries after Nix updates.
> 
>   - **Behavior**:
>     - Adds `verify-cache-integrity.sh` to check and purge stale plugin cache entries when Nix updates marketplace symlinks.
>     - Runs as Phase 3 in `orphan-cleanup.nix` after `linkGeneration`.
>   - **Scripts**:
>     - `verify-cache-integrity.sh` tracks store path hashes and purges cache directories on mismatch.
>     - Updates `~/.claude/plugins/cache/.nix-store-hashes` with new hashes.
>   - **Misc**:
>     - Updates `orphan-cleanup.nix` to include a new phase for cache integrity verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for f7739b813e9e6df4d17df89c69b01212c5c78694. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->