### PR TITLE
fix: prevent bot review comments from cancelling Claude review

### DIFF
--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -40,19 +40,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'review-code.yml',
-              event: 'pull_request',
-              branch: context.payload.pull_request.head.ref,
-            });
-            const prior = data.workflow_runs.filter(r =>
-              r.conclusion === 'success' && r.id !== context.runId
-            );
+            const prNumber = context.payload.pull_request.number;
+            const perPage = 100;
+            let page = 1;
+            let prior = [];
+
+            while (true) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'review-code.yml',
+                event: 'pull_request',
+                branch: context.payload.pull_request.head.ref,
+                per_page: perPage,
+                page,
+              });
+
+              const runs = data.workflow_runs || [];
+              const matched = runs.filter(r =>
+                r.conclusion === 'success' &&
+                r.id !== context.runId &&
+                Array.isArray(r.pull_requests) &&
+                r.pull_requests.some(pr => pr.number === prNumber)
+              );
+              prior = prior.concat(matched);
+
+              if (prior.length >= 2 || runs.length < perPage) break;
+              page += 1;
+            }
+
             const skip = prior.length >= 2;
             core.setOutput('skip', skip.toString());
-            console.log(`Prior successful reviews: ${prior.length}, skip: ${skip}`);
+            console.log(`PR #${prNumber} prior successful reviews: ${prior.length}, skip: ${skip}`);
 
       - name: Checkout repository
         if: steps.review-limit.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- **Fix concurrency bug**: Bot review comments (Gemini, Copilot) on PRs triggered `pull_request_review_comment` events that shared the same concurrency group as the `pull_request` event, cancelling the in-progress Claude review. Adding `github.event_name` to the concurrency group key isolates the two event types.
- **Add first-push re-review**: Claude now also reviews on `synchronize` (push) events, so it sees the code after initial feedback is addressed. A review count gate limits reviews to 2 successful runs per PR to avoid noise on subsequent pushes.
- **Add `actions: read` permission**: Required for the `listWorkflowRuns` API call in the review count gate.

## Test plan

- [ ] CI Gate passes on this PR
- [ ] Claude review runs on PR open (count = 0, review #1)
- [ ] Push to PR triggers review (count = 1, review #2)
- [ ] Further pushes skip review (count >= 2)
- [ ] Bot review comments no longer cancel in-progress reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes concurrency issue with bot comments and adds code push review trigger with a review limit in `review-code.yml`.
> 
>   - **Concurrency Fix**:
>     - Adds `github.event_name` to concurrency group in `review-code.yml` to prevent bot comments from cancelling Claude reviews.
>   - **Review Trigger**:
>     - Adds `synchronize` event to trigger Claude review on code push in `review-code.yml`.
>     - Limits reviews to 2 successful runs per PR using a review count gate.
>   - **Permissions**:
>     - Adds `actions: read` permission in `review-code.yml` for `listWorkflowRuns` API call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 858f540eb620617379600d7b01224354b87be183. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->