### PR TITLE
fix: add bridge job for reusable workflow always() limitation

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -21,9 +21,19 @@ jobs:
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.0
     secrets: inherit
 
-  resolve:
+  # Bridge job: always() on reusable workflow jobs with needs on another
+  # reusable workflow is not evaluated by GitHub Actions. This regular job
+  # ensures the resolve job runs when triage is skipped (workflow_dispatch).
+  gate:
     needs: triage
     if: always() && (github.event_name == 'workflow_dispatch' || github.event.sender.type != 'Bot') && (needs.triage.result == 'success' || needs.triage.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: 'true'
+
+  resolve:
+    needs: gate
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.0
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- GitHub Actions does not evaluate `always()` on reusable workflow `uses:` jobs when the `needs` dependency is also a reusable workflow job
- The `resolve` job was never started on `workflow_dispatch` because `triage` (skipped) was a reusable workflow call
- Adds a regular bridge job (`gate`) between `triage` and `resolve` so that `always()` is evaluated on a standard `runs-on` job, then `resolve` depends on `gate`

## Test plan
- [ ] Trigger `workflow_dispatch` with issue number → resolve job starts
- [ ] Open an issue → triage runs, then gate passes, then resolve runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a `gate` job in `issue-pipeline.yml` to ensure `resolve` runs when `triage` is skipped, addressing GitHub Actions' `always()` limitation with reusable workflows.
> 
>   - **Behavior**:
>     - Adds `gate` job in `issue-pipeline.yml` to bridge `triage` and `resolve` jobs.
>     - Ensures `resolve` runs when `triage` is skipped due to `workflow_dispatch`.
>   - **Workflow**:
>     - `gate` job uses `runs-on: ubuntu-latest` and runs a no-op step.
>     - `resolve` job now depends on `gate` instead of `triage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 9983677944ac51b2e48ca9f75da51a88b90228cc. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->