### PR TITLE
feat: add libreoffice homebrew cask for document-skills

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -158,6 +158,16 @@ in
         name = "microsoft-teams";
         greedy = true;
       }
+
+      # --- Office Suite (for Claude document-skills) ---
+      # LibreOffice provides the `soffice` CLI that /document-skills:{docx,xlsx,pptx}
+      # use to convert Office docs to PDF. nixpkgs does NOT build libreoffice for
+      # aarch64-darwin, so homebrew is the correct fallback per "nixpkgs first,
+      # then brew" policy. On Linux it ships via nix-home home.packages.
+      {
+        name = "libreoffice";
+        greedy = true;
+      }
     ];
 
     # Mac App Store apps (requires signed into App Store)


### PR DESCRIPTION
## Summary

- Adds `libreoffice` as a Homebrew cask (`greedy = true`) in `modules/darwin/homebrew.nix`.
- Fills in the macOS half of runtime deps for Anthropic's `/document-skills:{docx,xlsx,pptx}` plugins — they shell out to `soffice` for Office → PDF conversion.
- Pairs with [JacobPEvans/nix-home#142](https://github.com/JacobPEvans/nix-home/pull/142) which provides the Linux half (`libreoffice` via `home.packages`) plus cross-platform Python and nodejs/npm deps.

## Why homebrew for this one

`nixpkgs` does not build `libreoffice` for `aarch64-darwin` (`meta.platforms` excludes it), which is the whole repo's target. Homebrew is the correct fallback per the "nixpkgs first, then brew" policy — not a preference. `greedy = true` is required because LibreOffice ships a built-in updater that Homebrew would otherwise defer to.

## Test plan

- [x] `nix fmt`, `statix check`, `deadnix`
- [x] `nix build .#checks.aarch64-darwin.module-eval` passes
- [ ] After merge + nix-home#142 merge + flake input bump + `darwin-rebuild switch`:
  - [ ] `soffice --version` prints a LibreOffice version
  - [ ] `/document-skills:docx` can export a generated .docx to PDF