### PR TITLE
feat: add SOPS_AGE_KEY_FILE and EDITOR=vim to session variables

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -143,6 +143,12 @@ in
       // gitHooks
       // gitMergeDrivers;
 
+    sessionVariables = {
+      EDITOR = "vim";
+      # SOPS: age key file for secrets decryption
+      SOPS_AGE_KEY_FILE = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+    };
+
     # Activation scripts (run after home files are written)
     activation =
       geminiFiles.activation
@@ -215,9 +221,6 @@ in
       initContent = ''
         # GPG: Required for pinentry to prompt for passphrase in terminal
         export GPG_TTY=$(tty)
-
-        # SOPS: age key file for secrets decryption
-        export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
 
         # npm global packages (managed via ~/.npmrc prefix)
         # Packages installed with: npm install -g <package>


### PR DESCRIPTION
## Summary

- Adds `SOPS_AGE_KEY_FILE` and `EDITOR=vim` to `home.sessionVariables` in `common.nix`
- Uses `home.sessionVariables` (idiomatic home-manager) instead of shell `initContent` — declarative, shell-agnostic, static config separated from dynamic scripting
- `SOPS_AGE_KEY_FILE` points to `~/.config/sops/age/keys.txt` (standard age key location)

## Test plan

- [ ] Open a new terminal and verify `echo $SOPS_AGE_KEY_FILE` returns `~/.config/sops/age/keys.txt`
- [ ] Verify `echo $EDITOR` returns `vim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)