### PR TITLE
fix(git): use merge-base with origin/main for new-branch pre-push

### DIFF
--- a/modules/home-manager/git/hooks.nix
+++ b/modules/home-manager/git/hooks.nix
@@ -58,11 +58,18 @@ let
       fi
 
       if [ "$remote_sha" = "$z40" ]; then
-        # New branch: compare against merge-base with origin/main so we check
-        # only files changed in this branch, not the entire repo history.
-        # Falls back to empty tree if origin/main does not exist.
-        from=$(git merge-base "$local_sha" origin/main 2>/dev/null \
-               || git hash-object -t tree /dev/null)
+        # New branch: compare against merge-base with the remote's default branch
+        # so we check only files changed in this branch, not the entire repo history.
+        # Detect the actual default branch, then fall back to common names.
+        default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+        if [ -n "$default_branch" ]; then
+          from=$(git merge-base "$local_sha" "origin/$default_branch" 2>/dev/null \
+                 || git hash-object -t tree /dev/null)
+        else
+          from=$(git merge-base "$local_sha" origin/main 2>/dev/null \
+                 || git merge-base "$local_sha" origin/master 2>/dev/null \
+                 || git hash-object -t tree /dev/null)
+        fi
       else
         from="$remote_sha"
       fi


### PR DESCRIPTION
## Summary

Follow-up to #690. When pushing a **new branch** for the first time, the previous fix compared against the empty tree (all files in the repo), which still triggered heavy hooks like `terragrunt-plan` even when pushing only unrelated changes.

Use `git merge-base` with `origin/main` instead — this finds the point where the branch diverged from main and checks only the files changed in the branch.

## Behavior

| Push type | Before | After #690 | After this PR |
|-----------|--------|------------|---------------|
| Update existing branch | All files | Changed commits only ✓ | Changed commits only ✓ |
| New branch (first push) | All files | All files from empty tree ✗ | Branch-only files ✓ |
| Branch deletion | Fail (null SHA error) | Skip ✓ | Skip ✓ |

## Test plan
- [ ] Push new `chore/` branch to terraform-proxmox with only `.github/workflows/` changes — `terragrunt-plan` should not run
- [ ] Push new branch with `.tf` changes — `terragrunt-plan` should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pre-push hook now uses `git merge-base` with `origin/main` for new branches to check only branch-specific changes.
> 
>   - **Behavior**:
>     - In `hooks.nix`, pre-push hook for new branches now uses `git merge-base` with `origin/main` to determine changes, instead of comparing against the empty tree.
>     - Falls back to empty tree if `origin/main` does not exist.
>     - Prevents running heavy hooks on unrelated changes.
>   - **Test Plan**:
>     - Push new branch with only `.github/workflows/` changes to verify `terragrunt-plan` does not run.
>     - Push new branch with `.tf` changes to verify `terragrunt-plan` runs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for b7e974570ebf6cdffdfc060541f5e3cb3d246b49. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->