### PR TITLE
fix: remove deprecated SlashCommand permission

### DIFF
--- a/modules/home-manager/ai-cli/common/permissions.nix
+++ b/modules/home-manager/ai-cli/common/permissions.nix
@@ -141,7 +141,6 @@ in
         "Grep"
         "WebSearch"
         "TodoWrite"
-        "SlashCommand"
       ];
 
       # WebFetch with allowed domains (dynamically generated from ai-assistant-instructions)


### PR DESCRIPTION
## Summary

- Removes `SlashCommand` from the Claude Code permissions list in `permissions.nix`
- `SlashCommand` is no longer a valid permission type and causes a validation error on startup

## Test plan

- [ ] Rebuild and verify no `SlashCommand` validation warning in Claude Code startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes deprecated `SlashCommand` permission from `permissions.nix` to prevent startup validation error.
> 
>   - **Behavior**:
>     - Removes `SlashCommand` from the `claude.builtin` permissions list in `permissions.nix`.
>     - Prevents validation error on Claude Code startup due to deprecated permission.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for b67ce9e95dae67451be14a63d3130be700d230cb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->