### PR TITLE
fix: bump issue-resolver callers to v0.2.4

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -18,7 +18,7 @@ jobs:
   resolve:
     needs: triage
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   resolve:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"


### PR DESCRIPTION
## Summary
- Bump `issue-pipeline.yml` and `issue-auto-resolve.yml` from `@v0.2.3` to `@v0.2.4`

## Root Cause
v0.2.3's `issue-resolver.yml` used `inputs.issue_number` in the `concurrency:` group. GitHub Actions cannot evaluate the `inputs` context during concurrency group resolution for reusable workflows, causing startup_failure (0 jobs).

v0.2.4 (ai-workflows PR #30) replaces this with `github.event.issue.number || github.run_id`.

## Test Plan
After merge: `gh workflow run issue-pipeline.yml -f issue_number=659`
- Expect: eligibility-check + resolve jobs appear (not 0 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `issue-resolver.yml` version to `v0.2.4` in workflows to fix concurrency issue.
> 
>   - **Workflows**:
>     - Bump `issue-resolver.yml` version from `v0.2.3` to `v0.2.4` in `issue-auto-resolve.yml` and `issue-pipeline.yml`.
>   - **Root Cause**:
>     - `v0.2.3` used `inputs.issue_number` in `concurrency:` group, causing startup failure due to GitHub Actions' inability to evaluate `inputs` context.
>     - `v0.2.4` replaces this with `github.event.issue.number || github.run_id` to resolve the issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for d5843c588c8e6b275ba126949ef2a50041964016. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->