### PR TITLE
fix(terraform-shell): remove broken checkov and terrascan packages

### DIFF
--- a/shells/terraform/flake.nix
+++ b/shells/terraform/flake.nix
@@ -49,8 +49,10 @@
               tflint
 
               # === Security & Compliance ===
-              checkov
-              terrascan
+              # checkov and terrascan removed: checkov is broken in nixpkgs-unstable
+              # (pycep-parser fails to build with uv_build backend). Both hooks are
+              # also disabled in terraform-proxmox .pre-commit-config.yaml. Re-add
+              # when the upstream nixpkgs pycep-parser derivation is fixed.
               tfsec
               trivy
 
@@ -80,7 +82,6 @@
                 echo "  - opentofu: $(tofu version 2>/dev/null | head -1)"
                 echo ""
                 echo "Security & Compliance:"
-                echo "  - checkov: $(checkov --version 2>/dev/null)"
                 echo "  - tfsec: $(tfsec --version 2>/dev/null)"
                 echo ""
                 echo "Secrets Management:"


### PR DESCRIPTION
## Summary

- Removes `checkov` and `terrascan` from `shells/terraform/flake.nix` buildInputs
- `checkov` is broken in current nixpkgs-unstable: `pycep-parser-0.7.0` fails to build because its `uv_build` backend is unavailable
- Both tools are already disabled in `terraform-proxmox`'s `.pre-commit-config.yaml`, so this is a no-op for actual pre-commit behavior
- The broken package was blocking the entire terraform nix shell from building, which in turn broke the `tofu-test` and `terragrunt-validate` pre-commit hooks

## Test plan

- [ ] `nix develop ~/git/nix-config/fix/remove-broken-checkov/shells/terraform` builds successfully
- [ ] `tofu-test` and `terragrunt-validate` pre-commit hooks work in `terraform-proxmox`
- [ ] Re-add `checkov`/`terrascan` once `pycep-parser` is fixed upstream in nixpkgs-unstable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes broken `checkov` and `terrascan` from `shells/terraform/flake.nix` to fix terraform nix shell build.
> 
>   - **Behavior**:
>     - Removes `checkov` and `terrascan` from `buildInputs` in `shells/terraform/flake.nix` due to `checkov` being broken in `nixpkgs-unstable`.
>     - Unblocks terraform nix shell build, fixing `tofu-test` and `terragrunt-validate` pre-commit hooks.
>   - **Comments**:
>     - Adds comments in `flake.nix` explaining removal and future re-addition once `pycep-parser` is fixed upstream.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 0077caa3c3e536952e4bbef680fbfb4c8a862093. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->