### PR TITLE
fix(ci): remove jacobpevans-cc-plugins from AI_INPUTS

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -48,7 +48,6 @@ jobs:
         claude-code-plugins
         claude-cookbooks
         claude-plugins-official
-        jacobpevans-cc-plugins
         anthropic-agent-skills
         superpowers-marketplace
         nix-ai


### PR DESCRIPTION
## Summary

- `jacobpevans-cc-plugins` is a flake input in **nix-ai**, not nix-darwin
- It appears in nix-darwin's `flake.lock` only as a transitive dependency of `nix-ai`
- Removing it from `AI_INPUTS` stops nix-darwin from receiving spurious direct dispatch events from claude-code-plugins; the transitive lock entry updates automatically when `nix-ai` is updated

## Test Plan

- [ ] Verify nix-darwin CI passes
- [ ] Confirm `nix-ai` entry in `AI_INPUTS` still triggers transitive update of `jacobpevans-cc-plugins` in `flake.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)