### PR TITLE
feat: tiered GitHub token context switching

### DIFF
--- a/hosts/macbook-m4/gh-token-switching.zsh
+++ b/hosts/macbook-m4/gh-token-switching.zsh
@@ -1,0 +1,40 @@
+# GitHub token context switching — principle of least privilege
+# Tokens are tiered PATs stored in macOS Keychain.
+# Restricted: automation.keychain-db (unrestricted, AI can access freely)
+# Private/Admin: elevate-access.keychain-db (password-protected, requires user unlock)
+# Usage: gh-restricted | gh-private | gh-admin | gh-token-status
+
+_gh_switch_token() {
+  local svc="$1" db="$2" mode="$3" desc="$4"
+  local token
+  token=$(_get_keychain_secret "$svc" "$_KC_AI_ACCOUNT" "$db")
+  if [[ -z "$token" ]]; then
+    echo "ERROR: No keychain entry for service '$svc' in '$db'"
+    echo "Add it:  security add-generic-password -U -s '$svc' -a '$_KC_AI_ACCOUNT' -w '<token>' '$db'"
+    return 1
+  fi
+  export GITHUB_TOKEN="$token"
+  export GH_ENV_MODE="$mode"
+  echo "GitHub context: $mode ($desc)"
+}
+
+gh-restricted() {
+  _gh_switch_token "$_GH_SVC_RESTRICTED" "$_GH_DB_RESTRICTED" "RESTRICTED" "public repos"
+}
+
+gh-private() {
+  _gh_switch_token "$_GH_SVC_PRIVATE" "$_GH_DB_PRIVATE" "PRIVATE" "+ private repos"
+}
+
+gh-admin() {
+  _gh_switch_token "$_GH_SVC_ADMIN" "$_GH_DB_ADMIN" "ADMIN" "full access"
+}
+
+gh-token-status() {
+  echo "GH_ENV_MODE=${GH_ENV_MODE:-unset}"
+  if [[ -n "$GITHUB_TOKEN" ]]; then
+    echo "GITHUB_TOKEN=set (${#GITHUB_TOKEN} chars)"
+  else
+    echo "GITHUB_TOKEN=unset"
+  fi
+}

--- a/hosts/macbook-m4/gh-token-switching.zsh
+++ b/hosts/macbook-m4/gh-token-switching.zsh
@@ -3,17 +3,40 @@
 # Restricted: automation.keychain-db (unrestricted, AI can access freely)
 # Private/Admin: elevate-access.keychain-db (password-protected, requires user unlock)
 # Usage: gh-restricted | gh-private | gh-admin | gh-token-status
+#
+# REQUIRES (set by caller in home.nix initContent):
+#   _KC_AI_ACCOUNT        keychain account name (e.g. ai-cli-coder)
+#   _GH_SVC_RESTRICTED, _GH_DB_RESTRICTED
+#   _GH_SVC_PRIVATE,    _GH_DB_PRIVATE
+#   _GH_SVC_ADMIN,      _GH_DB_ADMIN
 
 _gh_switch_token() {
   local svc="$1" db="$2" mode="$3" desc="$4"
-  local token
-  token=$(_get_keychain_secret "$svc" "$_KC_AI_ACCOUNT" "$db")
-  if [[ -z "$token" ]]; then
-    echo "ERROR: No keychain entry for service '$svc' in '$db'"
-    echo "Add it:  security add-generic-password -U -s '$svc' -a '$_KC_AI_ACCOUNT' -w '<token>' '$db'"
+  local output status
+
+  # Call `security` directly (not via _get_keychain_secret, which swallows
+  # errors) so we can distinguish missing entries from other failures like
+  # locked keychain, access denied, or user-interaction-not-allowed.
+  output=$(security find-generic-password -w -s "$svc" -a "$_KC_AI_ACCOUNT" "$db" 2>&1)
+  status=$?
+
+  if (( status != 0 )); then
+    if [[ "$output" == *"could not be found"* ]]; then
+      echo "ERROR: No keychain entry for service '$svc' in '$db'" >&2
+      echo "Add it:  security add-generic-password -U -s '$svc' -a '$_KC_AI_ACCOUNT' -w '<token>' '$db'" >&2
+    else
+      echo "ERROR: Failed to read keychain entry for service '$svc' in '$db'" >&2
+      echo "$output" >&2
+    fi
     return 1
   fi
-  export GITHUB_TOKEN="$token"
+
+  if [[ -z "$output" ]]; then
+    echo "ERROR: Empty token returned for service '$svc' in '$db'" >&2
+    return 1
+  fi
+
+  export GITHUB_TOKEN="$output"
   export GH_ENV_MODE="$mode"
   echo "GitHub context: $mode ($desc)"
 }

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -105,7 +105,7 @@
 
       # macOS-specific shell init (appended after cross-platform initContent from nix-home)
       initContent = lib.mkAfter ''
-        # --- API Keys (from macOS Keychain) ---
+        # --- Keychain helper (persists for runtime token switching) ---
 
         _get_keychain_secret() {
           # Fetch a secret from the macOS Keychain by service name.
@@ -121,6 +121,8 @@
         _KC_AI_ACCOUNT='${userConfig.keychain.aiAccount}'
         _KC_AI_DB='${userConfig.keychain.aiDb}'
 
+        # --- API Keys (from macOS Keychain) ---
+
         # GitHub - for github@claude-plugins-official MCP server
         export GITHUB_PERSONAL_ACCESS_TOKEN=''${GITHUB_PERSONAL_ACCESS_TOKEN:-"$(_get_keychain_secret 'github-pat' "$_KC_USER")"}
 
@@ -130,8 +132,21 @@
         # HuggingFace - for huggingface MCP server and hf CLI (model downloads)
         export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
 
-        unset -f _get_keychain_secret
-        unset _KC_USER _KC_AI_ACCOUNT _KC_AI_DB
+        unset _KC_USER  # Only user account var cleaned up; AI vars persist for switching
+
+        # --- GitHub Token Context Switching ---
+        _GH_SVC_RESTRICTED='${userConfig.github.tokens.restricted.service}'
+        _GH_DB_RESTRICTED='${userConfig.github.tokens.restricted.keychain}'
+        _GH_SVC_PRIVATE='${userConfig.github.tokens.private.service}'
+        _GH_DB_PRIVATE='${userConfig.github.tokens.private.keychain}'
+        _GH_SVC_ADMIN='${userConfig.github.tokens.admin.service}'
+        _GH_DB_ADMIN='${userConfig.github.tokens.admin.keychain}'
+
+        source ${./gh-token-switching.zsh}
+
+        # Default to lowest privilege on every new shell
+        unset GITHUB_TOKEN
+        gh-restricted
 
         # --- macOS setup ---
         source ${./macos-setup.zsh}

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -132,7 +132,8 @@
         # HuggingFace - for huggingface MCP server and hf CLI (model downloads)
         export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
 
-        unset _KC_USER  # Only user account var cleaned up; AI vars persist for switching
+        unset -f _get_keychain_secret  # No longer needed after init
+        unset _KC_USER _KC_AI_DB  # _KC_AI_ACCOUNT persists for runtime gh-token switching
 
         # --- GitHub Token Context Switching ---
         _GH_SVC_RESTRICTED='${userConfig.github.tokens.restricted.service}'

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -116,6 +116,29 @@ in
   };
 
   # ==========================================================================
+  # GitHub Token Configuration
+  # ==========================================================================
+  github = {
+    tokens = {
+      # Tiered GitHub PATs — each tier specifies its keychain service + DB.
+      # Restricted uses the unrestricted automation keychain (AI can access freely).
+      # Private/Admin use a password-protected keychain (requires user unlock).
+      restricted = {
+        service = "GH_PAT_RESTRICTED";
+        keychain = "automation.keychain-db";
+      };
+      private = {
+        service = "GH_PAT_PRIVATE";
+        keychain = "elevate-access.keychain-db";
+      };
+      admin = {
+        service = "GH_PAT_ADMIN";
+        keychain = "elevate-access.keychain-db";
+      };
+    };
+  };
+
+  # ==========================================================================
   # Nix/NixOS Configuration
   # ==========================================================================
   nix = {

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -31,6 +31,7 @@ in
   nixpkgs.config.allowUnfree = true;
   nixpkgs.overlays = [
     (import ../../overlays/macos-apps.nix)
+    (import ../../overlays/direnv-darwin-fix.nix) # TEMPORARY: NixOS/nix#6065
   ];
 
   # --- User Configuration ---

--- a/overlays/direnv-darwin-fix.nix
+++ b/overlays/direnv-darwin-fix.nix
@@ -1,0 +1,31 @@
+# TEMPORARY WORKAROUND: direnv test-fish SIGKILL on macOS darwin
+#
+# direnv-2.37.1's test-fish check phase target is killed by signal 9 (SIGKILL)
+# on darwin. The root cause is a Nix daemon bug where RewritingSink corrupts
+# Mach-O code signatures, causing the kernel to kill the fish binary.
+#
+# This is NOT a direnv bug — the fish binary itself is corrupt after copying.
+# All meaningful tests (Go, bash, zsh) continue to run.
+#
+# Upstream references:
+#   - Nix daemon bug: https://github.com/NixOS/nix/issues/6065
+#   - nixpkgs tracking: https://github.com/NixOS/nixpkgs/issues/507531
+#   - Nix daemon fix PR: https://github.com/NixOS/nix/pull/15638
+#
+# REMOVE THIS OVERLAY when NixOS/nix#15638 is merged and the fixed Nix daemon
+# is available in our Determinate Nix version.
+
+_final: prev:
+
+if prev.stdenv.isDarwin then
+  {
+    direnv = prev.direnv.overrideAttrs (_: {
+      checkPhase = ''
+        runHook preCheck
+        make test-go test-bash test-zsh
+        runHook postCheck
+      '';
+    });
+  }
+else
+  { }

--- a/overlays/direnv-darwin-fix.nix
+++ b/overlays/direnv-darwin-fix.nix
@@ -16,16 +16,12 @@
 # is available in our Determinate Nix version.
 
 _final: prev:
-
-if prev.stdenv.isDarwin then
-  {
-    direnv = prev.direnv.overrideAttrs (_: {
-      checkPhase = ''
-        runHook preCheck
-        make test-go test-bash test-zsh
-        runHook postCheck
-      '';
-    });
-  }
-else
-  { }
+prev.lib.optionalAttrs prev.stdenv.isDarwin {
+  direnv = prev.direnv.overrideAttrs (_: {
+    checkPhase = ''
+      runHook preCheck
+      make test-go test-bash test-zsh
+      runHook postCheck
+    '';
+  });
+}


### PR DESCRIPTION
## Summary

- Adds tiered GitHub token context switching via three shell functions (restricted → private → admin) with security gates for escalated access
- Token tier defaults to restricted on shell startup; escalation to private/admin requires keychain unlock (password prompt), placing a security boundary between AI tooling and elevated GitHub access
- Decouples GITHUB_TOKEN (gh CLI) from GITHUB_PERSONAL_ACCESS_TOKEN (Claude's GitHub MCP), enabling independent token management for different consumers

## Changes

- **hosts/macbook-m4/gh-token-switching.zsh** (new) — Shell functions for tiered token switching: `gh-restricted`, `gh-private`, `gh-admin`, `gh-token-status`, and internal `_gh_switch_token` helper with comprehensive error handling
- **hosts/macbook-m4/home.nix** — Restructured shell initContent to source the new token-switching module; adds per-tier keychain variable exports; defaults to restricted token on shell startup
- **lib/user-config.nix** — Added `github.tokens` section with per-tier attributes (`service`, `keychain`) for DRY token configuration
- **overlays/direnv-darwin-fix.nix** (new) — Temporary overlay skipping broken direnv test-fish target on darwin (upstream issue: NixOS/nix#6065)
- **modules/darwin/common.nix** — Imports the new direnv-darwin-fix overlay

## Test Plan

- [ ] Run `nix flake check` — verifies flake syntax and overlay imports
- [ ] Run `sudo darwin-rebuild switch --flake .` — applies configuration; verify no errors
- [ ] Open new shell and confirm `gh-token-status` shows restricted token
- [ ] Run `gh-private` and verify keychain password prompt appears
- [ ] Confirm `GITHUB_TOKEN` is set from the elevate-access keychain after unlock
- [ ] Run `gh-restricted` and verify token reverts to automation keychain token
- [ ] Run `gh-admin` and verify admin token is set after keychain unlock
- [ ] Verify `GITHUB_PERSONAL_ACCESS_TOKEN` remains unchanged across all tier switches
- [ ] Test gh CLI commands in restricted mode (`gh repo list`) — should only see public repos
- [ ] Test gh CLI commands in private mode — should see all repos

## Related

- [NixOS/nix#6065](https://github.com/NixOS/nix/issues/6065) — direnv test-fish fails on darwin due to Mach-O signature corruption (workaround via overlay)
- [NixOS/nix#15638](https://github.com/NixOS/nix/issues/15638) — RewritingSink Mach-O signature bug root cause
- [NixOS/nixpkgs#507531](https://github.com/NixOS/nixpkgs/issues/507531) — direnv darwin-specific test handling (tracking upstream)
