### PR TITLE
feat: package placement audit — move whisper tools to nix-ai, group AI brews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,8 @@ cd <branch>
 
 ### Package placement
 
-- **`environment.systemPackages`**: Core bootstrapping (git, gnupg, vim), macOS-only tools, system services, GUI apps
-- **`home.packages`** (nix-home): User dev tools, linters, CLIs, language runtimes
-- **AI packages** (nix-ai): Claude Code, Gemini, Copilot, MCP servers
+See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
+decision matrix for all four repos including homebrew constraints and on-demand patterns.
 
 ## Part of a Quartet
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,11 @@ cd <branch>
 
 ### Package placement
 
-See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
-decision matrix for all four repos including homebrew constraints and on-demand patterns.
+See the `nix-package-placement` rule — lives in
+[ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
+and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
+Contains the full decision matrix for all four repos including homebrew constraints
+and on-demand patterns.
 
 ## Part of a Quartet
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -114,7 +114,7 @@ Source: nix-home (`home.packages` via flake input)
 
 ### Visualization & Diagramming
 
-On-demand via `nix run nixpkgs#d2` / `nix run nixpkgs#nodePackages.mermaid-cli` — not installed globally.
+On-demand via `nix run nixpkgs#d2` and `nix run nixpkgs#mermaid-cli` — not installed globally.
 
 ### Python
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -57,8 +57,6 @@ Source: `modules/darwin/common.nix`
 | Package | Description |
 |---------|-------------|
 | mas | Mac App Store CLI |
-| whisper-cpp | Local speech-to-text (OpenAI Whisper C++ port, CoreML/Metal) |
-| openai-whisper | Original OpenAI Whisper (Python, GPU/CPU, broader model support) |
 
 ---
 
@@ -86,10 +84,8 @@ Source: nix-home (`home.packages` via flake input)
 | pre-commit | Git pre-commit hook framework |
 | shellcheck | Shell script static analysis |
 | shfmt | Shell script formatter |
-| bats | Bash Automated Testing System |
-| lychee | Link checker for markdown and HTML |
+| lychee | Link checker for markdown and HTML (global: pre-commit language: system) |
 | markdownlint-cli2 | Markdown linter |
-| actionlint | GitHub Actions workflow linter |
 
 ### Nix Tooling
 
@@ -118,20 +114,16 @@ Source: nix-home (`home.packages` via flake input)
 
 ### Visualization & Diagramming
 
-| Package | Description |
-|---------|-------------|
-| d2 | Modern diagram scripting language (D2lang) |
-| mermaid-cli | Mermaid diagram generator CLI (mmdc) |
+On-demand via `nix run nixpkgs#d2` / `nix run nixpkgs#nodePackages.mermaid-cli` — not installed globally.
 
 ### Python
 
 | Package | Description |
 |---------|-------------|
-| pyright | Static type checker for Python |
-| python314 | Python 3.14 (bleeding edge) |
-| python312 | Python 3.12 (general development) |
+| pyright | Static type checker for Python (global: IDEs require it in PATH) |
+| python314 | Python 3.14 (primary runtime) |
 | uv | Fast Python package manager (also runs EOL versions) |
-| python3.withPackages | Unified env: cryptography, grip, pipx, pygithub |
+| python3.withPackages | Unified env: cryptography, pygithub + document-skills deps |
 
 ---
 

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -70,12 +70,6 @@ in
     portaudio # Cross-platform audio I/O library
 
     # ========================================================================
-    # AI/ML system services
-    # ========================================================================
-    whisper-cpp # Local speech-to-text (OpenAI Whisper C++ port, CoreML/Metal)
-    openai-whisper # Original OpenAI Whisper (Python, GPU/CPU, broader model support)
-
-    # ========================================================================
     # GUI applications (system-level, in /Applications/Nix Apps/)
     # ========================================================================
     bitwarden-desktop # Password manager desktop app

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -61,12 +61,15 @@ in
       # - Homebrew version is required for Gemini 3.1 Pro support
       "gemini-cli"
 
+      # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
+
       # Block Goose AI agent (https://github.com/block/goose)
       # - Using homebrew as nixpkgs version was >30 days old at time of addition; homebrew actively maintained
       # - Named 'block-goose-cli' to avoid conflict with nixpkgs 'goose' (database migration tool)
       "block-goose-cli"
 
       # Swift native on-device speech recognition (Apple Silicon, requires Xcode build - not in nixpkgs)
+      # Pairs with whisper-cpp + openai-whisper (those are in nix-ai home.packages as Nix derivations)
       "whisperkit-cli"
     ];
     casks = [


### PR DESCRIPTION
## Summary

- Remove `whisper-cpp` and `openai-whisper` from `environment.systemPackages` — AI tools belong in nix-ai, not system bootstrapping. `sox`/`portaudio` stay (general-purpose C libs).
- Add comment block grouping AI-adjacent brews (`block-goose-cli`, `whisperkit-cli`) in `homebrew.nix` — these must stay in nix-darwin since `homebrew.*` is a nix-darwin-only option; home-manager cannot declare brew formulas.
- Update `MANIFEST.md` to reflect package removals.
- Replace inline Package placement bullets in `AGENTS.md` with reference to the new `nix-package-placement` rule (see ai-assistant-instructions PR).

## Part of a coordinated 5-repo audit

| Repo | PR | What changed |
| ---- | -- | ------------ |
| **nix-darwin** (this) | this PR | Remove whisper tools, comment-group AI brews |
| nix-ai | separate PR | Add whisper-cpp + openai-whisper |
| nix-home | separate PR | Remove project-scoped tools (bats, actionlint, d2, mermaid-cli, pipx, grip, python312) |
| nix-devenv | separate PR | Add bats→ansible, actionlint→kubernetes, new python-base module |
| ai-assistant-instructions | separate PR | New nix-package-placement decision matrix rule |

## Test plan

- [ ] `nix flake check` passes in CI
- [ ] `sudo darwin-rebuild switch --flake .` succeeds
- [ ] `whisper-cpp --version` still works (now via nix-ai)
- [ ] `sox --version` still works (stays system-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)