### PR TITLE
feat: add git-bug as universally available system tool

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -71,6 +71,7 @@ Source: `modules/common/packages.nix`
 | Package | Description |
 |---------|-------------|
 | git-flow-next | Modern git-flow workflow tool (custom buildGoModule, gittower/git-flow-next v1.0.0) |
+| git-bug | Distributed bug tracker embedded in git (`git bug` command) |
 
 ### Pre-commit and Linters
 

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -21,6 +21,7 @@ with pkgs;
 
   # Git Workflow
   (pkgs.callPackage ./git-flow-next.nix { }) # git-flow workflow tool (not in nixpkgs)
+  git-bug # Distributed bug tracker embedded in git (git bug command)
 
   # ==========================================================================
   # Node.js and Bun Runtimes


### PR DESCRIPTION
## Summary

- Adds `git-bug` (v0.10.1) from nixpkgs stable to `modules/common/packages.nix`
- Available system-wide on all machines alongside `git`, `gh`, `awscli2`, etc.
- Updates `MANIFEST.md` inventory under "Git Workflow"

`git-bug` is a distributed bug tracker embedded in git — issues are stored directly in the repo with no external server required.

## Test plan

- [x] `nix flake check` passes (all 5 checks clean)
- [x] `sudo darwin-rebuild switch --flake .` succeeds — `git-bug-0.10.1` fetched from `cache.nixos.org`
- [x] `which git-bug` → `/run/current-system/sw/bin/git-bug`
- [x] `git-bug version` → `0.10.1`
- [x] All pre-commit hooks pass (push hooks included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `git-bug` as a universally available system tool by updating `modules/common/packages.nix` and `MANIFEST.md`.
> 
>   - **Behavior**:
>     - Adds `git-bug` (v0.10.1) to `modules/common/packages.nix` for system-wide availability.
>     - Updates `MANIFEST.md` to include `git-bug` under "Git Workflow".
>   - **Testing**:
>     - `nix flake check` passes all checks.
>     - `sudo darwin-rebuild switch --flake .` confirms `git-bug-0.10.1` is fetched from `cache.nixos.org`.
>     - `which git-bug` and `git-bug version` confirm installation and version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 23bc57a0dba6a1dfea651e4837f49ef3ca2c1b70. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->