### PR TITLE
fix: add explicit if condition on resolve job for skipped ancestors

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -34,6 +34,10 @@ jobs:
 
   resolve:
     needs: gate
+    # success() checks the ENTIRE needs graph (triage→gate→resolve).
+    # Triage is skipped on workflow_dispatch, so success() returns false.
+    # Explicitly check only the direct dependency.
+    if: always() && needs.gate.result == 'success'
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.2
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- The default `success()` condition checks the **entire needs graph**, not just direct dependencies
- When triage is skipped (`workflow_dispatch`), `success()` returns false even though `gate` succeeded
- Adds `if: always() && needs.gate.result == 'success'` so resolve only depends on its direct dependency

## Root cause
GitHub Actions `success()` walks the full ancestor chain: `triage → gate → resolve`. Since triage is skipped on `workflow_dispatch`, `success()` returns false, silently skipping the resolve job.

The system log confirmed: `Evaluating: success() / Result: false`

## Test plan
- [ ] After merge, trigger `workflow_dispatch` on Issue Pipeline with issue #659 → resolve job starts and eligibility check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `resolve` job condition in `issue-pipeline.yml` to only depend on direct dependency `gate`, ensuring it runs when `triage` is skipped.
> 
>   - **Behavior**:
>     - Adds `if: always() && needs.gate.result == 'success'` to `resolve` job in `issue-pipeline.yml` to ensure it runs when `triage` is skipped.
>     - Fixes issue where `success()` condition checked entire needs graph, causing `resolve` to be skipped on `workflow_dispatch`.
>   - **Root Cause**:
>     - `success()` evaluated full ancestor chain (`triage → gate → resolve`), returning false when `triage` was skipped.
>   - **Test Plan**:
>     - After merge, trigger `workflow_dispatch` on Issue Pipeline with issue #659 to verify `resolve` job starts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for fb7e4e8319f5425b1e016f265bd53f153aa0fefb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->