### PR TITLE
fix: split resolve into auto and manual paths

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -21,23 +21,19 @@ jobs:
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.2
     secrets: inherit
 
-  # Bridge job: always() on reusable workflow jobs with needs on another
-  # reusable workflow is not evaluated by GitHub Actions. This regular job
-  # ensures the resolve job runs when triage is skipped (workflow_dispatch).
-  gate:
+  # Auto path: issues trigger → triage labels → resolve picks up
+  resolve-auto:
     needs: triage
-    if: always() && (github.event_name == 'workflow_dispatch' || github.event.sender.type != 'Bot') && (needs.triage.result == 'success' || needs.triage.result == 'skipped')
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - run: 'true'
+    if: github.event_name == 'issues' && github.event.sender.type != 'Bot'
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.2
+    secrets: inherit
+    with:
+      repo_context: "NixOS/nix-darwin system configuration using flakes"
+      extra_tools: "Bash(nix:*)"
 
-  resolve:
-    needs: gate
-    # success() checks the ENTIRE needs graph (triage→gate→resolve).
-    # Triage is skipped on workflow_dispatch, so success() returns false.
-    # Explicitly check only the direct dependency.
-    if: always() && needs.gate.result == 'success'
+  # Manual path: workflow_dispatch → resolve directly (no triage needed)
+  resolve-manual:
+    if: github.event_name == 'workflow_dispatch'
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.2
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
GitHub Actions has multiple issues with reusable workflow job chains:
1. `always()` on reusable workflow `uses:` jobs is never evaluated when ancestors are skipped
2. Default `success()` checks the full ancestor graph, not just direct `needs`
3. Bridge jobs don't fix #2 because `success()` still walks all ancestors

Splits the resolve job into two independent paths:
- **resolve-auto**: `needs: triage` (issues trigger, clean dependency chain)
- **resolve-manual**: no `needs` (workflow_dispatch, runs independently)

Removes the gate bridge job — no longer needed.

## Test plan
- [ ] After merge, trigger `workflow_dispatch` with issue #659 → resolve-manual starts
- [ ] Open a test issue → triage runs, then resolve-auto runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Splits `resolve` job into `resolve-auto` and `resolve-manual` paths in `.github/workflows/issue-pipeline.yml`, removing the `gate` job and simplifying conditions.
> 
>   - **Behavior**:
>     - Splits `resolve` job into `resolve-auto` and `resolve-manual` in `.github/workflows/issue-pipeline.yml`.
>     - `resolve-auto` runs after `triage` for `issues` events.
>     - `resolve-manual` runs independently for `workflow_dispatch` events.
>   - **Removals**:
>     - Removes the `gate` bridge job, simplifying the workflow.
>   - **Conditions**:
>     - `resolve-auto` uses `needs: triage` and checks `github.event_name == 'issues'`.
>     - `resolve-manual` checks `github.event_name == 'workflow_dispatch'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 95d4b0ecf0e8ddc4aa04d458eab911240ea3c26d. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->