### PR TITLE
chore(deps): update nix-ai flake input to re-enable greptile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1772213505,
-        "narHash": "sha256-o5UYGUg82ia3Ii/QpQIXBnM0f3Hgy+x1Z1dpg0eGDTg=",
+        "lastModified": 1772303721,
+        "narHash": "sha256-naREIF0C9d4GAFpFcEBgIaPBRnmoXtQjRl3UXW6AMt4=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "4bb02a2a798aec92914cdf9ab377bedb4e4c14bd",
+        "rev": "8cb80c9895d582ff32cd3d026ef0e486bcca17ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates nix-ai flake input to pick up the greptile re-enable commit
- `greptile@claude-plugins-official` is now `true` in nix-ai

## Related
- nix-ai PR: JacobPEvans/nix-ai#81 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `nix-ai` flake input to re-enable `greptile` by setting `greptile@claude-plugins-official` to `true`.
> 
>   - **Flake Input Update**:
>     - Updates `nix-ai` flake input in `flake.lock` to commit `8cb80c9895d582ff32cd3d026ef0e486bcca17ad`.
>     - Changes `lastModified` to `1772303721` and `narHash` to `sha256-naREIF0C9d4GAFpFcEBgIaPBRnmoXtQjRl3UXW6AMt4=`.
>   - **Behavior**:
>     - Re-enables `greptile` by setting `greptile@claude-plugins-official` to `true` in `nix-ai`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-darwin&utm_source=github&utm_medium=referral)<sup> for da8ab2f12db8033140fdb8e91c5b0dc50767f5d2. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->