### PR TITLE
fix: bump ai-workflows to v0.2.6 and add id-token:write

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -20,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.6
     with:
       repo_context: "Nix flakes configuration for macOS and Linux systems"
       ci_structure: "ci-gate.yml (orchestrator calling _nix-validate, _nix-build, _markdown-lint, _file-size, _claude-settings)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.6
     with:
       review_prompt: "Focus on Nix flake patterns, module structure, system configuration best practices"
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -9,10 +9,11 @@ on:
 permissions:
   checks: read
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.6
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -6,19 +6,20 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
 jobs:
   run-triage:
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.5
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.6
     secrets: inherit
 
   resolve-issue:
     needs: run-triage
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.5
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.6
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -10,12 +10,13 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.5
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.6
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"


### PR DESCRIPTION
## Summary

- Bump all ai-workflows caller references to `@v0.2.6`
- Add `id-token: write` permission to ci-fix, final-pr-review, issue-pipeline, and issue-auto-resolve callers (required for OIDC token exchange in `claude-code-action@v1`)
- `claude-review.yml` already had `id-token: write` — only version bump needed

## Context

ai-workflows v0.2.6 migrates from deprecated `claude-code-action` inputs (`direct_prompt`, `allowed_tools`, `model`) to the current API (`prompt`, `claude_args`), and uses OIDC for git push auth instead of explicit token checkout.

## Test plan

- [ ] Manual dispatch: `gh workflow run issue-pipeline.yml -f issue_number=659`
- [ ] Verify: eligibility passes → Claude Resolve starts → draft PR created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ai-workflows to v0.2.6 and add id-token:write permission for OIDC token exchange in multiple workflows.
> 
>   - **Version Update**:
>     - Bump `ai-workflows` version to `v0.2.6` in `ci-fix.yml`, `claude-review.yml`, `final-pr-review.yml`, `issue-auto-resolve.yml`, and `issue-pipeline.yml`.
>   - **Permissions**:
>     - Add `id-token: write` permission to `ci-fix.yml`, `final-pr-review.yml`, `issue-auto-resolve.yml`, and `issue-pipeline.yml` for OIDC token exchange.
>     - `claude-review.yml` already had `id-token: write` permission.
>   - **Context**:
>     - `ai-workflows` v0.2.6 migrates deprecated inputs to current API and uses OIDC for git push auth.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 65fd79f7635d597a4408a62315247ee5e0c91d51. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->