### PR TITLE
chore: use minimal attribution for git commits

### DIFF
--- a/lib/claude-settings.nix
+++ b/lib/claude-settings.nix
@@ -33,6 +33,11 @@ in
   # Enable extended thinking mode
   alwaysThinkingEnabled = true;
 
+  # Minimal commit attribution (no verbose Co-Authored-By trailer)
+  attribution = {
+    commit = "(claude)";
+  };
+
   # Plugin marketplace configuration - transformed to Claude's expected format
   extraKnownMarketplaces = lib.mapAttrs toClaudeMarketplaceFormat plugins.marketplaces;
 

--- a/modules/home-manager/ai-cli/claude/settings.nix
+++ b/modules/home-manager/ai-cli/claude/settings.nix
@@ -52,6 +52,11 @@ let
   }
   // {
 
+    # Minimal commit attribution (no verbose Co-Authored-By trailer)
+    attribution = {
+      commit = "(claude)";
+    };
+
     # Permissions
     permissions = {
       inherit (cfg.settings.permissions) allow deny ask;


### PR DESCRIPTION
## Summary

- Adds `attribution.commit = "(claude)"` to Claude Code settings
- Replaces the verbose `Co-Authored-By: Claude Code <noreply@anthropic.com>` trailer with a compact `(claude)` string
- Keeps git log and release notes clean
- Updated both `modules/home-manager/ai-cli/claude/settings.nix` (deployed) and `lib/claude-settings.nix` (CI validation)

## Test plan

- [x] `nix flake check` passed
- [x] `sudo darwin-rebuild switch --flake .` succeeded
- [x] `cat ~/.claude/settings.json | jq '.attribution'` shows `{"commit": "(claude)"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds minimal commit attribution setting to Claude Code, replacing verbose trailers with `(claude)` in `lib/claude-settings.nix` and `modules/home-manager/ai-cli/claude/settings.nix`.
> 
>   - **Settings Update**:
>     - Adds `attribution.commit = "(claude)"` to `lib/claude-settings.nix` and `modules/home-manager/ai-cli/claude/settings.nix`.
>     - Replaces `Co-Authored-By` trailer with `(claude)` for minimal commit attribution.
>   - **Testing**:
>     - `nix flake check` and `sudo darwin-rebuild switch --flake .` confirm successful application.
>     - Validated with `jq` to ensure correct JSON output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for ef56d984fd22fed93ffd9fad73c488bcd93a368a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->