### PR TITLE
fix: SHA-pin xinbenlv/openhands-action (carries ANTHROPIC_API_KEY)

### DIFF
--- a/.github/workflows/ai-openhands.yml
+++ b/.github/workflows/ai-openhands.yml
@@ -57,7 +57,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Run OpenHands Agent
-        uses: xinbenlv/openhands-action@v1.0.1-rc3
+        uses: xinbenlv/openhands-action@3ad1d1a274c5eba6f53a177140cc8ea08b92c33e # v1.0.1-rc3
         with:
           prompt: |
             You are an autonomous AI agent working on issue #${{ steps.issue.outputs.number }}.


### PR DESCRIPTION
## Summary

- SHA-pin `xinbenlv/openhands-action` from tag `v1.0.1-rc3` to commit digest `3ad1d1a274c5eba6f53a177140cc8ea08b92c33e`
- This action receives the `ANTHROPIC_API_KEY` secret and has `contents: write`, `pull-requests: write`, `issues: write` permissions
- Tag-only pinning on an RC release from a personal GitHub account is a critical supply chain risk — a compromised tag could exfiltrate the API key or inject malicious code with write access

## Context

Q1 2026 security audit finding. The action is from `xinbenlv` (personal account), uses a release candidate tag (`v1.0.1-rc3`), and is granted broad write permissions plus a sensitive secret. SHA pinning ensures the exact reviewed code runs regardless of future tag mutations.

## Test plan

- [x] Verify SHA `3ad1d1a274c5eba6f53a177140cc8ea08b92c33e` resolves to the `v1.0.1-rc3` tag
- [ ] Confirm workflow still triggers correctly on `workflow_dispatch`

Generated with [Claude Code](https://claude.com/claude-code)