### PR TITLE
feat: remove nodejs and python310 from global packages

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -57,7 +57,6 @@ Source: `modules/darwin/common.nix`
 | Package | Description |
 |---------|-------------|
 | mas | Mac App Store CLI |
-| nodejs | Node.js LTS |
 | ollama | LLM runtime (models on /Volumes/Ollama/models) |
 | whisper-cpp | Local speech-to-text (OpenAI Whisper C++ port, CoreML/Metal) |
 | openai-whisper | Original OpenAI Whisper (Python, GPU/CPU, broader model support) |
@@ -72,7 +71,6 @@ Source: `modules/common/packages.nix`
 
 | Package | Description |
 |---------|-------------|
-| nodejs | Provides npm and npx |
 | bun | Fast all-in-one JavaScript runtime (provides bunx) |
 
 ### Git Workflow
@@ -133,7 +131,6 @@ Source: `modules/common/packages.nix`
 | pyright | Static type checker for Python |
 | python314 | Python 3.14 (bleeding edge) |
 | python312 | Python 3.12 (general development) |
-| python310 | Python 3.10 (compatibility testing) |
 | uv | Fast Python package manager (also runs EOL versions) |
 | python3.withPackages | Unified env: cryptography, grip, ollama, pipx, pygithub |
 

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -24,11 +24,10 @@ with pkgs;
   git-bug # Distributed bug tracker embedded in git (git bug command)
 
   # ==========================================================================
-  # Node.js and Bun Runtimes
+  # Bun Runtime
   # ==========================================================================
-  # Provides npm, npx (from nodejs) and bunx (from bun)
-  # Essential development tools for JavaScript/TypeScript projects
-  nodejs # Provides npm and npx (node package executor)
+  # Provides bunx (from bun)
+  # nodejs available per-repo via devShells
   bun # Fast all-in-one JavaScript runtime (provides bunx)
 
   # ==========================================================================
@@ -97,11 +96,11 @@ with pkgs;
   pyright # Static type checker for Python
 
   # Python interpreters: Multiple versions via Nix (no pip - packages via Nix only)
-  # Available: python3 (3.13), python314, python312, python310
+  # Available: python3 (3.13), python314, python312
   # For Python 3.9 (Splunk, EOL): Use `uv run --python 3.9` (on-demand download)
   python314 # Python 3.14: Bleeding edge features
   python312 # Python 3.12: General development and testing
-  python310 # Python 3.10: Older compatibility testing
+  # python310 available per-repo via devShells
 
   # uv: For running EOL Python versions (3.9) not in nixpkgs
   # Usage: uv run --python 3.9 pytest tests/

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -108,7 +108,7 @@ in
     ])
     ++ (with pkgs; [
       mas # Mac App Store CLI
-      nodejs # Node.js LTS (nixpkgs default tracks current LTS)
+      # nodejs available per-repo via devShells
       ollama # LLM runtime (models on /Volumes/Ollama/models)
       whisper-cpp # Local speech-to-text (OpenAI Whisper C++ port, CoreML/Metal)
       openai-whisper # Original OpenAI Whisper (Python, GPU/CPU, broader model support)

--- a/scripts/workflows/check-package-versions.sh
+++ b/scripts/workflows/check-package-versions.sh
@@ -28,7 +28,6 @@ PACKAGES=(
   "git:Security:stable"
   "gnupg:Security:stable"
   "gh:Security:stable"
-  "nodejs:Security:stable"
   "codex:AI Tool:unstable"
   "github-mcp-server:AI Tool:unstable"
   "ollama:AI Tool:unstable"


### PR DESCRIPTION
## Summary

- Remove `nodejs` from `modules/darwin/common.nix` (line 111) — available per-repo via devShells
- Remove `nodejs` from `modules/common/packages.nix` (line 31) — available per-repo via devShells
- Remove `python310` from `modules/common/packages.nix` (line 104) — available per-repo via devShells
- Update section headers and comments to reflect these packages are now per-repo

These packages were removed from `nix-home`'s global packages in March 2026 when the `shells/` directory was replaced with per-repo `templates/`. This PR mirrors that change in `nix-darwin`.

Repos that need `nodejs` or `python310` can scaffold a devShell via:
```sh
nix flake init -t github:JacobPEvans/nix-home#ansible  # or other templates
```

## Test plan

- [x] `nix flake check` passes with no errors on `aarch64-darwin`
- [x] All pre-commit hooks pass (nixfmt, statix, deadnix, semgrep, etc.)
- [ ] After merge: run `sudo darwin-rebuild switch --flake .` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `nodejs` and `python310` from global packages, making them available per-repo via devShells, and update comments accordingly.
> 
>   - **Behavior**:
>     - Remove `nodejs` from `modules/darwin/common.nix` and `modules/common/packages.nix`.
>     - Remove `python310` from `modules/common/packages.nix`.
>     - Update comments and section headers to indicate `nodejs` and `python310` are available per-repo via devShells.
>   - **Context**:
>     - Mirrors changes from March 2026 when `shells/` was replaced with per-repo `templates/` in `nix-home`.
>     - Repos needing `nodejs` or `python310` can use `nix flake init` with appropriate templates.
>   - **Testing**:
>     - `nix flake check` passes on `aarch64-darwin`.
>     - Pre-commit hooks pass (nixfmt, statix, deadnix, semgrep).
>     - Post-merge: run `sudo darwin-rebuild switch --flake .` to confirm no regressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-darwin&utm_source=github&utm_medium=referral)<sup> for 14d18bbe4aa8b18787c1cefa1eed49040c7757f9. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->