### PR TITLE
fix: bump all ai-workflows callers to v0.2.8

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   recommend:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.2.8
     with:
       repo_context: "Nix flakes configuration for macOS and Linux systems"
       ci_structure: "ci-gate.yml (orchestrator calling _nix-validate, _nix-build, _markdown-lint, _file-size, _claude-settings)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.2.8
     with:
       review_prompt: "Focus on Nix flake patterns, module structure, system configuration best practices"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -13,13 +13,13 @@ permissions:
 jobs:
   run-triage:
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.2.8
     secrets: inherit
 
   resolve-issue:
     needs: run-triage
     if: github.event.sender.type != 'Bot'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.8
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   resolve-issue:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.2.8
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   analyze:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.2.8
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.7
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.2.8
     secrets: inherit


### PR DESCRIPTION
## Summary
- Bumps all ai-workflows caller references from v0.2.7 to v0.2.8
- v0.2.8 switches issue-resolver and ci-fix from API commit signing (broken in agent mode) to SSH signing with `GH_APP_PRIVATE_KEY`

## Test plan
- [ ] After `GH_APP_PRIVATE_KEY` secret is synced, re-run issue resolver on issue #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps ai-workflows version to v0.2.8 across workflows, switching to SSH signing with `GH_APP_PRIVATE_KEY`.
> 
>   - **Version Update**:
>     - Bumps `ai-workflows` version from v0.2.7 to v0.2.8 in `.github/workflows/best-practices.yml`, `.github/workflows/ci-fix.yml`, and `.github/workflows/claude-review.yml`.
>     - Updates also in `.github/workflows/code-simplifier.yml`, `.github/workflows/final-pr-review.yml`, and 7 other workflow files.
>   - **Signing Method**:
>     - v0.2.8 switches from API commit signing to SSH signing using `GH_APP_PRIVATE_KEY` for `issue-resolver` and `ci-fix` workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 41f718bc7ce4430390f358cf5d641acd61c9c389. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->