### PR TITLE
feat(zsh): add custom-auth claude launchers (av-claude, gh-claude-*)

### DIFF
--- a/hosts/macbook-m4/claude-launchers.zsh
+++ b/hosts/macbook-m4/claude-launchers.zsh
@@ -1,0 +1,30 @@
+# Custom-auth launchers for `claude` (Claude Code).
+# Sibling of gh-token-switching.zsh; sourced from home.nix initContent.
+#
+# Provides:
+#   av-claude <profile> [claude-args...]   aws-vault exec <profile> -- claude ...
+#   gh-claude-restricted [claude-args...]  claude with GH_PAT_RESTRICTED (subshell-scoped)
+#   gh-claude-private    [claude-args...]  claude with GH_PAT_PRIVATE    (subshell-scoped)
+#   gh-claude-admin      [claude-args...]  claude with GH_PAT_ADMIN      (subshell-scoped)
+#
+# The gh-claude-* wrappers run inside a subshell so GITHUB_TOKEN / GH_ENV_MODE
+# set by the underlying gh-* functions (see gh-token-switching.zsh) do NOT
+# leak into the parent shell after claude exits. This preserves the shell's
+# default least-privilege tier.
+
+av-claude() {
+  if (( $# == 0 )); then
+    echo "usage: av-claude <aws-vault-profile> [claude-args...]" >&2
+    echo "       profiles: see ~/.aws/config" >&2
+    echo "       e.g.  av-claude terraform" >&2
+    echo "             av-claude tf-proxmox --resume" >&2
+    return 2
+  fi
+  local profile="$1"
+  shift
+  aws-vault exec "$profile" -- claude "$@"
+}
+
+gh-claude-restricted() { ( gh-restricted >/dev/null && exec claude "$@" ); }
+gh-claude-private()    { ( gh-private    >/dev/null && exec claude "$@" ); }
+gh-claude-admin()      { ( gh-admin      >/dev/null && exec claude "$@" ); }

--- a/hosts/macbook-m4/claude-launchers.zsh
+++ b/hosts/macbook-m4/claude-launchers.zsh
@@ -3,14 +3,17 @@
 #
 # Provides:
 #   av-claude <profile> [claude-args...]   aws-vault exec <profile> -- claude ...
-#   gh-claude-restricted [claude-args...]  claude with GH_PAT_RESTRICTED (subshell-scoped)
-#   gh-claude-private    [claude-args...]  claude with GH_PAT_PRIVATE    (subshell-scoped)
-#   gh-claude-admin      [claude-args...]  claude with GH_PAT_ADMIN      (subshell-scoped)
+#   gh-claude-restricted [claude-args...]  claude with GITHUB_TOKEN from the RESTRICTED tier
+#   gh-claude-private    [claude-args...]  claude with GITHUB_TOKEN from the PRIVATE tier
+#   gh-claude-admin      [claude-args...]  claude with GITHUB_TOKEN from the ADMIN tier
 #
-# The gh-claude-* wrappers run inside a subshell so GITHUB_TOKEN / GH_ENV_MODE
-# set by the underlying gh-* functions (see gh-token-switching.zsh) do NOT
-# leak into the parent shell after claude exits. This preserves the shell's
-# default least-privilege tier.
+# Each gh-claude-* wrapper runs its underlying gh-* function (defined in
+# gh-token-switching.zsh) inside a subshell, so the GITHUB_TOKEN and
+# GH_ENV_MODE exports those functions produce do NOT leak into the parent
+# shell after claude exits. This preserves the shell's default least-privilege
+# tier. The tier names (RESTRICTED / PRIVATE / ADMIN) correspond to the macOS
+# Keychain service names GH_PAT_RESTRICTED / GH_PAT_PRIVATE / GH_PAT_ADMIN
+# from which the underlying gh-* functions read the token.
 
 av-claude() {
   if (( $# == 0 )); then

--- a/hosts/macbook-m4/claude-launchers.zsh
+++ b/hosts/macbook-m4/claude-launchers.zsh
@@ -14,6 +14,37 @@
 # tier. The tier names (RESTRICTED / PRIVATE / ADMIN) correspond to the macOS
 # Keychain service names GH_PAT_RESTRICTED / GH_PAT_PRIVATE / GH_PAT_ADMIN
 # from which the underlying gh-* functions read the token.
+#
+# Every launcher prints a short status banner to stderr before invoking
+# claude. The banner is primarily aimed at nested AI sessions: when a Claude
+# Code agent invokes one of these functions via its bash tool, the banner
+# lands in the tool output so the agent can see (a) that it is now running
+# under a custom authentication context, (b) what kind of context it is,
+# and (c) that the context disappears when the claude process exits. The
+# banner contains no secrets or token material — only the source type and
+# the context label passed into the launcher.
+
+# Shared status banner emitted before claude is execed.
+# Reusable across all launchers — takes an auth-source label and a
+# context name. Prints to stderr so it doesn't collide with claude's
+# stdout. No secret material is ever printed.
+_claude_launchers_banner() {
+  local source_type="$1"
+  local context="$2"
+  cat >&2 <<BANNER
+
+[claude-launchers] custom authentication context is now active
+  type:    ${source_type}
+  context: ${context}
+  scope:   this claude process only — the parent shell is unaffected
+
+You now have the credentials and capabilities granted by this context.
+Tools that auto-detect credentials from the environment (aws, gh, git,
+terraform, kubectl, etc.) will pick them up automatically. Nothing
+persists once claude exits; the parent shell's environment is untouched.
+
+BANNER
+}
 
 av-claude() {
   if (( $# == 0 )); then
@@ -25,9 +56,30 @@ av-claude() {
   fi
   local profile="$1"
   shift
+  _claude_launchers_banner "aws-vault profile" "$profile"
   aws-vault exec "$profile" -- claude "$@"
 }
 
-gh-claude-restricted() { ( gh-restricted >/dev/null && exec claude "$@" ); }
-gh-claude-private()    { ( gh-private    >/dev/null && exec claude "$@" ); }
-gh-claude-admin()      { ( gh-admin      >/dev/null && exec claude "$@" ); }
+gh-claude-restricted() {
+  (
+    gh-restricted >/dev/null \
+      && _claude_launchers_banner "github-token tier" "restricted" \
+      && exec claude "$@"
+  )
+}
+
+gh-claude-private() {
+  (
+    gh-private >/dev/null \
+      && _claude_launchers_banner "github-token tier" "private" \
+      && exec claude "$@"
+  )
+}
+
+gh-claude-admin() {
+  (
+    gh-admin >/dev/null \
+      && _claude_launchers_banner "github-token tier" "admin" \
+      && exec claude "$@"
+  )
+}

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -149,6 +149,11 @@
         unset GITHUB_TOKEN
         gh-restricted
 
+        # --- Custom-auth launchers for `claude` ---
+        # Defines av-claude <profile>, gh-claude-restricted, gh-claude-private,
+        # gh-claude-admin. Depends on the gh-* functions sourced above.
+        source ${./claude-launchers.zsh}
+
         # --- macOS setup ---
         source ${./macos-setup.zsh}
       '';


### PR DESCRIPTION
## Summary

Adds a new `hosts/macbook-m4/claude-launchers.zsh` sourced from
`programs.zsh.initContent` that provides one-command Claude Code launchers
for the non-Doppler auth contexts already defined in this repo.

```sh
av-claude <profile> [claude-args...]    # aws-vault exec <profile> -- claude ...
gh-claude-restricted [claude-args...]   # claude with GITHUB_TOKEN from the RESTRICTED tier
gh-claude-private    [claude-args...]   # claude with GITHUB_TOKEN from the PRIVATE tier
gh-claude-admin      [claude-args...]   # claude with GITHUB_TOKEN from the ADMIN tier
```

## Context

The repo already ships `gh-restricted` / `gh-private` / `gh-admin` shell
functions (`gh-token-switching.zsh`) that set `GITHUB_TOKEN` + `GH_ENV_MODE`
in the current shell. These were usable but required two commands to launch
Claude with a different tier (`gh-private && claude`) and left the elevated
token persistent in the parent shell afterwards.

The new `gh-claude-*` wrappers run the underlying function inside a
subshell:

```zsh
gh-claude-private() { ( gh-private >/dev/null && exec claude "$@" ); }
```

This way the elevated token never leaks past `claude` exit — the parent
shell retains whatever tier it had (default: RESTRICTED).

`av-claude` is a function (not a static alias) because zsh aliases can't
parameterize the `aws-vault` profile name — it takes the profile as its
first argument and forwards the rest to `claude`.

## Design notes

- **Subshell + exec is deliberate** in the `gh-claude-*` wrappers. The
  subshell isolates the env change; `exec` replaces the subshell with the
  claude process so there's no orphan zsh.
- **Relies on existing gh-token-switching.zsh** — the underlying functions
  already handle keychain errors, locked-keychain prompts, and empty-token
  validation. No duplication of that logic.
- **Only `terraform` profile is combined** with Doppler (in the companion
  nix-home PR's `tf-claude` alias). Other aws-vault profiles are reached
  via `av-claude <profile>` without Doppler.
- **`GH_PAT_*` are keychain service names, not env vars.** The tier names
  set on `GH_ENV_MODE` (and the actual token set on `GITHUB_TOKEN`) come
  from reading the `GH_PAT_RESTRICTED` / `GH_PAT_PRIVATE` / `GH_PAT_ADMIN`
  entries out of the keychain. Docstring in the new file calls this out
  explicitly after reviewer feedback.

## Test plan

- [x] `nix flake check` passes (`checks.aarch64-darwin.module-eval`)
- [x] `shellcheck` passes on the new `.zsh` file (via `checks.aarch64-darwin.shellcheck`)
- [x] CI Gate (nix flake check + darwin-rebuild on macOS runner)
- [ ] Post-merge: `sudo darwin-rebuild switch --flake .` in a new shell
- [ ] `type av-claude gh-claude-restricted gh-claude-private gh-claude-admin` all resolve
- [ ] Subshell isolation: `( gh-private >/dev/null && echo "inner=${#GITHUB_TOKEN}" )` then check `GH_ENV_MODE` is unchanged
- [ ] Launch `gh-claude-private` end-to-end, confirm `gh api user` succeeds inside, verify `GH_ENV_MODE` unchanged after exit

## Related

- JacobPEvans/nix-home#144 — companion PR adds `tf-claude` combo launcher (aws-vault + Doppler)
