### PR TITLE
fix(ci): add nix-home to AI_INPUTS allowlist for dispatch events

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -52,6 +52,7 @@ jobs:
         anthropic-agent-skills
         superpowers-marketplace
         nix-ai
+        nix-home
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
## Summary

- Adds `nix-home` to the `AI_INPUTS` env var in `deps-update-flake.yml`
- nix-home's `trigger-nix-update.yml` dispatches `upstream-repo-updated` events to nix-darwin on merge to main, but the dispatch was silently rejected because `nix-home` was not in the allowlist
- This enables instant `flake.lock` updates when nix-home changes, rather than waiting for Tue/Fri full update runs

## Test plan

- [ ] Merge something to nix-home main
- [ ] Verify `upstream-repo-updated` dispatch triggers `deps-update-flake.yml` on nix-darwin
- [ ] Confirm a PR is created updating only the `nix-home` input in `flake.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `nix-home` to `AI_INPUTS` in `deps-update-flake.yml` to enable immediate `flake.lock` updates on `nix-home` changes.
> 
>   - **Behavior**:
>     - Adds `nix-home` to `AI_INPUTS` in `deps-update-flake.yml` to allow dispatch events from `nix-home`.
>     - Enables immediate `flake.lock` updates when `nix-home` changes, bypassing scheduled updates.
>   - **Testing**:
>     - Verify dispatch triggers `deps-update-flake.yml` on `nix-darwin` after `nix-home` main merge.
>     - Confirm PR creation updating only `nix-home` input in `flake.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-darwin&utm_source=github&utm_medium=referral)<sup> for 092b5ec28c0599a0143ad3df1007505695312591. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->