### PR TITLE
fix: bump all ai-workflows callers to v0.2.7

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.7
     with:
       repo_context: "Nix flakes configuration for macOS and Linux systems"
       ci_structure: "ci-gate.yml (orchestrator calling _nix-validate, _nix-build, _markdown-lint, _file-size, _claude-settings)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.7
     with:
       review_prompt: "Focus on Nix flake patterns, module structure, system configuration best practices"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -13,13 +13,13 @@ permissions:
 jobs:
   run-triage:
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.7
     secrets: inherit
 
   resolve-issue:
     needs: run-triage
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.7
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.6
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.7
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.7
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.3
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.7
     secrets: inherit


### PR DESCRIPTION
## Summary
- Bumps all ai-workflows caller references from v0.2.3/v0.2.6 to v0.2.7
- v0.2.7 fixes commit signing (resolver/ci-fix) and migrates triage to v1 action with OIDC auth

## Test plan
- [ ] Verify issue auto-resolve pipeline creates draft PR (issue #676)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps all ai-workflows references to v0.2.7 across multiple GitHub Actions workflows for improved commit signing and OIDC auth.
> 
>   - **Version Update**:
>     - Bumps `ai-workflows` references to `v0.2.7` in `.github/workflows/best-practices.yml`, `.github/workflows/ci-fix.yml`, and `.github/workflows/claude-review.yml`.
>     - Updates `.github/workflows/code-simplifier.yml`, `.github/workflows/final-pr-review.yml`, and `.github/workflows/issue-auto-resolve.yml` to use `v0.2.7`.
>     - Changes `.github/workflows/issue-hygiene.yml`, `.github/workflows/issue-pipeline.yml`, and `.github/workflows/issue-sweeper.yml` to `v0.2.7`.
>     - Modifies `.github/workflows/next-steps.yml`, `.github/workflows/post-merge-docs-review.yml`, and `.github/workflows/post-merge-tests.yml` to `v0.2.7`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for d3050cf1e0c7a679baad840c4a5586555b9f9454. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->