### PR TITLE
fix: update issue pipeline to ai-workflows v0.2.2

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   triage:
     if: github.event_name == 'issues' && github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.2
     secrets: inherit
 
   # Bridge job: always() on reusable workflow jobs with needs on another
@@ -34,7 +34,7 @@ jobs:
 
   resolve:
     needs: gate
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.2
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"


### PR DESCRIPTION
## Summary
- Updates issue-pipeline.yml to reference ai-workflows v0.2.2
- v0.2.2 removes `sender.type` bot check from reusable workflow jobs that silently skipped all inner jobs on `workflow_dispatch`

## Test plan
- [ ] After merge, trigger `workflow_dispatch` on Issue Pipeline with issue #659 → resolve job starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `issue-pipeline.yml` to use `ai-workflows` v0.2.2, removing bot check to fix `workflow_dispatch` issues.
> 
>   - **Workflows**:
>     - Update `issue-pipeline.yml` to use `ai-workflows` v0.2.2.
>     - Removes `sender.type` bot check from `triage` job, allowing `workflow_dispatch` to trigger inner jobs.
>   - **Jobs**:
>     - Update `triage` job to use `issue-triage.yml@v0.2.2`.
>     - Update `resolve` job to use `issue-resolver.yml@v0.2.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 85bdaf567de7fe7361c4b157493468c3cf7bd347. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->