### PR TITLE
chore(deps): bump nix-home to 1.17.0 for document-skills

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -582,11 +582,11 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1775817630,
-        "narHash": "sha256-hMuTjIZm3p+hpIvOh/cm5TMMGTN2pEG2ZA/kRyvJIZc=",
+        "lastModified": 1775855792,
+        "narHash": "sha256-3eeOlaCzCLbRkW/HnnK4O4e3QWjYW0iA/KOAaTZ+VuM=",
         "owner": "JacobPEvans",
         "repo": "nix-home",
-        "rev": "02f27d6e157333b5c6771d1aee865901278350e0",
+        "rev": "cfa05a94f0419ceae5d8aa4e4d51c7aff40ef355",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bumps \`nix-home\` flake input from 1.16.0 → 1.17.0 ([cfa05a9](https://github.com/JacobPEvans/nix-home/commit/cfa05a9)).
- Pulls in [JacobPEvans/nix-home#142](https://github.com/JacobPEvans/nix-home/pull/142) — runtime dependencies for Claude's \`/document-skills:{docx,xlsx,pptx}\`: \`pandoc\`, \`poppler-utils\`, \`nodejs\`, Python libs (\`pandas\`, \`openpyxl\`, \`pillow\`, \`markitdown\`), and the pinned npm-global install of \`docx\` + \`pptxgenjs\` via home.activation.
- Pairs with #974 (libreoffice homebrew cask, already on main) to complete the macOS side.

## Test plan

- [x] \`nix build .#darwinConfigurations.jevans-mbp.system\` completes locally
- [ ] CI: Nix Build / Validate
- [ ] Post-merge: \`sudo darwin-rebuild switch --flake .\` + end-to-end skill invocation