### PR TITLE
fix: add schedule→dispatch workaround for OIDC bug (claude-code-action#814)

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -6,12 +6,26 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: read
   id-token: write
   issues: write
   pull-requests: read
 
 jobs:
+  dispatch:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run "$WORKFLOW_NAME" --repo "${{ github.repository }}"
+
   recommend:
+    if: github.event_name != 'schedule'
     uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -6,11 +6,25 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   id-token: write
   pull-requests: write
 
 jobs:
+  dispatch:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run "$WORKFLOW_NAME" --repo "${{ github.repository }}"
+
   simplify:
+    if: github.event_name != 'schedule'
     uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -6,12 +6,26 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   id-token: write
   issues: write
   pull-requests: write
 
 jobs:
+  dispatch:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run "$WORKFLOW_NAME" --repo "${{ github.repository }}"
+
   analyze:
+    if: github.event_name != 'schedule'
     uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.7.0
     secrets: inherit

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -85,10 +85,17 @@ rules:
   # a 'review' job (needs contents/id-token/pull-requests: write) calls the reusable
   # workflow. GitHub requires workflow-level to hold the union of all job needs.
   # The dispatch job explicitly restricts its own access via job-level permissions.
+  #
+  # best-practices.yml, code-simplifier.yml, and next-steps.yml use the same
+  # schedule→dispatch pattern: a 'dispatch' job (needs actions: write) re-triggers
+  # the workflow on schedule, then the main job calls the reusable workflow.
   excessive-permissions:
     ignore:
+      - best-practices.yml
+      - code-simplifier.yml
       - issue-auto-resolve.yml
       - issue-pipeline.yml
+      - next-steps.yml
       - post-merge-docs-review.yml
       - post-merge-tests.yml
 


### PR DESCRIPTION
## Summary

- Adds a thin `dispatch` job to `next-steps.yml`, `best-practices.yml`, and `code-simplifier.yml` that converts `schedule` events into `workflow_dispatch` events
- Root cause: upstream OIDC bug in `anthropics/claude-code-action#814` where `schedule`-triggered tokens are rejected by Anthropic's token exchange endpoint, but `workflow_dispatch` tokens succeed
- Updates `zizmor.yml` to suppress `excessive-permissions` for these workflows (same pattern as `post-merge-docs-review.yml`)

## Pattern Applied

```yaml
jobs:
  dispatch:
    if: github.event_name == 'schedule'
    runs-on: ubuntu-latest
    steps:
      - name: Re-trigger as workflow_dispatch
        env:
          WORKFLOW_NAME: ${{ github.workflow }}
        run: gh workflow run "$WORKFLOW_NAME" --repo "${{ github.repository }}"
        env:
          GH_TOKEN: ${{ github.token }}

  analyze:  # (or recommend / simplify)
    if: github.event_name != 'schedule'
    uses: ...
```

## Test plan

- [x] Test run triggered via workflow_dispatch: https://github.com/JacobPEvans/nix-darwin/actions/runs/22669511111
- [ ] Verify next scheduled run converts via dispatch job
- [ ] Monitor upstream fix: anthropics/claude-code-action#814

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a `dispatch` job to convert `schedule` events to `workflow_dispatch` in three workflows and updates `zizmor.yml` to suppress related warnings.
> 
>   - **Workflows**:
>     - Adds `dispatch` job to `next-steps.yml`, `best-practices.yml`, and `code-simplifier.yml` to convert `schedule` events to `workflow_dispatch` events.
>     - `dispatch` job runs on `ubuntu-latest` and re-triggers the workflow using `gh workflow run`.
>   - **Configuration**:
>     - Updates `zizmor.yml` to suppress `excessive-permissions` warnings for the modified workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-darwin&utm_source=github&utm_medium=referral)<sup> for 4608e2de0cd7db53de9c9bdcdf787033c633e745. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->