### PR TITLE
fix: rename caller job keys to avoid reusable workflow name collision

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -10,13 +10,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  triage:
+  run-triage:
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.4
     secrets: inherit
 
-  resolve:
-    needs: triage
+  resolve-issue:
+    needs: run-triage
     if: github.event.sender.type != 'Bot'
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
     secrets: inherit

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  resolve:
+  resolve-issue:
     uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- Rename `resolve` → `resolve-issue` in `issue-pipeline.yml`
- Rename `triage` → `run-triage` and `resolve` → `resolve-issue` in `issue-auto-resolve.yml`
- Bump `issue-triage.yml` caller to `@v0.2.4`

## Root Cause
When a caller's job key matches an internal job key in the reusable workflow, GitHub Actions fails at startup (0 jobs, 3-second completion). The caller's `resolve` job key collided with `issue-resolver.yml`'s internal `resolve` job, and `triage` collided with `issue-triage.yml`'s internal `triage` job.

This is the final piece of the puzzle after:
- PR #669: Split issue-pipeline into two files + fix permissions/version
- PR #670: Bump to v0.2.4 (concurrency fix)

## Test Plan
After merge: `gh workflow run issue-pipeline.yml -f issue_number=659`
- Expect: `resolve-issue / Check eligibility` + `resolve-issue / Claude Resolve` jobs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames job keys in GitHub Actions workflows to avoid naming collisions with internal job keys, ensuring correct execution.
> 
>   - **Behavior**:
>     - Rename `resolve` to `resolve-issue` in `issue-pipeline.yml` to avoid collision with internal job keys.
>     - Rename `triage` to `run-triage` and `resolve` to `resolve-issue` in `issue-auto-resolve.yml` to prevent naming conflicts.
>     - Bump `issue-triage.yml` version to `@v0.2.4` in `issue-auto-resolve.yml`.
>   - **Root Cause**:
>     - GitHub Actions failed due to job key collisions between caller and internal job keys in reusable workflows.
>   - **Test Plan**:
>     - After merge, run `gh workflow run issue-pipeline.yml -f issue_number=659` to verify `resolve-issue` jobs appear correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 3a650e3bf80e62637f0af52cbfb5ce601c40ce1a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->