### PR TITLE
fix(home-manager): replace backupFileExtension with backupCommand rm -rf

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -74,13 +74,11 @@ sudo mv /etc/bashrc /etc/bashrc.before-nix-darwin
 
 **Problem**: Existing `~/.zshrc` prevented home-manager from managing it.
 
-**Solution**: Added backup extension in `flake.nix`:
+**Solution**: `home-manager.backupCommand = "rm -rf --"` is set in `lib/home-manager-defaults.nix`.
 
-```nix
-home-manager.backupFileExtension = "backup";
-```
-
-**Why**: Automatically backs up existing files before home-manager takes control (creates `.zshrc.backup`).
+**Why**: Home-manager removes conflicting files/directories so it can place its managed symlinks.
+The Nix store is the source of truth — pre-existing conflicting content is permanently deleted
+(no `.backup` files). Rebuild to restore any HM-managed file.
 
 ### 5. Nix Settings Warnings
 
@@ -134,13 +132,14 @@ home-manager --version
 1. **Clean slate approach**: Started minimal instead of adapting Linux-based config
 2. **Determinate Nix**: Using Determinate installer instead of official Nix
 3. **Documentation disabled**: Cleaner builds, faster compilation
-4. **File backups**: All existing files backed up automatically
+4. **File conflicts**: Conflicting files removed so home-manager can place symlinks
 5. **Single profile initially**: Testing with default profile before adding complexity
 
 ## Lessons Learned
 
 1. **Determinate Nix conflicts** with nix-darwin's Nix management - use `determinateNix.enable = true` (official module handles `nix.enable = false` automatically)
-2. **Always backup files** - home-manager and nix-darwin can clobber existing configs
+2. **Nix is the source of truth** - home-manager removes conflicting files to place symlinks;
+   back up anything important before first rebuild
 3. **Unknown setting warnings are harmless** - forward compatibility doesn't break functionality
 4. **Flakes require git tracking** - all files must be `git add`ed before building
 5. **Permissions matter** - some git objects created by Nix need ownership fixes

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -102,10 +102,12 @@ sudo mv /etc/conflicting-file /etc/conflicting-file.before-nix-darwin
 
 ### Home-manager activation fails
 
-Ensure backup extension is set in flake.nix:
+`backupCommand = "rm -rf --"` is set in `lib/home-manager-defaults.nix` to handle
+conflicting files. If activation still fails, remove the conflicting path manually:
 
-```nix
-home-manager.backupFileExtension = "backup";
+```bash
+rm -rf ~/.path/to/conflicting/file-or-dir
+darwin-rebuild switch --flake .
 ```
 
 ### "error: attribute 'package-name' missing"
@@ -320,18 +322,15 @@ creates a conflict that blocks home-manager's `linkGeneration` phase.
 
 **Solution**: Fixed in nix-ai `modules/home-manager/ai-cli/claude/plugins.nix` (PR #298):
 
-1. **Pre-linkGeneration Cleanup**: `cleanupMarketplaceDirectories` activation script runs BEFORE
-   `linkGeneration` to detect and move conflicting directories to `.backup` files
-2. **Post-linkGeneration Diff Report**: `reportMarketplaceDiffs` shows what changed between the
-   backed-up directory and new Nix-managed symlink
-3. **Single Backup**: Only one backup is kept (replaces old backups to avoid clutter)
+1. **Pre-checkLinkTargets Cleanup**: `cleanupConflictingDirectorySymlinks` runs BEFORE
+   `checkLinkTargets` to remove real directories and stale symlinks at marketplace paths
+2. **backupCommand**: `rm -rf --` removes any remaining conflicts so HM can place symlinks
 
-**Verification**: After rebuild, check for backup files:
+**Verification**: After rebuild, confirm all marketplace entries are symlinks:
 
 ```bash
-ls -la ~/.claude/plugins/marketplaces/*.backup
-# Review diffs shown during activation
-# Manually delete backups when satisfied
+ls -la ~/.claude/plugins/marketplaces/
+# All entries should show lrwxr-xr-x (symlinks), none drwxr-xr-x (real dirs)
 ```
 
 **Status**: ✅ RESOLVED - Activation now completes successfully past this point

--- a/lib/home-manager-defaults.nix
+++ b/lib/home-manager-defaults.nix
@@ -15,7 +15,8 @@
   # Install user packages to /etc/profiles instead of ~/.nix-profile
   useUserPackages = true;
 
-  # Backup conflicting files to allow home-manager to update symlinks
-  # After rebuild, clean up .backup files with: find ~ -name "*.backup" -delete
-  backupFileExtension = "backup";
+  # Remove conflicting files so home-manager can place its symlinks.
+  # Nix store is the source of truth — all managed files are recoverable via
+  # `home-manager generations`. No backups, no .backup file pollution.
+  backupCommand = "rm -rf";
 }

--- a/lib/home-manager-defaults.nix
+++ b/lib/home-manager-defaults.nix
@@ -15,8 +15,11 @@
   # Install user packages to /etc/profiles instead of ~/.nix-profile
   useUserPackages = true;
 
-  # Remove conflicting files so home-manager can place its symlinks.
-  # Nix store is the source of truth — all managed files are recoverable via
-  # `home-manager generations`. No backups, no .backup file pollution.
-  backupCommand = "rm -rf";
+  # Remove conflicting files/directories so home-manager can place its symlinks.
+  # Nix store is the source of truth for all HM-managed files. Pre-existing
+  # conflicting content (files not yet in the Nix store) is permanently deleted
+  # without recovery — this is intentional. Previous HM generations can restore
+  # managed symlinks but cannot restore pre-existing conflicting content.
+  # `--` ensures paths starting with `-` are never treated as flags.
+  backupCommand = "rm -rf --";
 }


### PR DESCRIPTION
## Summary

- Replaces `backupFileExtension = "backup"` with `backupCommand = "rm -rf"` in `lib/home-manager-defaults.nix`
- `backupFileExtension` cannot handle directory conflicts — `cmp(1)` fails when the HM store path is a directory, so `checkLinkTargets` exits before the backup/rename logic runs
- `backupCommand = "rm -rf"` works for both files and directories, and produces zero `.backup` file pollution

## Test plan

- [ ] Verify `darwin-rebuild switch` completes without "would be clobbered" errors
- [ ] Confirm no `*.backup` files appear in `$HOME` after rebuild
- [ ] Confirm marketplace symlinks are all proper Nix store symlinks (no real directories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)