### PR TITLE
feat(zsh): throttle brew update/doctor daily, add outdated check

### DIFF
--- a/hosts/macbook-m4/macos-setup.zsh
+++ b/hosts/macbook-m4/macos-setup.zsh
@@ -3,10 +3,14 @@
 # Set tabs to 2 spaces
 tabs -2
 
-# Homebrew: update package index on shell start.
-# Runs in the foreground so available updates are visible immediately.
-# Note: onActivation.autoUpdate = false keeps darwin-rebuild fast; this compensates.
-brew update
+# Homebrew: update + doctor once per day; outdated versions on every start.
+_brew_stamp="${TMPDIR:-/tmp}/.brew_daily_$(date +%Y%m%d)"
+if [[ ! -f "$_brew_stamp" ]]; then
+  touch "$_brew_stamp"
+  brew update
+  brew doctor
+fi
+brew outdated --verbose
 
 # Clean up .DS_Store files in common directories.
 # Single find across all dirs; -exec rm {} + batches args for fewer rm invocations.

--- a/hosts/macbook-m4/macos-setup.zsh
+++ b/hosts/macbook-m4/macos-setup.zsh
@@ -7,11 +7,11 @@ tabs -2
 _brew_dir="${TMPDIR:-/tmp}/brew" && mkdir -p "$_brew_dir"
 _brew_stamp="$_brew_dir/daily_$(date +%Y%m%d)"
 if [[ ! -f "$_brew_stamp" ]]; then
-  touch "$_brew_stamp"
-  brew update
+  brew update && touch "$_brew_stamp"
   brew doctor
 fi
-brew outdated --verbose
+HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --verbose
+unset _brew_dir _brew_stamp
 
 # Clean up .DS_Store files in common directories.
 # Single find across all dirs; -exec rm {} + batches args for fewer rm invocations.

--- a/hosts/macbook-m4/macos-setup.zsh
+++ b/hosts/macbook-m4/macos-setup.zsh
@@ -4,7 +4,8 @@
 tabs -2
 
 # Homebrew: update + doctor once per day; outdated versions on every start.
-_brew_stamp="${TMPDIR:-/tmp}/.brew_daily_$(date +%Y%m%d)"
+_brew_dir="${TMPDIR:-/tmp}/brew" && mkdir -p "$_brew_dir"
+_brew_stamp="$_brew_dir/daily_$(date +%Y%m%d)"
 if [[ ! -f "$_brew_stamp" ]]; then
   touch "$_brew_stamp"
   brew update


### PR DESCRIPTION
# Throttle Brew Update/Doctor Daily, Add Outdated Check

## Summary

- `brew update` + `brew doctor` run once per day (stamp file: `$TMPDIR/brew/daily_YYYYMMDD`)
- `brew outdated --verbose` runs on every shell start, displaying installed vs available version per formula
- Removes unnecessary startup overhead while keeping Homebrew status visible

## Changes

- `hosts/macbook-m4/macos-setup.zsh`: replace always-on `brew update` with daily-throttled guard block + per-startup `brew outdated --verbose`

## Test plan

- [ ] First terminal of the day: `brew update` and `brew doctor` output appears
- [ ] Second terminal same day: only `brew outdated --verbose` output, no update/doctor
- [ ] `rm $TMPDIR/brew/daily_$(date +%Y%m%d)` then open terminal — update + doctor run again

Related: #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
