### PR TITLE
fix: add /opt/homebrew/bin to granola-watcher PATH

### DIFF
--- a/modules/home-manager/ai-cli/claude/granola-watcher.nix
+++ b/modules/home-manager/ai-cli/claude/granola-watcher.nix
@@ -51,7 +51,7 @@ let
         pkgs.jq
         pkgs.bc
       ]
-    }:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin";
+    }:/opt/homebrew/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin";
   }
   // lib.optionalAttrs cfg.apiKeyHelper.enable {
     API_KEY_HELPER = "${homeDir}/${cfg.apiKeyHelper.scriptPath}";


### PR DESCRIPTION
## Summary

- Adds `/opt/homebrew/bin` to the granola-watcher LaunchAgent PATH
- Fixes `command not found: claude` error — `claude` is installed via homebrew cask at `/opt/homebrew/bin/claude` but the LaunchAgent PATH only included Nix paths + system defaults

## Test plan

- [ ] `darwin-rebuild switch --flake .` regenerates plist with updated PATH
- [ ] `launchctl print gui/$(id -u)/com.visicore.granola-watcher | grep PATH` includes `/opt/homebrew/bin`
- [ ] Granola watcher log shows successful `claude` invocation (no more "command not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `/opt/homebrew/bin` to `PATH` in `granola-watcher.nix` to fix `command not found: claude` error.
> 
>   - **Behavior**:
>     - Adds `/opt/homebrew/bin` to the `PATH` in `granola-watcher.nix` to fix `command not found: claude` error.
>     - Ensures `claude` command is found when installed via Homebrew cask.
>   - **Testing**:
>     - `darwin-rebuild switch --flake .` regenerates plist with updated PATH.
>     - `launchctl print gui/$(id -u)/com.visicore.granola-watcher | grep PATH` confirms inclusion of `/opt/homebrew/bin`.
>     - Granola watcher log verifies successful `claude` invocation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for b43dc80ef09aa5f52ff042d1e4418547ba954038. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->