### PR TITLE
chore: bump ai-workflows to v0.8.0

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -27,5 +27,5 @@ jobs:
 
   recommend:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.8.0
     with:
       workflow_name: "CI Gate"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.8.0
     with:
       repo_context: "Nix flakes configuration for macOS and Linux systems"
       ci_structure: "ci-gate.yml (orchestrator calling _nix-validate, _nix-build, _markdown-lint, _file-size, _claude-settings)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.8.0
     with:
       review_prompt: "Focus on Nix flake patterns, module structure, system configuration best practices"
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -26,5 +26,5 @@ jobs:
 
   simplify:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -64,7 +64,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.8.0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -75,7 +75,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.8.0
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -27,5 +27,5 @@ jobs:
 
   analyze:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.8.0
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.8.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.8.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
Bump all ai-workflows references from v0.7.0 to v0.8.0. Includes soft bot guard, suite workflows, AI provenance, and Slack notifications.