### PR TITLE
fix(claude): restore opusplan as default model

### DIFF
--- a/modules/home-manager/ai-cli/claude-config.nix
+++ b/modules/home-manager/ai-cli/claude-config.nix
@@ -66,10 +66,9 @@ in
   # Agent teams display mode (direct settings.json property)
   teammateMode = "auto";
 
-  # Model override: uncomment to use opusplan (Opus for planning, Sonnet for execution)
-  # Default (when unset): account-tier Opus for all tasks
+  # Model: opusplan uses Opus for planning, Sonnet for execution
   # See: https://code.claude.com/docs/en/model-config
-  # model = "opusplan";
+  model = "opusplan";
 
   # Release channel: "stable" delays ~1 week to avoid regressions
   autoUpdatesChannel = "stable";
@@ -129,8 +128,7 @@ in
     # See: https://code.claude.com/docs/en/settings
     # See: https://code.claude.com/docs/en/model-config
     env = {
-      # Model selection: account-tier Opus is the default (model override is commented out).
-      # Uncomment model = "opusplan" above for split Opus-planning/Sonnet-execution.
+      # Model selection: opusplan is set above (Opus for planning, Sonnet for execution).
       # Auto-claude background jobs use their own CLAUDE_MODEL env var (haiku).
       # ANTHROPIC_MODEL = "sonnet"; # Uncomment to override default model via env var
       # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents


### PR DESCRIPTION
## Summary
- Restores `model = "opusplan"` as the default Claude Code model setting
- This was changed to upstream default (opus) in #617 but should always be opusplan
- Updates surrounding comments to reflect the active state

## Test plan
- [ ] `nix flake check` passes
- [ ] `darwin-rebuild switch --flake .` applies successfully
- [ ] New Claude Code sessions start with opusplan model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores `opusplan` as the default model in `claude-config.nix` and updates comments accordingly.
> 
>   - **Behavior**:
>     - Restores `model = "opusplan"` as the default in `claude-config.nix`.
>     - Updates comments to reflect `opusplan` as the active model.
>   - **Test Plan**:
>     - Ensure `nix flake check` passes.
>     - Verify `darwin-rebuild switch --flake .` applies successfully.
>     - Confirm new Claude Code sessions start with `opusplan` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for abc18a7a6d1676591eaaf2519a406080efa582e5. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->