### PR TITLE
fix(git): run pre-push hook on changed files only, not --all-files

### DIFF
--- a/modules/home-manager/git/hooks.nix
+++ b/modules/home-manager/git/hooks.nix
@@ -49,9 +49,15 @@ let
     # Using --from-ref/--to-ref prevents heavy hooks (e.g. terragrunt-plan)
     # from running when only unrelated files (e.g. YAML) are pushed.
     # Reads the ref pairs from stdin as per the git pre-push hook protocol.
+    z40=0000000000000000000000000000000000000000
     exit_code=0
-    while read local_ref local_sha remote_ref remote_sha; do
-      if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+      # Skip branch deletions (local_sha is all zeros — not a valid commit ref)
+      if [ "$local_sha" = "$z40" ]; then
+        continue
+      fi
+
+      if [ "$remote_sha" = "$z40" ]; then
         # New branch: compare against the empty tree
         from=$(git hash-object -t tree /dev/null)
       else


### PR DESCRIPTION
## Summary

- The pre-push hook was using `--all-files` which caused hooks with `stages: [pre-push]` (e.g. `terragrunt-plan` in terraform-proxmox) to run on ALL matching files in the repo, not just files being pushed
- Every push to terraform-proxmox triggered a full `terragrunt plan` even when pushing only unrelated files (e.g. GitHub Actions workflows)
- Switched to `--from-ref`/`--to-ref` to check only files changed in the push — the correct behavior for a pre-push hook

## Test plan
- [ ] Push workflow-only changes to terraform-proxmox — `terragrunt-plan` should not run
- [ ] Push actual `.tf` changes to terraform-proxmox — `terragrunt-plan` should run
- [ ] Push to other repos with pre-commit configs — hooks should still run on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify pre-push hook in `hooks.nix` to run on changed files only, optimizing performance and preventing unnecessary operations.
> 
>   - **Behavior**:
>     - Modify pre-push hook in `hooks.nix` to run on changed files only, using `--from-ref`/`--to-ref`.
>     - Prevents running heavy hooks like `terragrunt-plan` on unrelated file changes.
>   - **Implementation**:
>     - Reads ref pairs from stdin to determine changed files.
>     - Handles new branches by comparing against the empty tree.
>   - **Testing**:
>     - Push workflow-only changes to verify `terragrunt-plan` does not run.
>     - Push `.tf` changes to verify `terragrunt-plan` runs.
>     - Ensure hooks run on changed files in other repos.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for d2b1734a2caa13bf7d372a1e31adb57e41e69696. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->