### PR TITLE
fix: bump issue resolver/triage callers to v0.2.5

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -12,13 +12,13 @@ permissions:
 jobs:
   run-triage:
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.5
     secrets: inherit
 
   resolve-issue:
     needs: run-triage
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.5
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.4
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.5
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"


### PR DESCRIPTION
## Summary
- Bump `issue-pipeline.yml` and `issue-auto-resolve.yml` from `@v0.2.4` to `@v0.2.5`

## Root Cause
v0.2.5 (ai-workflows PR #32) changes `issue_number` and `max_attempts` from `type: number` to `type: string`. GitHub Actions `workflow_call` inputs with `type: number` cause startup_failure (0 jobs) when callers pass string expressions from `workflow_dispatch` events.

**Evidence**: The `issues: [opened]` path worked (doesn't pass `issue_number`, uses default). The `workflow_dispatch` path failed (passes string "659" to `type: number` → startup_failure).

## Test Plan
After merge: `gh workflow run issue-pipeline.yml -f issue_number=659`
- Expect: `resolve-issue / Check eligibility` + `resolve-issue / Claude Resolve` jobs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update issue resolver and triage workflows to v0.2.5 to fix type mismatch causing startup failures.
> 
>   - **Version Update**:
>     - Bump `issue-triage.yml` and `issue-resolver.yml` from `@v0.2.4` to `@v0.2.5` in `issue-auto-resolve.yml` and `issue-pipeline.yml`.
>   - **Root Cause Fix**:
>     - Fixes type mismatch by changing `issue_number` and `max_attempts` from `type: number` to `type: string` in v0.2.5.
>     - Resolves startup failures when passing string expressions from `workflow_dispatch` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 60d7946b9dfb51cd99ee655eb645ecd7ef3f671e. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->