### PR TITLE
fix(claude): use recursive=true for marketplace dirs, remove cleanup scripts

### DIFF
--- a/modules/home-manager/ai-cli/claude/orphan-cleanup.nix
+++ b/modules/home-manager/ai-cli/claude/orphan-cleanup.nix
@@ -14,10 +14,6 @@
 # Phase 3 (AFTER linkGeneration):
 # - Verifies plugin cache integrity when marketplace symlinks change
 #
-# Phase 4 (AFTER reportMarketplaceDiffs):
-# - Removes .backup directories for Nix-managed marketplaces
-# - Removes known deprecated/orphan marketplace directories
-#
 { config, lib, ... }:
 
 let
@@ -34,21 +30,6 @@ let
       echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] $1" >&2
     }
   '';
-
-  marketplacesDir = "${homeDir}/.claude/plugins/marketplaces";
-
-  # Known deprecated marketplace directories to remove
-  # These were previously used but are no longer needed
-  deprecatedMarketplaceDirs = [
-    "awesome-claude-code-plugins"
-    "claudeforge-marketplace"
-    "axton-obsidian-visual-skills" # Old name; Nix manages obsidian-visual-skills
-  ];
-
-  # Get names of Nix-managed marketplaces (those with flakeInput set)
-  nixManagedMarketplaceNames = lib.mapAttrsToList (name: _: lib.last (lib.splitString "/" name)) (
-    lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces
-  );
 
   # Component directories that are managed as individual files (not directory symlinks)
   componentDirs = [
@@ -155,43 +136,6 @@ in
         $DRY_RUN_CMD ${verifyCacheIntegrityScript} "${homeDir}"
       '';
 
-      # Phase 4: Clean up orphan marketplace directories AFTER reportMarketplaceDiffs
-      # Removes .backup directories and known deprecated marketplace directories
-      # Must run after reportMarketplaceDiffs to allow diff viewing before deletion
-      cleanupOrphanMarketplaces = lib.hm.dag.entryAfter [ "reportMarketplaceDiffs" ] ''
-        ${logHelper}
-
-        # Remove .backup directories for Nix-managed marketplaces (older than 14 days only)
-        # These are created by plugins.nix when converting runtime dirs to symlinks
-        # The 14-day threshold allows users to review/recover runtime content before deletion
-        ${lib.concatMapStringsSep "\n" (name: ''
-          BACKUP="${marketplacesDir}/${name}.backup"
-          if [ -d "$BACKUP" ]; then
-            # Only delete backups older than 14 days to reduce data loss risk
-            if find "$BACKUP" -maxdepth 0 -mtime +14 >/dev/null 2>&1; then
-              if $DRY_RUN_CMD rm -rf "$BACKUP"; then
-                log_info "Removed marketplace backup (older than 14 days): ${name}.backup"
-              else
-                log_warn "Failed to remove marketplace backup: ${name}.backup"
-              fi
-            else
-              log_info "Skipping recent marketplace backup (you may still need it for review): ${name}.backup"
-            fi
-          fi
-        '') nixManagedMarketplaceNames}
-
-        # Remove known deprecated marketplace directories
-        ${lib.concatMapStringsSep "\n" (name: ''
-          DEPRECATED="${marketplacesDir}/${name}"
-          if [ -d "$DEPRECATED" ] && [ ! -L "$DEPRECATED" ]; then
-            if $DRY_RUN_CMD rm -rf "$DEPRECATED"; then
-              log_info "Removed deprecated marketplace: ${name}"
-            else
-              log_warn "Failed to remove deprecated marketplace: ${name}"
-            fi
-          fi
-        '') deprecatedMarketplaceDirs}
-      '';
     };
   };
 }

--- a/modules/home-manager/ai-cli/claude/plugins.nix
+++ b/modules/home-manager/ai-cli/claude/plugins.nix
@@ -3,25 +3,10 @@
 # Symlinks Nix-managed plugin directories from flake inputs.
 # Runtime plugins are unaffected - they live in separate directories.
 #
-# Automatic cleanup: When a marketplace directory exists but should be a symlink,
-# it's automatically removed (with diff reporting). Only one backup is kept.
-#
-# ACTIVATION SCRIPT ORDERING (using home-manager DAG):
-#
-# 1. cleanupMarketplaceDirectories (entryBefore linkGeneration)
-#    - Runs BEFORE home-manager creates symlinks
-#    - Moves conflicting directories to .backup
-#    - Required to prevent "cannot overwrite directory" errors
-#
-# 2. linkGeneration (home-manager built-in)
-#    - Creates all symlinks defined in home.file
-#
-# 3. reportMarketplaceDiffs (entryAfter linkGeneration)
-#    - Runs AFTER symlinks are created
-#    - Shows diffs between backup and new Nix-managed content
-#    - Helps users verify marketplace transitions
-#
-# Do NOT change this ordering without understanding the dependencies.
+# Uses `recursive = true` to create per-file symlinks inside each marketplace
+# directory, rather than symlinking the entire directory. This allows Claude
+# Code's extra files (.git/, caches) to coexist without conflict, and avoids
+# "cannot overwrite directory with symlink" errors on darwin-rebuild switch.
 { config, lib, ... }:
 
 let
@@ -39,97 +24,14 @@ let
     name: marketplace:
     lib.nameValuePair ".claude/plugins/marketplaces/${getMarketplaceName name}" {
       source = marketplace.flakeInput;
+      recursive = true;
       force = true;
     }
-  ) nixManagedMarketplaces;
-
-  # Generate list of marketplace paths that should be symlinks
-  marketplacePaths = lib.mapAttrsToList (
-    name: _: "${config.home.homeDirectory}/.claude/plugins/marketplaces/${getMarketplaceName name}"
   ) nixManagedMarketplaces;
 
 in
 {
   config = lib.mkIf cfg.enable {
-    home = {
-      file = marketplaceSymlinks;
-
-      activation = {
-        # Activation script to clean up conflicting marketplace directories
-        # MUST run before linkGeneration to prevent "cannot overwrite directory" errors
-        # Log format: YYYY-MM-DD HH:MM:SS [LOG_LEVEL] message
-        cleanupMarketplaceDirectories = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
-          # Clean up marketplace directories that conflict with Nix-managed symlinks
-          # This handles the case where runtime plugin installs created real directories
-          # that now prevent Nix from creating symlinks
-          ${lib.concatMapStringsSep "\n" (path: ''
-            if [ -d "${path}" ] && [ ! -L "${path}" ]; then
-              BACKUP="${path}.backup"
-
-              # Remove old backup if it exists (only keep one)
-              if [ -e "$BACKUP" ]; then
-                rm -rf "$BACKUP"
-              fi
-
-              # Move directory to backup
-              mv "${path}" "$BACKUP"
-              echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Cleaned up marketplace directory: ${path}" >&2
-              echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Backup saved to: $BACKUP" >&2
-              echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   After activation completes, a diff will be shown" >&2
-            fi
-          '') marketplacePaths}
-        '';
-
-        # Post-activation script to show diffs for manual review
-        # Log format: YYYY-MM-DD HH:MM:SS [LOG_LEVEL] message
-        reportMarketplaceDiffs = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
-          # Show diffs between backed-up directories and new Nix-managed symlinks
-          # Backups are kept for manual review and deletion
-          ${lib.concatMapStringsSep "\n" (path: ''
-            BACKUP="${path}.backup"
-            if [ -d "$BACKUP" ]; then
-              echo "" >&2
-              echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Marketplace update: ${path}" >&2
-
-              if [ -L "${path}" ]; then
-                NEW_TARGET=$(readlink "${path}")
-                echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Old: Real directory (runtime install)" >&2
-                echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   New: Symlink -> $NEW_TARGET (Nix-managed)" >&2
-
-                # Verify symlink target exists before diffing
-                if [ ! -e "$NEW_TARGET" ]; then
-                  echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN]   Symlink target does not exist: $NEW_TARGET" >&2
-                  echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN]   Cannot compare directories" >&2
-                elif [ ! -d "$NEW_TARGET" ]; then
-                  echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN]   Symlink target is not a directory: $NEW_TARGET" >&2
-                  echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN]   Cannot compare directories" >&2
-                else
-                  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Comparing directories (showing first 20 differences):"
-
-                  # Show directory structure comparison
-                  # diff exit codes: 0=identical, 1=different, 2+=error
-                  # Run diff directly (no pipeline) to capture its exit code reliably
-                  diff -r "$BACKUP" "${path}" > "$BACKUP.diff_tmp" 2>&1 && diff_exit=0 || diff_exit=$?
-                  diff_output=$(head -20 "$BACKUP.diff_tmp")
-                  rm -f "$BACKUP.diff_tmp"
-
-                  if [ $diff_exit -eq 0 ]; then
-                    echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Directories are identical"
-                  elif [ $diff_exit -eq 1 ]; then
-                    echo "$diff_output"
-                  else
-                    echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR]  diff command failed (exit code: $diff_exit). Output follows:" >&2
-                    echo "$diff_output" >&2
-                  fi
-                fi
-
-                echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Full comparison available at: $BACKUP" >&2
-                echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO]   Review and manually delete backup when satisfied." >&2
-              fi
-            fi
-          '') marketplacePaths}
-        '';
-      };
-    };
+    home.file = marketplaceSymlinks;
   };
 }

--- a/modules/home-manager/ai-cli/claude/registry.nix
+++ b/modules/home-manager/ai-cli/claude/registry.nix
@@ -35,11 +35,11 @@ in
     home.activation.cleanupMarketplacesSymlink = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
       MARKETPLACES="${homeDir}/.claude/plugins/known_marketplaces.json"
       if [ -L "$MARKETPLACES" ]; then
-        if ! $DRY_RUN_CMD rm "$MARKETPLACES"; then
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to remove Nix symlink at $MARKETPLACES" >&2
-          exit 1
+        if $DRY_RUN_CMD rm "$MARKETPLACES"; then
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed Nix-managed symlink for known_marketplaces.json (now Claude-managed)"
+        else
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to remove Nix symlink at $MARKETPLACES (non-critical)" >&2
         fi
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed Nix-managed symlink for known_marketplaces.json (now Claude-managed)"
       fi
     '';
   };

--- a/modules/home-manager/ai-cli/claude/settings.nix
+++ b/modules/home-manager/ai-cli/claude/settings.nix
@@ -201,38 +201,13 @@ in
     ];
 
     home.file = {
-      ".claude/settings.json".source = settingsJson;
+      ".claude/settings.json" = {
+        source = settingsJson;
+        force = true;
+      };
     }
     // statusLineScript
     // hookFiles;
 
-    # Cleanup activation script: Remove blocking regular files before symlink creation
-    # This handles the case where settings.json exists as a regular file (e.g., created by Claude Code)
-    # which would prevent home-manager from creating the Nix-managed symlink
-    #
-    # Note: Uses .backup suffix (same as home-manager's backup mechanism) for consistency.
-    # Timestamped backups would create accumulating files; single .backup is cleaner.
-    # Log format: YYYY-MM-DD HH:MM:SS [LOG_LEVEL] message
-    home.activation.cleanupClaudeSettings = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
-      SETTINGS="${homeDir}/.claude/settings.json"
-      if [ -e "$SETTINGS" ] && [ ! -L "$SETTINGS" ]; then
-        BACKUP="$SETTINGS.backup"
-        if ! $DRY_RUN_CMD mv "$SETTINGS" "$BACKUP"; then
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to back up existing settings.json from $SETTINGS to $BACKUP" >&2
-          exit 1
-        fi
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Backed up existing settings.json to $BACKUP" >&2
-      fi
-
-      # Also clean up broken statusline symlink
-      OLD_STATUSLINE="${homeDir}/.claude/statusline/Config.toml"
-      if [ -L "$OLD_STATUSLINE" ] && [ ! -e "$OLD_STATUSLINE" ]; then
-        if ! $DRY_RUN_CMD rm "$OLD_STATUSLINE"; then
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] Failed to remove broken statusline symlink at $OLD_STATUSLINE" >&2
-          exit 1
-        fi
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed broken statusline symlink" >&2
-      fi
-    '';
   };
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed**: Marketplace directories in `~/.claude/plugins/marketplaces/` were becoming root-owned when Claude Code cloned into them, causing `darwin-rebuild switch` to fail with "Permission denied" when activation scripts tried to `mv` them
- **Fix**: Add `recursive = true` to marketplace `home.file` entries — home-manager now creates the directory and symlinks individual files inside, so Claude Code's extra files (`.git/`, caches) coexist naturally and `force = true` works at the file level
- **Net result**: ~120 lines of custom cleanup scripts deleted; the root-ownership problem cannot recur

## Changes

| File | Change |
|------|--------|
| `plugins.nix` | Add `recursive = true`; remove `cleanupMarketplaceDirectories`, `reportMarketplaceDiffs`, `marketplacePaths` |
| `orphan-cleanup.nix` | Remove Phase 4 `cleanupOrphanMarketplaces` and related let bindings |
| `settings.nix` | Add `force = true` to `settings.json`; remove `cleanupClaudeSettings` activation script |
| `registry.nix` | Fix `exit 1` → `if/else` + `[WARN]` per activation rules |

## Test plan

- [ ] Run `sudo rm -rf ~/.claude/plugins/marketplaces/claude-plugins-official ~/.claude/plugins/marketplaces/axton-obsidian-visual-skills` (one-time cleanup of root-owned legacy dirs)
- [ ] Run `nix flake check` — all checks pass
- [ ] Run `sudo darwin-rebuild switch --flake .` — no permission errors, no `mv` failures
- [ ] Verify `ls -la ~/.claude/plugins/marketplaces/claude-plugins-official/` — user-owned directory with per-file Nix symlinks inside
- [ ] Verify `grep -r 'exit 1' modules/home-manager/ai-cli/claude/*.nix` — no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes root-owned marketplace directories by using recursive symlinks and removes unnecessary cleanup scripts.
> 
>   - **Behavior**:
>     - Fixes root-owned marketplace directories issue by using `recursive = true` in `plugins.nix` for marketplace `home.file` entries.
>     - Removes custom cleanup scripts, preventing root-ownership problems from recurring.
>   - **Files**:
>     - `plugins.nix`: Adds `recursive = true` to marketplace symlinks, removes `cleanupMarketplaceDirectories`, `reportMarketplaceDiffs`.
>     - `orphan-cleanup.nix`: Removes Phase 4 `cleanupOrphanMarketplaces` and related bindings.
>     - `settings.nix`: Adds `force = true` to `settings.json`, removes `cleanupClaudeSettings` activation script.
>     - `registry.nix`: Changes `exit 1` to `if/else` with `[WARN]` for activation rules.
>   - **Test Plan**:
>     - Verify no permission errors or `mv` failures during `darwin-rebuild switch`.
>     - Check user-owned directories with per-file Nix symlinks.
>     - Ensure no `exit 1` occurrences in Claude modules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 0795ed8d527f62d64a9fce88e3afc9d379cd0ce2. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->