### PR TITLE
chore(deps): update all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771631286,
-        "narHash": "sha256-jVmz7CIXpnUz5QwVHQAvfVqBgStUypn3pvUr9OGerMo=",
+        "lastModified": 1771877222,
+        "narHash": "sha256-mckBLMBUEoxMZ7t1XZ4q1JGLt9MBxKg6NUNVMyMmEHo=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "3ad3231f0f3a9ff4e1be18d20cbea1e9955d0047",
+        "rev": "76826f2c8025ea271a52e5bbf6a906ffa2f44c95",
         "type": "github"
       },
       "original": {

--- a/shells/image-building/flake.lock
+++ b/shells/image-building/flake.lock
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771631286,
-        "narHash": "sha256-jVmz7CIXpnUz5QwVHQAvfVqBgStUypn3pvUr9OGerMo=",
+        "lastModified": 1771877222,
+        "narHash": "sha256-mckBLMBUEoxMZ7t1XZ4q1JGLt9MBxKg6NUNVMyMmEHo=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "3ad3231f0f3a9ff4e1be18d20cbea1e9955d0047",
+        "rev": "76826f2c8025ea271a52e5bbf6a906ffa2f44c95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updated claude-code plugin to latest version across:
- Root flake
- Shell environment (image-building)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
(claude)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `claude-code-plugins` to latest version in `flake.lock` and `shells/image-building/flake.lock`.
> 
>   - **Dependencies**:
>     - Update `claude-code-plugins` in `flake.lock` and `shells/image-building/flake.lock` to latest version.
>     - Changes `rev` to `76826f2c8025ea271a52e5bbf6a906ffa2f44c95`, `lastModified` to `1771877222`, and `narHash` to `sha256-mckBLMBUEoxMZ7t1XZ4q1JGLt9MBxKg6NUNVMyMmEHo=`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for bc01234156de692328d2c4d7db0f7924a81af0ff. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->