### PR TITLE
fix(agents): drop 'quartet' and 'all four repos' language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,10 @@ cd <branch>
 See the `nix-package-placement` rule — lives in
 [ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
 and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
-Contains the full decision matrix for all four repos including homebrew constraints
+Contains the full decision matrix for the nix repos including homebrew constraints
 and on-demand patterns.
 
-## Part of a Quartet
+## Related Repos
 
 | Repo | Scope | Used via |
 | ---- | ----- | -------- |


### PR DESCRIPTION
## Summary

Removes numeric-type group words ("quartet", "all four repos") from `AGENTS.md`. These words bake a repo count into the docs, so every time a repo is added or removed the docs have to be chased down and updated. Neutral phrasing ("the nix repos", "Related Repos") avoids that maintenance tax.

**Context**: This is the follow-up cleanup that didn't land in #981 before it was merged. The "Package placement" rewrite in #981 pointed at a new `nix-package-placement` rule (JacobPEvans/ai-assistant-instructions#554), but the surrounding doc still used "Part of a Quartet" and "all four repos".

## Changes

- `AGENTS.md`: "Part of a Quartet" → "Related Repos"
- `AGENTS.md`: "for all four repos" → "for the nix repos"

## Test plan

- [ ] CI passes (markdownlint, cspell)
- [ ] No functional changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)