### PR TITLE
fix(granola-migrate): restore homebrew PATH and skip budget on failure

### DIFF
--- a/modules/home-manager/ai-cli/claude/granola-migrate.sh
+++ b/modules/home-manager/ai-cli/claude/granola-migrate.sh
@@ -119,7 +119,8 @@ log "Claude exited with code ${CLAUDE_EXIT}"
 # Claude's --max-budget-usd caps actual spending, so charge the full effective budget.
 # This is conservative (may overcount) but simple and safe.
 
-# Only charge budget on successful runs (not command-not-found failures)
+# Only charge budget on successful runs (exit 0) to avoid charging for failed/partial runs,
+# including command-not-found and other non-zero exit codes.
 if (( CLAUDE_EXIT == 0 )); then
   new_spent=$(echo "$spent + $effective_budget" | bc)
   echo "{\"date\":\"${TODAY}\",\"spent\":${new_spent}}" > "$BUDGET_FILE"


### PR DESCRIPTION
## Summary

- Adds `export PATH="/opt/homebrew/bin:$PATH"` before `set -euo pipefail` to restore the homebrew PATH that nix-darwin's `/etc/zshenv` strips from launchd environments
- Only charges the daily budget counter when Claude exits with code 0; failed runs (e.g. command-not-found) no longer eat into the budget

## Test plan

- [ ] Trigger a granola-migrate launchd run and confirm homebrew tools are found
- [ ] Simulate a non-zero Claude exit and confirm budget file is unchanged
- [ ] Confirm normal successful run still increments `$BUDGET_FILE` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores Homebrew PATH and modifies budget handling in `granola-migrate.sh` to charge only on successful Claude runs.
> 
>   - **Behavior**:
>     - Adds `export PATH="/opt/homebrew/bin:$PATH"` in `granola-migrate.sh` to restore Homebrew PATH stripped by nix-darwin.
>     - Modifies budget handling in `granola-migrate.sh` to only charge budget when Claude exits with code 0.
>   - **Logging**:
>     - Logs a message when Claude fails, indicating no budget charge.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 27560d30cc5ad0902910da973999bacb19663cab. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->