### PR TITLE
test: try SHA ref for reusable workflow

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -7,5 +7,5 @@ permissions: {}
 
 jobs:
   test:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@c7aaa12e4abe024ae6a951cba932e52c5373bc52
     secrets: inherit


### PR DESCRIPTION
Testing if SHA pin fixes startup_failure
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `test-reusable.yml` to use a specific SHA for `issue-triage.yml` to test startup failure fix.
> 
>   - **Workflow**:
>     - Update `test-reusable.yml` to use SHA `c7aaa12e4abe024ae6a951cba932e52c5373bc52` for `issue-triage.yml` instead of version `v0.2.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for b954072faeb069dca8225bec627af0b0385e49ed. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->