### PR TITLE
chore(deps): update all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1771884374,
-        "narHash": "sha256-nf1yUvarUzhCmYPztMpxtz6IdA7IJdtgOdjg6pM6CdQ=",
+        "lastModified": 1772016290,
+        "narHash": "sha256-5KLtn3dTd8OfPB6xScGPwnDc1Bb21lh3G0d8irdOzX4=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "bca3fd37e9876c4a9d0a78420257249db5ca0668",
+        "rev": "591ae2f6de7a6e6c7037edf1c79a30b54693d02d",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "anthropic-agent-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1770412772,
-        "narHash": "sha256-9FGubcwHcGBJcKl02aJ+YsTMiwDOdgU/FHALjARG51c=",
+        "lastModified": 1771993718,
+        "narHash": "sha256-mZZ0rlj/kju7we1h+MvUjgFAVjcZ/qKkMbNZfhfCSvk=",
         "owner": "anthropics",
         "repo": "skills",
-        "rev": "1ed29a03dc852d30fa6ef2ca53a67dc2c2c2c563",
+        "rev": "3d59511518591fa82e6cfcf0438d68dd5dad3e76",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771915148,
-        "narHash": "sha256-E8CIJd+ucMLIUNmQ1TriadGzudfjCTrOitg0eWCJKsA=",
+        "lastModified": 1772000823,
+        "narHash": "sha256-IdnfV88YjgsUqzHsNlZcwtc/Td9yKQYohYsL5ANuJTc=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "8f0fe03e5687b10134d400c10240071523ace5c5",
+        "rev": "db3858a5589c8e6ffeb4cf765edc23cd4dbf900a",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1771605554,
-        "narHash": "sha256-jnDTccQoooxw/FAwh0CoBopqUc1JayVxP9jJ895HmzA=",
+        "lastModified": 1771977324,
+        "narHash": "sha256-K+BbkpbnTAGCzHfYxpsOEMinmg2hs7YurDGtZMqv4io=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "419ce35fa8457347ff8bf61bffed791f8617b8c1",
+        "rev": "112611bacad67a1e1947f35e1672d5f9f6a3ee93",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1771914705,
-        "narHash": "sha256-C12715TGUleFD6AU86thxGFTxBj0X1QvaRdRt/RGc1o=",
+        "lastModified": 1771993700,
+        "narHash": "sha256-pcMIh9sgdMDs0dlc0POomxnPOLoP5/EOdCGMKoESmoc=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "99e11d95926936deb21c3fa29a098511573100d1",
+        "rev": "55b58ec6e5649104f926ba7558b567dc8d33c5ff",
         "type": "github"
       },
       "original": {
@@ -290,11 +290,11 @@
     "lunar-claude": {
       "flake": false,
       "locked": {
-        "lastModified": 1771815750,
-        "narHash": "sha256-18XTJGRa4bXn60kaLPVKwyP/3dRH3TBXVyvpimX+E44=",
+        "lastModified": 1771937456,
+        "narHash": "sha256-H487qwWEUrhgJf21IrvXblxnLjVGv5h4MhCDdmg14Ys=",
         "owner": "basher83",
         "repo": "lunar-claude",
-        "rev": "92a0afc0220634ca415d07b7b8123a5853aceb51",
+        "rev": "b9ae7b82c9c5cca0c4db1be50c3f328dcd183dc6",
         "type": "github"
       },
       "original": {

--- a/shells/ansible/flake.lock
+++ b/shells/ansible/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/containers/flake.lock
+++ b/shells/containers/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/go/flake.lock
+++ b/shells/go/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/image-building/flake.lock
+++ b/shells/image-building/flake.lock
@@ -3,11 +3,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1771884374,
-        "narHash": "sha256-nf1yUvarUzhCmYPztMpxtz6IdA7IJdtgOdjg6pM6CdQ=",
+        "lastModified": 1772016290,
+        "narHash": "sha256-5KLtn3dTd8OfPB6xScGPwnDc1Bb21lh3G0d8irdOzX4=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "bca3fd37e9876c4a9d0a78420257249db5ca0668",
+        "rev": "591ae2f6de7a6e6c7037edf1c79a30b54693d02d",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "anthropic-agent-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1770412772,
-        "narHash": "sha256-9FGubcwHcGBJcKl02aJ+YsTMiwDOdgU/FHALjARG51c=",
+        "lastModified": 1771993718,
+        "narHash": "sha256-mZZ0rlj/kju7we1h+MvUjgFAVjcZ/qKkMbNZfhfCSvk=",
         "owner": "anthropics",
         "repo": "skills",
-        "rev": "1ed29a03dc852d30fa6ef2ca53a67dc2c2c2c563",
+        "rev": "3d59511518591fa82e6cfcf0438d68dd5dad3e76",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1771915148,
-        "narHash": "sha256-E8CIJd+ucMLIUNmQ1TriadGzudfjCTrOitg0eWCJKsA=",
+        "lastModified": 1772000823,
+        "narHash": "sha256-IdnfV88YjgsUqzHsNlZcwtc/Td9yKQYohYsL5ANuJTc=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "8f0fe03e5687b10134d400c10240071523ace5c5",
+        "rev": "db3858a5589c8e6ffeb4cf765edc23cd4dbf900a",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1771605554,
-        "narHash": "sha256-jnDTccQoooxw/FAwh0CoBopqUc1JayVxP9jJ895HmzA=",
+        "lastModified": 1771977324,
+        "narHash": "sha256-K+BbkpbnTAGCzHfYxpsOEMinmg2hs7YurDGtZMqv4io=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "419ce35fa8457347ff8bf61bffed791f8617b8c1",
+        "rev": "112611bacad67a1e1947f35e1672d5f9f6a3ee93",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1771914705,
-        "narHash": "sha256-C12715TGUleFD6AU86thxGFTxBj0X1QvaRdRt/RGc1o=",
+        "lastModified": 1771993700,
+        "narHash": "sha256-pcMIh9sgdMDs0dlc0POomxnPOLoP5/EOdCGMKoESmoc=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "99e11d95926936deb21c3fa29a098511573100d1",
+        "rev": "55b58ec6e5649104f926ba7558b567dc8d33c5ff",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
     "lunar-claude": {
       "flake": false,
       "locked": {
-        "lastModified": 1771815750,
-        "narHash": "sha256-18XTJGRa4bXn60kaLPVKwyP/3dRH3TBXVyvpimX+E44=",
+        "lastModified": 1771937456,
+        "narHash": "sha256-H487qwWEUrhgJf21IrvXblxnLjVGv5h4MhCDdmg14Ys=",
         "owner": "basher83",
         "repo": "lunar-claude",
-        "rev": "92a0afc0220634ca415d07b7b8123a5853aceb51",
+        "rev": "b9ae7b82c9c5cca0c4db1be50c3f328dcd183dc6",
         "type": "github"
       },
       "original": {
@@ -389,11 +389,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -405,11 +405,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/infrastructure-automation/flake.lock
+++ b/shells/infrastructure-automation/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/js/flake.lock
+++ b/shells/js/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/kubernetes/flake.lock
+++ b/shells/kubernetes/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/powershell/flake.lock
+++ b/shells/powershell/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/python-data/flake.lock
+++ b/shells/python-data/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/python/flake.lock
+++ b/shells/python/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/python310/flake.lock
+++ b/shells/python310/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/python312/flake.lock
+++ b/shells/python312/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/python314/flake.lock
+++ b/shells/python314/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/splunk-dev/flake.lock
+++ b/shells/splunk-dev/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {

--- a/shells/terraform/flake.lock
+++ b/shells/terraform/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771482645,
-        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updated nixpkgs and other inputs across:
- Root flake
- Shell environments

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `flake.lock` files to latest `nixpkgs` and other dependencies across root and shell environments.
> 
>   - **Updates**:
>     - Update `nixpkgs` input to revision `ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2` in `shells/ansible/flake.lock`, `shells/containers/flake.lock`, and `shells/go/flake.lock`.
>     - Update `ai-assistant-instructions` to revision `591ae2f6de7a6e6c7037edf1c79a30b54693d02d` in `flake.lock` and `shells/image-building/flake.lock`.
>     - Update `claude-code-plugins` to revision `db3858a5589c8e6ffeb4cf765edc23cd4dbf900a` in `flake.lock` and `shells/image-building/flake.lock`.
>   - **Consistency**:
>     - Ensures all environments use the same `nixpkgs` revision for consistency.
>   - **Misc**:
>     - Co-authored by Claude Sonnet 4.5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for a676be6cdc5a8cbf7f2d19068fc6a5996ad5e269. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->