### PR TITLE
fix: change issue_number input type from number to string

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -6,7 +6,7 @@ on:
       issue_number:
         description: "Issue number to resolve (must already be labeled)"
         required: true
-        type: number
+        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Changes `type: number` to `type: string` for `issue_number` input in `issue-pipeline.yml`
- `workflow_dispatch` inputs are always strings; this aligns the caller with the reusable workflow (fixed in ai-workflows v0.2.5)

## Test plan
- [x] Pre-commit hooks pass (yaml, zizmor, semgrep)
- [ ] Verify manual `workflow_dispatch` still works with string input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `issue_number` input type from `number` to `string` in `issue-pipeline.yml` to align with `workflow_dispatch` input types.
> 
>   - **Behavior**:
>     - Change `issue_number` input type from `number` to `string` in `issue-pipeline.yml`.
>     - Aligns with `workflow_dispatch` inputs being strings.
>   - **Test Plan**:
>     - Verify manual `workflow_dispatch` works with string input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for e2e344ea91a039fa78d1b27894740afb33502d73. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->