### PR TITLE
chore: update nix-ai to pick up plugin error fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,22 @@
         "type": "github"
       }
     },
+    "axton-obsidian-visual-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770862721,
+        "narHash": "sha256-28hLlKPifZ0GT3vc3eYuIN0C2DQm6vtZhJIKEomRp0M=",
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "rev": "1265976d9746a84858b4b7b42fb86a215aa93de9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "type": "github"
+      }
+    },
     "bills-claude-skills": {
       "flake": false,
       "locked": {
@@ -274,11 +290,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1772173804,
-        "narHash": "sha256-OxzYT/MfDQMwx1zvbyPoPcnMJetg55A+t3uhZ47cJ0w=",
+        "lastModified": 1772212799,
+        "narHash": "sha256-0gxUADZJdS8pMea3KS1IzO8ncuGY8qs9dlm8CC8b67U=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "d5a25c4e436337be9abf2160d4b598213d68042b",
+        "rev": "81ab6af92f9074fb44f33111d3228a076d753d8f",
         "type": "github"
       },
       "original": {
@@ -334,6 +350,7 @@
       "inputs": {
         "ai-assistant-instructions": "ai-assistant-instructions",
         "anthropic-agent-skills": "anthropic-agent-skills",
+        "axton-obsidian-visual-skills": "axton-obsidian-visual-skills",
         "bills-claude-skills": "bills-claude-skills",
         "cc-dev-tools": "cc-dev-tools",
         "cc-marketplace": "cc-marketplace",
@@ -352,16 +369,15 @@
           "nixpkgs"
         ],
         "obsidian-skills": "obsidian-skills",
-        "obsidian-visual-skills": "obsidian-visual-skills",
         "superpowers-marketplace": "superpowers-marketplace",
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1772184174,
-        "narHash": "sha256-LvkDqomnlc/P3Oax/r50EpqSAgJhM9pZrXjlhPjWrnY=",
+        "lastModified": 1772213505,
+        "narHash": "sha256-o5UYGUg82ia3Ii/QpQIXBnM0f3Hgy+x1Z1dpg0eGDTg=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "5a2273efb075c03db1b9ec711e5d572c93139994",
+        "rev": "4bb02a2a798aec92914cdf9ab377bedb4e4c14bd",
         "type": "github"
       },
       "original": {
@@ -438,22 +454,6 @@
       "original": {
         "owner": "kepano",
         "repo": "obsidian-skills",
-        "type": "github"
-      }
-    },
-    "obsidian-visual-skills": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1770862721,
-        "narHash": "sha256-28hLlKPifZ0GT3vc3eYuIN0C2DQm6vtZhJIKEomRp0M=",
-        "owner": "axtonliu",
-        "repo": "axton-obsidian-visual-skills",
-        "rev": "1265976d9746a84858b4b7b42fb86a215aa93de9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "axtonliu",
-        "repo": "axton-obsidian-visual-skills",
         "type": "github"
       }
     },


### PR DESCRIPTION
## Summary

Updates `nix-ai` flake input to include the plugin error fixes from nix-ai PR #2 and claude-code-plugins PR #59.

**Changes pulled in via lock file update:**
- `obsidian-visual-skills` renamed to `axton-obsidian-visual-skills` (correct marketplace name)
- Obsidian plugin references fixed to use actual plugin names (`obsidian@obsidian-skills`, `obsidian-visual-skills@axton-obsidian-visual-skills`)
- `scripts` and `tests` dirs excluded from jacobpevans-cc-plugins auto-discovery
- `example-plugin@claude-plugins-official` removed (non-existent plugin caused error even when disabled)
- codeql-resolver skill files restructured as proper SKILL.md directories

## Test plan

- [ ] Claude Code restarts with 0 plugin errors (was 13)
- [ ] `settings.json` no longer contains `scripts@`, `tests@`, or `example-plugin@` entries
- [ ] Obsidian skills load: `/obsidian-markdown`, `/obsidian-bases`, etc.
- [ ] Visual skills load: `/excalidraw-diagram`, `/mermaid-visualizer`, etc.
- [ ] codeql-resolver skills load without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `nix-ai` flake input to fix plugin errors by renaming, correcting references, excluding directories, removing non-existent plugins, and restructuring skill files.
> 
>   - **Behavior**:
>     - Updates `nix-ai` flake input to include plugin error fixes from nix-ai PR #2 and claude-code-plugins PR #59.
>     - Renames `obsidian-visual-skills` to `axton-obsidian-visual-skills`.
>     - Fixes Obsidian plugin references to use correct names (`obsidian@obsidian-skills`, `obsidian-visual-skills@axton-obsidian-visual-skills`).
>     - Excludes `scripts` and `tests` directories from `jacobpevans-cc-plugins` auto-discovery.
>     - Removes `example-plugin@claude-plugins-official` due to non-existence.
>     - Restructures `codeql-resolver` skill files as `SKILL.md` directories.
>   - **Test Plan**:
>     - Ensure Claude Code restarts with 0 plugin errors (previously 13).
>     - Verify `settings.json` excludes `scripts@`, `tests@`, and `example-plugin@` entries.
>     - Confirm Obsidian skills load correctly: `/obsidian-markdown`, `/obsidian-bases`, etc.
>     - Confirm visual skills load correctly: `/excalidraw-diagram`, `/mermaid-visualizer`, etc.
>     - Ensure `codeql-resolver` skills load without path errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-darwin&utm_source=github&utm_medium=referral)<sup> for b5bd8c674cde6a4d2834f3f5223e5073e2f2d9d7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->