### PR TITLE
Disable greptile plugin

### DIFF
--- a/modules/home-manager/ai-cli/claude/plugins/external.nix
+++ b/modules/home-manager/ai-cli/claude/plugins/external.nix
@@ -41,7 +41,7 @@ _:
 
     # Greptile - AI-powered codebase search
     # Requires: Greptile API key
-    "greptile@claude-plugins-official" = true;
+    "greptile@claude-plugins-official" = false;
 
     # =========================================================================
     # Documentation & Context


### PR DESCRIPTION
## Summary

Greptile plugin has been disabled since no API key is available.

## Changes

- Set `greptile@claude-plugins-official = false` in external plugin configuration

## Verification

- Pre-commit hooks passed
- No other functionality affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable `greptile@claude-plugins-official` in `external.nix` due to missing API key.
> 
>   - **Configuration**:
>     - Disable `greptile@claude-plugins-official` in `external.nix` by setting it to `false` due to missing API key.
>   - **Verification**:
>     - Pre-commit hooks passed.
>     - No other functionality affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 723f9e19683930ce1e62e9ee9e1b95066ec45692. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->