### PR TITLE
chore(flake): bump nix-ai + ai-assistant-instructions to pick up Bifrost rerouting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1775560396,
-        "narHash": "sha256-S+KoBsoo+scdMnswBz1YAnLh1vT9CBR2ZHbPyBpfKSQ=",
+        "lastModified": 1775867735,
+        "narHash": "sha256-QfREms9L7HG6YlDd/eS+4FjdfrbAHWrjGEen+lAUjr8=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "f6bc4002478dd6faea48a2ae78ce41c597f8ffb0",
+        "rev": "9a5408919922ae074948493d30bfd47a330d406e",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1775816360,
-        "narHash": "sha256-fPSUwD76ab7GZYzyf6qc+6mf2Srl0cFkmS/lPhUenXQ=",
+        "lastModified": 1775868682,
+        "narHash": "sha256-EnnJhbU/SP6IlfHZx3mueS3o6wPlXtEUOYWxOO5vdd8=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "5572dde2b9f59191c6b04b6870c6b085dbb3de9c",
+        "rev": "e9e83016c2718afb7c717f8f34b72bf81e9bb1bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450 — PAL MCP → Bifrost migration umbrella

## Summary

- **nix-ai**: \`5572dde → e9e8301\` (1.35.0 release containing JacobPEvans/nix-ai#466)
- **ai-assistant-instructions**: \`f6bc400 → 9a54089\` (includes JacobPEvans/ai-assistant-instructions#549)

## Why

The merged JacobPEvans/nix-ai#466 changes \`modules/mcp/default.nix\` so PAL MCP's \`CUSTOM_API_URL\` routes through the Bifrost AI gateway at \`http://localhost:30080/v1\` instead of talking to vllm-mlx directly on \`:11434\`. Bumping the nix-ai input here propagates that change into the live system via \`darwin-rebuild switch\`.

The ai-assistant-instructions bump picks up the matching docs migration (JacobPEvans/ai-assistant-instructions#549) that retitles the Token Economy section to \"Use Bifrost + Native Subagents Aggressively\", adds a Bifrost Path column to the Model Routing Rules table, and trims the PAL MCP Tools section to only \`clink\`/\`consensus\`.

## Test plan

- [x] \`nix flake update nix-ai ai-assistant-instructions\` succeeded
- [x] \`darwin-rebuild switch --flake .\` applied cleanly — PAL health check passed all 6 gates (binary, Doppler auth, GEMINI/OPENAI/OPENROUTER keys, log dir)
- [x] Verified \`~/.claude.json\` now has \`.mcpServers.pal.env.CUSTOM_API_URL == \"http://localhost:30080/v1\"\`
- [x] Verified Bifrost gateway live with 509 routable models
- [x] Cloud benchmark via Bifrost: Gemini 2.5 Flash roundtrip in ~757 ms
- [x] Local MLX benchmark via Bifrost: ~290 ms overhead vs. direct call to vllm-mlx
- [ ] CI passes