### PR TITLE
feat(copilot): Copilot coding agent + CI fail issue workflow

### DIFF
--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -1,0 +1,20 @@
+name: CI Fail Issue
+
+on:
+  workflow_run:
+    workflows: ["CI Gate"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  handle-failure:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.0
+    with:
+      workflow_name: "CI Gate"
+    secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,13 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_call:
+
+jobs:
+  copilot-setup-steps:
+    name: Copilot Setup Steps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/flake-checker-action@v9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -21,6 +21,7 @@ rules:
       - best-practices.yml
       - ci-auto-claude.yml
       - ci-eol-check.yml
+      - ci-fail-issue.yml
       - ci-file-length.yml
       - ci-fix.yml
       - ci-gate.yml
@@ -31,6 +32,7 @@ rules:
       - ci-validate.yml
       - claude-review.yml
       - code-simplifier.yml
+      - copilot-setup-steps.yml
       - deps-monitor-packages.yml
       - deps-update-flake.yml
       - final-pr-review.yml
@@ -45,12 +47,14 @@ rules:
       - review-deps.yml
 
   # ACCEPTED: workflow_run is the only trigger for reacting to CI completions.
-  # ci-fix.yml is safe because:
-  # - It only reads logs via the GitHub API (not fork PR code).
-  # - It does not execute untrusted fork code.
-  # - The should-fix job validates the PR exists and belongs to this repo.
+  # ci-fix.yml and ci-fail-issue.yml are safe because:
+  # - They only read logs via the GitHub API (not fork PR code).
+  # - They do not execute untrusted fork code.
+  # - ci-fix.yml: the should-fix job validates the PR exists and belongs to this repo.
+  # - ci-fail-issue.yml: only triggers on main branch CI Gate failures.
   dangerous-triggers:
     ignore:
+      - ci-fail-issue.yml
       - ci-fix.yml
 
   # ACCEPTED: secrets: inherit is required for reusable workflow callers.
@@ -60,6 +64,7 @@ rules:
   secrets-inherit:
     ignore:
       - best-practices.yml
+      - ci-fail-issue.yml
       - ci-fix.yml
       - claude-review.yml
       - code-simplifier.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,50 @@
-# Nix Configuration - AI Agent Instructions
+# GitHub Copilot Instructions — nix-config
+
+## Repository Purpose
+
+macOS/Linux system configuration managed with Nix flakes (Determinate Nix).
+Covers home-manager, Darwin, NixOS, and shared modules.
 
 ## Critical Constraints
 
 1. **Flakes-only**: Never use `nix-env`, `nix-channels`, or imperative commands
-2. **Determinate Nix**: Keep `nix.enable = false` in darwin config
-3. **Nixpkgs first**: Use homebrew only when nixpkgs unavailable
+2. **Determinate Nix**: Keep `nix.enable = false` in darwin config; use `nix` (Determinate), not `nix-env` or `nix-channel`
+3. **Nixpkgs first**: Use homebrew only when nixpkgs unavailable; prefer `pkgs.*` over overlays or custom derivations
 4. **Worktrees required**: Run `/init-worktree` before any work
-5. **No direct main commits**: Always use feature branches
+5. **No direct main commits**: Always use feature branches via PRs
 
-## Build Validation
+## Build & Validate
 
 Build validation is enforced by **GitHub Actions CI** (`ci-gate.yml`) on every PR — not by a local pre-push hook.
 
 Local quick checks (formatting, linting, dead code) run automatically on every commit via pre-commit hooks:
 
 ```bash
-nix fmt         # fix formatting
-statix check    # lint
-deadnix         # dead code
+nix flake check         # full flake check (run in CI)
+nix fmt                 # format all Nix files (alejandra)
+statix check            # static analysis
+deadnix                 # dead code detection
 ```
 
 A full `nix flake check && sudo darwin-rebuild switch --flake .` is run by CI on macOS runners and must
 pass before merge. You may run it locally to verify before pushing, but it is not required locally.
+
+## File Conventions
+
+- `.nix` files: Nix expression language only
+- Modules follow `{ config, pkgs, lib, ... }:` function pattern
+- Use `lib.mkOption` for configurable options
+- Attribute sets use `{}` not record syntax
+
+## Common Patterns
+
+```nix
+# Module definition
+{ config, pkgs, lib, ... }: {
+  options.my.option = lib.mkEnableOption "description";
+  config = lib.mkIf config.my.option { ... };
+}
+```
 
 ## Worktree Workflow
 
@@ -45,3 +68,7 @@ cd <branch>
 - Never auto-merge without explicit user approval
 - 50-comment limit per PR
 - Batch commits locally, push once
+
+## Secrets
+
+Secrets managed via Bitwarden Secrets Manager — never hardcode credentials or tokens.


### PR DESCRIPTION
## Summary

- Update `AGENTS.md` (symlinked as `.github/copilot-instructions.md`) with expanded Nix conventions, File Conventions, Common Patterns, and Secrets sections
- Add `copilot-setup-steps.yml` — environment setup for Copilot (Determinate Nix installer + flake checker)
- Add `ci-fail-issue.yml` — calls [`ai-workflows@v0.6.0`](https://github.com/JacobPEvans/ai-workflows) reusable workflow to create a GitHub issue assigned to Copilot when CI Gate fails on main
- Update `.github/zizmor.yml` to suppress false-positive warnings for the new workflows

## Behavior

When CI Gate fails on a commit to main:
1. 5 safety gates are checked (dedup, bot-author loop prevention, 3/24h daily limit)
2. If all gates pass, an issue is created with the failure logs and assigned to Copilot
3. Copilot opens a fix PR on a `copilot/*` branch

> **Note**: Requires ai-workflows v0.6.0 to be released (PR [#60](https://github.com/JacobPEvans/ai-workflows/pull/60))

## Test plan

- [ ] After ai-workflows v0.6.0 is released and this merges: trigger CI failure on main → verify issue created and assigned to Copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces Copilot coding agent and CI fail issue workflow, updating documentation and security configurations.
> 
>   - **Behavior**:
>     - Adds `ci-fail-issue.yml` workflow to create GitHub issue assigned to Copilot when CI Gate fails on main.
>     - Adds `copilot-setup-steps.yml` for environment setup using Determinate Nix installer and flake checker.
>     - Updates `.github/zizmor.yml` to suppress false-positive warnings for new workflows.
>   - **Documentation**:
>     - Updates `AGENTS.md` with expanded Nix conventions, file conventions, common patterns, and secrets management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix&utm_source=github&utm_medium=referral)<sup> for 4aa5c060aee1f027cf2543246a5ec2ecf089b5c6. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->