### PR TITLE
fix(zsh): rename 'status' local to 'rc' to avoid zsh read-only special

### DIFF
--- a/hosts/macbook-m4/gh-token-switching.zsh
+++ b/hosts/macbook-m4/gh-token-switching.zsh
@@ -12,15 +12,18 @@
 
 _gh_switch_token() {
   local svc="$1" db="$2" mode="$3" desc="$4"
-  local output status
+  local output rc
 
   # Call `security` directly (not via _get_keychain_secret, which swallows
   # errors) so we can distinguish missing entries from other failures like
   # locked keychain, access denied, or user-interaction-not-allowed.
+  # NOTE: `rc` not `status` — in zsh, $status is a read-only special parameter
+  # (alias for $?). `local status` does not shadow it cleanly in zsh 5.9, and
+  # the subsequent assignment raises "read-only variable: status" at runtime.
   output=$(security find-generic-password -w -s "$svc" -a "$_KC_AI_ACCOUNT" "$db" 2>&1)
-  status=$?
+  rc=$?
 
-  if (( status != 0 )); then
+  if (( rc != 0 )); then
     if [[ "$output" == *"could not be found"* ]]; then
       echo "ERROR: No keychain entry for service '$svc' in '$db'" >&2
       echo "Add it:  security add-generic-password -U -s '$svc' -a '$_KC_AI_ACCOUNT' -w '<token>' '$db'" >&2


### PR DESCRIPTION
## Summary

- Rename `local status` → `local rc` in `_gh_switch_token` so the subsequent
  `rc=$?` assignment doesn't collide with zsh's read-only special `$status`
- Add an explanatory comment in the function so the rename doesn't get
  innocently reverted by a future refactor

## Why

`$status` in zsh is a **read-only special parameter** (alias for `$?`).
Declaring `local status` in a function does **not** cleanly shadow the
special in zsh 5.9 — subsequent assignments to it raise:

```
_gh_switch_token:8: read-only variable: status
```

Every fresh interactive shell was hitting this error during `.zshrc`
execution because `gh-restricted` runs at init and its first statement
goes straight into `_gh_switch_token`.

Pure syntactic rename. No behavioral change. Three edits (declaration,
assignment, conditional).

## Hypothesis (to verify after merge)

Prior session observed that in fresh interactive shells, `source
/nix/store/...claude-launchers.zsh` was being silently skipped during
`.zshrc` init — the functions (`av-claude`, `gh-claude-*`,
`_claude_launchers_banner`) were NOT defined post-init despite the source
line being present and the file parsing cleanly when sourced manually.

Working theory: the read-only assignment error aborts `.zshrc` execution
in a way that skips subsequent top-level `source` calls but still allows
in-shell commands to work later. Fixing Bug 1 may make Bug 2 disappear
entirely. Will verify in a fresh real-terminal shell (Terminal.app /
iTerm2) post-merge before declaring the launcher rollout complete.

## Test plan

- [x] `nix flake check` — all 6 checks pass on aarch64-darwin
- [ ] Post-merge: fresh shell in Terminal.app shows no `read-only
      variable: status` error on startup
- [ ] Post-merge: `type av-claude gh-claude-private _claude_launchers_banner
      tf-claude` all resolve in that fresh shell