### PR TITLE
feat(claude): pin statusline semver, set effort medium, disable 1M context models

### DIFF
--- a/.claude/rules/ai-cli-module.md
+++ b/.claude/rules/ai-cli-module.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "modules/home-manager/ai-cli/**/*"
+---
+
+# Claude Code AI CLI Module Conventions
+
+## Settings Configuration
+
+- **Always prefer `settings.json` keys** over environment variables for Claude Code configuration
+- Before adding an env var, check if a native JSON key exists at <https://code.claude.com/docs/en/settings>
+- If a native key is added upstream for an existing env var, migrate to the native key
+- Environment variables are appropriate only when no native JSON key exists (e.g., MCP timeouts, experimental flags)
+
+## Module Structure
+
+- `claude/options.nix` — All option declarations
+- `claude/settings.nix` — Generates `~/.claude/settings.json` from options
+- `claude/statusline/` — Statusline configuration (powerline theme)
+- `claude/plugins.nix` — Plugin symlink management
+- `claude/registry.nix` — Marketplace registry management
+- `claude-config.nix` — Configuration values (where options are SET)
+
+## Key Patterns
+
+- New Claude Code settings: add option in `options.nix`, wire in `settings.nix`, set value in `claude-config.nix`
+- Single source of truth: `lib/claude-registry.nix` for marketplace format
+- Statusline uses `bunx` with semver pinning (`@^1`) — no build-time hash maintenance
+- Never manually edit `~/.claude/settings.json` — it's a Nix store symlink

--- a/modules/home-manager/ai-cli/claude-config.nix
+++ b/modules/home-manager/ai-cli/claude-config.nix
@@ -76,7 +76,7 @@ in
   # Show turn duration in UI for performance visibility
   showTurnDuration = true;
 
-  # effortLevel = "medium";  # Uncomment to override (default: high)
+  effortLevel = "medium";
 
   # Auto-Claude: DISABLED - migrating to ai-workflows repo
   # Module files preserved (guarded by mkIf), will be extracted later
@@ -145,6 +145,10 @@ in
       # Experimental: Agent teams - coordinate multiple Claude Code instances
       # See: https://code.claude.com/docs/en/agent-teams
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+
+      # Disable 1M token context window models from model picker
+      # No native settings.json key exists; env var removes only 1M variants
+      CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
 
       # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning
       # MAX_THINKING_TOKENS = "31999";

--- a/modules/home-manager/ai-cli/claude/statusline/powerline.nix
+++ b/modules/home-manager/ai-cli/claude/statusline/powerline.nix
@@ -25,9 +25,8 @@ in
       enable = true;
       script = ''
         #!/usr/bin/env bash
-        # Claude Powerline statusline
-        # Uses bunx for runtime execution (no build-time hash maintenance)
-        exec ${pkgs.bun}/bin/bunx @owloops/claude-powerline --config=${configFile} "$@"
+        # Claude Powerline statusline (semver-pinned for stability)
+        exec ${pkgs.bun}/bin/bunx @owloops/claude-powerline@'^1' --config=${configFile} "$@"
       '';
     };
   };


### PR DESCRIPTION
## Summary

- **Statusline fix**: Pin `bunx` invocation to `@owloops/claude-powerline@'^1'` — prevents \"Unexpected end of JSON input\" crash caused by unpinned version fetching incompatible release; blocks breaking `2.x` changes while auto-updating for minor/patch
- **Effort level**: Set `effortLevel = "medium"` (was a commented-out hint; upstream default is `"high"`)
- **1M context models**: Add `CLAUDE_CODE_DISABLE_1M_CONTEXT = "1"` env var — removes 1M token context window variants from model picker with zero maintenance (no explicit model list to keep updated)
- **Module rule**: Create `.claude/rules/ai-cli-module.md` with path-scoped conventions for `modules/home-manager/ai-cli/**/*` documenting settings.json-first policy and module structure

## Test plan

- [x] `nix flake check` — passed, no errors or warnings
- [x] `sudo darwin-rebuild switch --flake .` — succeeded, new generation activated
- [x] `jq '{effortLevel, env}' ~/.claude/settings.json` — confirms `effortLevel: "medium"` and `CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"`
- [ ] Clear bun cache (`rm -rf ~/.bun/install/cache/@owloops`) and open new Claude Code session — verify statusline renders and 1M models absent from picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin `bunx` version for statusline, set effort level to medium, and disable 1M context models in Claude Code configuration.
> 
>   - **Statusline**:
>     - Pin `bunx` invocation to `@owloops/claude-powerline@'^1'` in `powerline.nix` to prevent crashes from incompatible releases.
>   - **Configuration**:
>     - Set `effortLevel = "medium"` in `claude-config.nix`.
>     - Add `CLAUDE_CODE_DISABLE_1M_CONTEXT = "1"` to disable 1M token context models in `claude-config.nix`.
>   - **Documentation**:
>     - Create `.claude/rules/ai-cli-module.md` to document path-scoped conventions for `modules/home-manager/ai-cli/**/*`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 3f120d93fda63036efce71283fe81883009e977d. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->