### PR TITLE
chore(deps): update all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771545304,
-        "narHash": "sha256-e2B4Xg+IU9iWb7hUEwkj6JU8E1arx4V8S1aWgmuJ3tQ=",
+        "lastModified": 1771631286,
+        "narHash": "sha256-jVmz7CIXpnUz5QwVHQAvfVqBgStUypn3pvUr9OGerMo=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "0d996a7c346e2f3aca34e3488e49f1da537d7811",
+        "rev": "3ad3231f0f3a9ff4e1be18d20cbea1e9955d0047",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "claude-code-workflows": {
       "flake": false,
       "locked": {
-        "lastModified": 1771528919,
-        "narHash": "sha256-xAMIqjLheBXe2bIBCSglPFaBMAVpDpWRPSFsQSK3lkk=",
+        "lastModified": 1771636241,
+        "narHash": "sha256-vA0ye9RfBPBKjsRCZ8v5jYEAy4GII9tLO9nbgwnb+Vc=",
         "owner": "wshobson",
         "repo": "agents",
-        "rev": "682abfcdeba70645a29bf057e63bb97118d01dff",
+        "rev": "5140d2020499db4b32a6a204f23286ae9462fc5f",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1771354210,
-        "narHash": "sha256-MppB26fR1Z3QW4XSbhJgFctLvAE+zJxfWgwsXGaKHD4=",
+        "lastModified": 1771605554,
+        "narHash": "sha256-jnDTccQoooxw/FAwh0CoBopqUc1JayVxP9jJ895HmzA=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "944b94a0ebc6025e89aaf90136e120a72068b077",
+        "rev": "419ce35fa8457347ff8bf61bffed791f8617b8c1",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1771462612,
-        "narHash": "sha256-rgSYS8armT0mBAf3IziRdQ+NFhq9DTKToe5z/rPZ2LU=",
+        "lastModified": 1771606364,
+        "narHash": "sha256-13IHT4I7U3u+lXrl9/ZgehsWOs8QqvoZt18Upg7ye5c=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "8deab8460a9d4df5a01315ef722a5ca6b061c074",
+        "rev": "aa296ec81e8ccb49c9784f167c2c0aa625a86cec",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771504355,
-        "narHash": "sha256-VS9XIlXm6Juz/UIF5JQMS2Shtqi1KapwcWrhISFz1lc=",
+        "lastModified": 1771585808,
+        "narHash": "sha256-EDkrYQCP3O5dB8UdJZsMxgriJsq9n/nnQ97Pr7ASMCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "202ee4db135f82197897df676e8c3cf949472bc6",
+        "rev": "53584140326059f7d044f3812f7ca37b4e1fad68",
         "type": "github"
       },
       "original": {

--- a/shells/image-building/flake.lock
+++ b/shells/image-building/flake.lock
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771545304,
-        "narHash": "sha256-e2B4Xg+IU9iWb7hUEwkj6JU8E1arx4V8S1aWgmuJ3tQ=",
+        "lastModified": 1771631286,
+        "narHash": "sha256-jVmz7CIXpnUz5QwVHQAvfVqBgStUypn3pvUr9OGerMo=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "0d996a7c346e2f3aca34e3488e49f1da537d7811",
+        "rev": "3ad3231f0f3a9ff4e1be18d20cbea1e9955d0047",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "claude-code-workflows": {
       "flake": false,
       "locked": {
-        "lastModified": 1771528919,
-        "narHash": "sha256-xAMIqjLheBXe2bIBCSglPFaBMAVpDpWRPSFsQSK3lkk=",
+        "lastModified": 1771636241,
+        "narHash": "sha256-vA0ye9RfBPBKjsRCZ8v5jYEAy4GII9tLO9nbgwnb+Vc=",
         "owner": "wshobson",
         "repo": "agents",
-        "rev": "682abfcdeba70645a29bf057e63bb97118d01dff",
+        "rev": "5140d2020499db4b32a6a204f23286ae9462fc5f",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1771354210,
-        "narHash": "sha256-MppB26fR1Z3QW4XSbhJgFctLvAE+zJxfWgwsXGaKHD4=",
+        "lastModified": 1771605554,
+        "narHash": "sha256-jnDTccQoooxw/FAwh0CoBopqUc1JayVxP9jJ895HmzA=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "944b94a0ebc6025e89aaf90136e120a72068b077",
+        "rev": "419ce35fa8457347ff8bf61bffed791f8617b8c1",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1771462612,
-        "narHash": "sha256-rgSYS8armT0mBAf3IziRdQ+NFhq9DTKToe5z/rPZ2LU=",
+        "lastModified": 1771606364,
+        "narHash": "sha256-13IHT4I7U3u+lXrl9/ZgehsWOs8QqvoZt18Upg7ye5c=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "8deab8460a9d4df5a01315ef722a5ca6b061c074",
+        "rev": "aa296ec81e8ccb49c9784f167c2c0aa625a86cec",
         "type": "github"
       },
       "original": {
@@ -373,11 +373,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771504355,
-        "narHash": "sha256-VS9XIlXm6Juz/UIF5JQMS2Shtqi1KapwcWrhISFz1lc=",
+        "lastModified": 1771585808,
+        "narHash": "sha256-EDkrYQCP3O5dB8UdJZsMxgriJsq9n/nnQ97Pr7ASMCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "202ee4db135f82197897df676e8c3cf949472bc6",
+        "rev": "53584140326059f7d044f3812f7ca37b4e1fad68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updated nixpkgs and other inputs across:
- Root flake: agents, claude-cookbooks, claude-plugins-official, nixpkgs
- Shell environments: image-building

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `flake.lock` files to latest revisions for multiple dependencies including `claude-code-plugins` and `nixpkgs`.
> 
>   - **Dependencies Updated**:
>     - Updated `claude-code-plugins`, `claude-code-workflows`, and `claude-cookbooks` to new revisions in `flake.lock`.
>     - Updated `claude-plugins-official` and `nixpkgs` to new revisions in `flake.lock`.
>   - **Files Affected**:
>     - Changes made in `flake.lock` and `shells/image-building/flake.lock`.
>   - **Misc**:
>     - Co-authored by Claude Sonnet 4.5 <noreply@anthropic.com>.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for a9e3897e1a619c78338d1f52a8767bcd735454b4. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->