### PR TITLE
feat(dock): add Microsoft Outlook to persistent Dock bar

### DIFF
--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -31,6 +31,7 @@ in
       "/System/Applications/Reminders.app"
       "/System/Applications/Calendar.app"
       "/Applications/Toggl Track.app"
+      "/Applications/Microsoft Outlook.app"
 
       # Communication
       "/Applications/Shortwave.app" # AI-powered email client (homebrew cask)


### PR DESCRIPTION
## Summary

- Adds Microsoft Outlook to the persistent Dock bar
- Positioned after Toggl Track and before Shortwave in the Time & Tasks / Communication area

## Test plan

- [ ] Run `sudo darwin-rebuild switch --flake .` and verify Outlook appears in the Dock between Toggl Track and Shortwave

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Microsoft Outlook to the persistent Dock bar in `persistent-apps.nix`, positioned between Toggl Track and Shortwave.
> 
>   - **Behavior**:
>     - Adds Microsoft Outlook to the persistent Dock bar in `persistent-apps.nix`.
>     - Positioned between Toggl Track and Shortwave in the Time & Tasks / Communication section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for f29f154bcdbc7e4d795b8403e760a107976a1cd3. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->