### PR TITLE
fix(ci): add hosts/** to nix path filter in ci-gate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -61,6 +61,7 @@ jobs:
               - '**.nix'
               - 'flake.lock'
               - 'modules/**'
+              - 'hosts/**'
               - 'scripts/**'
             flake-lock:
               - 'flake.lock'


### PR DESCRIPTION
## Summary

- Add `hosts/**` to the `nix` path filter in `ci-gate.yml`

## Why

Files under `hosts/` are embedded into nix-built outputs — e.g.
`hosts/macbook-m4/gh-token-switching.zsh` and `hosts/macbook-m4/claude-launchers.zsh`
are sourced into `programs.zsh.initContent` by `hosts/macbook-m4/home.nix`.

The path filter only had `**.nix`, `flake.lock`, `modules/**`, `scripts/**` —
so changes to `.zsh` (or any non-`.nix`) files under `hosts/` skipped Nix Build
entirely. PR #985 exposed this: a `.zsh` file rename correctly had Nix Build
skipped by CI even though the file is part of the build output.

## Test plan

- [ ] This PR's own CI should trigger Nix Build (the workflow file itself is
      under `.github/` which isn't in the nix filter, but the change detection
      job runs on every PR)
- [ ] Future PRs touching `hosts/**` non-`.nix` files should trigger Nix Build