### PR TITLE
feat(cribl-edge): declarative management with Renovate tracking

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -76,7 +76,7 @@ in
     # Cribl Cloud manages all runtime configuration after enrollment.
     cribl-edge = {
       enable = true;
-      version = "4.17.0-7e952fa7";
+      version = "4.17.0-7e952fa7"; # cribl-edge
       cloud = {
         host = "main-stoic-kaminsky-d9o9i3r.cribl.cloud";
         group = "default_fleet";

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -71,18 +71,17 @@ in
     };
 
     # --- Cribl Edge ---
-    # Log collection agent managed by Cribl Cloud
-    # Installed externally via .pkg — Nix manages the LaunchDaemon and ACLs
+    # Log collection agent managed by Cribl Cloud.
+    # Nix installs the .pkg on every rebuild and manages the LaunchDaemon.
+    # Cribl Cloud manages all runtime configuration after enrollment.
     cribl-edge = {
       enable = true;
-      acls = [
-        "/var/log" # system.log, install.log, wifi.log
-        "/var/log/asl" # Apple System Log archives
-        "/var/log/DiagnosticMessages" # system diagnostics
-        "/var/audit" # BSM audit trail (login, sudo, file access)
-        "/Library/Logs" # system-level application logs
-        "/Library/Logs/DiagnosticReports" # crash reports
-      ];
+      version = "4.17.0-7e952fa7";
+      cloud = {
+        host = "main-stoic-kaminsky-d9o9i3r.cribl.cloud";
+        group = "default_fleet";
+        tokenCommand = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
+      };
       packs = {
         cc-edge-macos-power = pkgs.fetchzip {
           url = "https://github.com/JacobPEvans/cc-edge-macos-power/releases/download/v1.0.0/cc-edge-macos-power-v1.0.0.crbl";

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -72,14 +72,15 @@ in
 
     # --- Cribl Edge ---
     # Log collection agent managed by Cribl Cloud.
-    # Nix installs the .pkg on every rebuild and manages the LaunchDaemon.
+    # Nix invokes Cribl Cloud's install-edge.sh on every rebuild and manages the LaunchDaemon.
     # Cribl Cloud manages all runtime configuration after enrollment.
+    # Sensitive values (org ID, workspace ID, token) fetched from Doppler at activation time.
     cribl-edge = {
       enable = true;
       version = "4.17.0-7e952fa7"; # cribl-edge
       cloud = {
-        host = "main-stoic-kaminsky-d9o9i3r.cribl.cloud";
-        group = "default_fleet";
+        orgIdCommand = "doppler secrets get CRIBL_ORG_ID --plain -p iac-conf-mgmt -c prd";
+        workspaceIdCommand = "doppler secrets get CRIBL_WORKSPACE_ID --plain -p iac-conf-mgmt -c prd";
         tokenCommand = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
       };
       packs = {

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -5,12 +5,11 @@
 # which gets overwritten on every upgrade — this module removes it and replaces it
 # with a Nix-managed service definition.
 #
-# Cribl Edge itself is installed externally via .pkg (not in any package manager).
-# This module manages: LaunchDaemon lifecycle, ACL-based file permissions, pack deployment.
-# Service runs as user 'cribl'; activation scripts run as root. No FDA — ACLs only for monitored paths.
+# This module manages: binary installation (via .pkg on every rebuild), LaunchDaemon
+# lifecycle, fleet enrollment config (fresh installs only), and pack deployment.
+# Cribl Cloud manages all runtime configuration after enrollment.
 #
-# Note: Disabling this module does not automatically remove ACLs from previously
-# configured paths. Run `/bin/chmod -a "cribl allow ..." <path>` manually if needed.
+# Service runs as root (temporary — revert user/group to cribl:cribl when ready).
 
 {
   lib,
@@ -22,9 +21,8 @@
 let
   cfg = config.programs.cribl-edge;
   path = cfg.installPath;
-  user = "cribl";
-  group = "cribl";
-  aclPerms = "${user} allow read,readattr,readextattr,readsecurity,list,search";
+  user = "root";
+  group = "wheel";
   ts = "$(date '+%Y-%m-%d %H:%M:%S')";
 
   # Build a deploy script per pack — each invocation is idempotent
@@ -85,19 +83,39 @@ in
     installPath = lib.mkOption {
       type = lib.types.str;
       default = "/opt/cribl";
-      description = "Installation path for Cribl Edge (set by .pkg installer).";
+      description = "Installation path for Cribl Edge.";
     };
 
-    acls = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Paths to grant the cribl user read ACL access to.";
-      example = [
-        "/var/log"
-        "/var/audit"
-        "/Library/Logs"
-        "/Library/Logs/DiagnosticReports"
-      ];
+    version = lib.mkOption {
+      type = lib.types.str;
+      description = "Cribl Edge version string (e.g., '4.17.0-7e952fa7'). Bump to upgrade.";
+      example = "4.17.0-7e952fa7";
+    };
+
+    cloud = {
+      host = lib.mkOption {
+        type = lib.types.str;
+        description = "Cribl Cloud leader hostname.";
+        example = "main-stoic-kaminsky-d9o9i3r.cribl.cloud";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 4200;
+        description = "Cribl Cloud leader port.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "default_fleet";
+        description = "Fleet group name.";
+      };
+
+      tokenCommand = lib.mkOption {
+        type = lib.types.str;
+        description = "Shell command that outputs the auth token. Only used on fresh installs (when instance.yml does not exist).";
+        example = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
+      };
     };
 
     packs = lib.mkOption {
@@ -132,47 +150,109 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      if [ ! -d "${path}/bin" ]; then
-        echo "${ts} [WARN] Cribl Edge not found at ${path}"
-        echo "  Install via .pkg from https://cribl.io/download/ or Cribl Cloud enrollment"
-      else
-        # The .pkg installer creates everything as root:wheel but the LaunchDaemon
-        # runs as ${user}:${group}. Only chown if ownership has drifted.
-        if [ "$(/usr/bin/stat -f '%Su' "${path}")" != "${user}" ]; then
-          /usr/sbin/chown -R ${user}:${group} "${path}"
-          echo "${ts} [INFO] Fixed Cribl Edge directory ownership → ${user}:${group}"
-        fi
-      fi
+            # ── 1. Download and install the .pkg ──────────────────────────────────────
+            _major="${cfg.version}"
+            _major="''${_major%%-*}"
+            _pkg_url="https://cdn.cribl.io/dl/$_major/cribl-${cfg.version}-darwin-universal.pkg"
+            _pkg="/tmp/cribl-${cfg.version}.pkg"
 
-      ${lib.optionalString (cfg.acls != [ ]) ''
-        # Remove-then-add ensures idempotency: prevents duplicate ACEs across rebuilds
-        _acl_applied=0
-        ${lib.concatMapStringsSep "\n" (p: ''
-          if [ -e "${p}" ]; then
-            /bin/chmod -a "${aclPerms}" "${p}" 2>/dev/null || true
-            /bin/chmod +a "${aclPerms}" "${p}" 2>&1 || echo "${ts} [WARN] Failed to set ACL on ${p}"
-            _acl_applied=$((_acl_applied + 1))
-          fi
-        '') cfg.acls}
-        echo "${ts} [INFO] Applied Cribl Edge ACLs to $_acl_applied of ${toString (builtins.length cfg.acls)} path(s)"
-      ''}
-
-      ${lib.optionalString (cfg.packs != { }) ''
-        _packs_changed=0
-        ${lib.concatStringsSep "\n" (
-          lib.mapAttrsToList (name: src: ''
-            _result=$(${deployPack}/bin/cribl-deploy-pack "${name}" "${src}" "${path}")
-            if [ "$_result" != "unchanged" ]; then
-              _packs_changed=1
-              echo "${ts} [INFO] Cribl Edge pack ${name}: $_result"
+            echo "${ts} [INFO] Installing Cribl Edge ${cfg.version}..."
+            if ! curl -Lso "$_pkg" "$_pkg_url"; then
+              echo "${ts} [ERROR] Failed to download Cribl Edge .pkg" >&2
+              exit 1
             fi
-          '') cfg.packs
-        )}
-        if [ "$_packs_changed" -eq 1 ]; then
-          /bin/launchctl kickstart -k system/com.nix-darwin.cribl-edge 2>/dev/null || true
-          echo "${ts} [INFO] Restarted Cribl Edge (pack changes detected)"
-        fi
-      ''}
+            if curl -Lso "$_pkg.md5" "$_pkg_url.md5"; then
+              _expected=$(awk '{print $1}' "$_pkg.md5")
+              _actual=$(md5 -q "$_pkg")
+              if [ "$_expected" != "$_actual" ]; then
+                echo "${ts} [ERROR] Cribl .pkg checksum mismatch (expected=$_expected actual=$_actual)" >&2
+                rm -f "$_pkg" "$_pkg.md5"
+                exit 1
+              fi
+            else
+              echo "${ts} [WARN] Could not fetch .md5 — skipping checksum verification"
+            fi
+
+            # Stop Nix-managed service before installing
+            /bin/launchctl bootout system/com.nix-darwin.cribl-edge 2>/dev/null || true
+
+            if ! installer -pkg "$_pkg" -target /; then
+              echo "${ts} [ERROR] Cribl .pkg installation failed" >&2
+              rm -f "$_pkg" "$_pkg.md5"
+              exit 1
+            fi
+
+            # Installer auto-starts its own plist — tear it down, Nix manages the service
+            /bin/launchctl bootout system/io.cribl 2>/dev/null || true
+            rm -f /Library/LaunchDaemons/io.cribl.plist "$_pkg" "$_pkg.md5"
+            echo "${ts} [INFO] Cribl Edge ${cfg.version} installed"
+
+            # ── 2. Ownership ──────────────────────────────────────────────────────────
+            /usr/sbin/chown -R ${user}:${group} "${path}"
+
+            # ── 3. Remove cribl user/group ────────────────────────────────────────────
+            if /usr/bin/dscl . -read /Users/cribl >/dev/null 2>&1; then
+              /usr/bin/dscl . -delete /Users/cribl 2>/dev/null || true
+              echo "${ts} [INFO] Removed cribl user (service now runs as root)"
+            fi
+            if /usr/bin/dscl . -read /Groups/cribl >/dev/null 2>&1; then
+              /usr/bin/dscl . -delete /Groups/cribl 2>/dev/null || true
+              echo "${ts} [INFO] Removed cribl group"
+            fi
+
+            # ── 4. Fleet enrollment (fresh installs only) ─────────────────────────────
+            _instance_yml="${path}/local/_system/instance.yml"
+            if [ ! -f "$_instance_yml" ]; then
+              echo "${ts} [INFO] Writing fleet enrollment config..."
+              mkdir -p "${path}/local/_system"
+              _token=$(eval "${cfg.cloud.tokenCommand}") || {
+                echo "${ts} [ERROR] Failed to fetch Cribl auth token" >&2
+                exit 1
+              }
+              cat > "$_instance_yml" <<INSTANCEEOF
+      distributed:
+        mode: managed-edge
+        master:
+          host: ${cfg.cloud.host}
+          port: ${toString cfg.cloud.port}
+          authToken: $_token
+          tls:
+            disabled: false
+        group: ${cfg.cloud.group}
+        tags: []
+      INSTANCEEOF
+              /usr/sbin/chown ${user}:${group} "$_instance_yml"
+              echo "${ts} [INFO] Fleet enrollment config written"
+            fi
+
+            # ── 5. Clean up stale cribl ACLs (one-time, idempotent) ───────────────────
+            _acl="cribl allow read,readattr,readextattr,readsecurity,list,search"
+            for _p in /var/log /var/log/asl /var/log/DiagnosticMessages /var/audit /Library/Logs /Library/Logs/DiagnosticReports; do
+              if [ -e "$_p" ]; then
+                /bin/chmod -a "$_acl" "$_p" 2>/dev/null || true
+              fi
+            done
+
+            # ── 6. Deploy packs ───────────────────────────────────────────────────────
+            ${lib.optionalString (cfg.packs != { }) ''
+              _packs_changed=0
+              ${lib.concatStringsSep "\n" (
+                lib.mapAttrsToList (name: src: ''
+                  _result=$(${deployPack}/bin/cribl-deploy-pack "${name}" "${src}" "${path}")
+                  if [ "$_result" != "unchanged" ]; then
+                    _packs_changed=1
+                    echo "${ts} [INFO] Cribl Edge pack ${name}: $_result"
+                  fi
+                '') cfg.packs
+              )}
+              if [ "$_packs_changed" -eq 1 ]; then
+                echo "${ts} [INFO] Packs updated"
+              fi
+            ''}
+
+            # ── 7. Start service ──────────────────────────────────────────────────────
+            /bin/launchctl kickstart system/com.nix-darwin.cribl-edge 2>/dev/null || true
+            echo "${ts} [INFO] Cribl Edge service started"
     '';
 
     launchd.daemons.cribl-edge = {

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -5,11 +5,11 @@
 # which gets overwritten on every upgrade — this module removes it and replaces it
 # with a Nix-managed service definition.
 #
-# This module manages: binary installation (via .pkg on every rebuild), LaunchDaemon
-# lifecycle, fleet enrollment config (fresh installs only), and pack deployment.
+# Installation uses Cribl Cloud's official install-edge.sh endpoint, which handles
+# binary download, .pkg installation, and fleet enrollment in one step.
 # Cribl Cloud manages all runtime configuration after enrollment.
 #
-# Service runs as root (temporary — revert user/group to cribl:cribl when ready).
+# Service runs as root (temporary — revert serviceUser/serviceGroup to cribl:cribl when ready).
 
 {
   lib,
@@ -20,61 +20,18 @@
 
 let
   cfg = config.programs.cribl-edge;
-  path = cfg.installPath;
-  user = "root";
-  group = "wheel";
-  major = builtins.head (builtins.splitString "-" cfg.version);
   ts = "$(date '+%Y-%m-%d %H:%M:%S')";
 
-  # Build a deploy script per pack — each invocation is idempotent
-  deployPack = pkgs.writeShellApplication {
+  activateScript = pkgs.writeShellApplication {
+    name = "cribl-edge-activate";
+    runtimeInputs = [ ];
+    text = builtins.readFile ./scripts/cribl-edge-activate.sh;
+  };
+
+  deployPackScript = pkgs.writeShellApplication {
     name = "cribl-deploy-pack";
     runtimeInputs = [ pkgs.jq ];
-    text = ''
-      PACK_NAME="$1"
-      PACK_SRC="$2"
-      CRIBL_PATH="$3"
-      STATUS="unchanged"
-
-      # Validate pack name (activation runs as root — prevent directory traversal)
-      case "$PACK_NAME" in
-        ""|*/*|*..*)
-          echo "Invalid pack name '$PACK_NAME': must be a simple basename" >&2
-          exit 1
-          ;;
-      esac
-
-      TARGET="$CRIBL_PATH/default/$PACK_NAME"
-      MARKER="$TARGET/.nix-store-path"
-
-      # Deploy if store path changed (stage to tmp dir, then atomic mv)
-      if [ ! -f "$MARKER" ] || [ "$(cat "$MARKER" 2>/dev/null)" != "$PACK_SRC" ]; then
-        STAGING="''${TARGET}.tmp.$$"
-        rm -rf "$STAGING" "$TARGET"
-        cp -R "$PACK_SRC" "$STAGING"
-        /usr/sbin/chown -R ${user}:${group} "$STAGING"
-        mv "$STAGING" "$TARGET"
-        echo "$PACK_SRC" > "$MARKER"
-        STATUS="deployed"
-      fi
-
-      # Register in package.json if missing (uses jq --arg to keep $CRIBL_HOME literal)
-      if [ -f "$CRIBL_PATH/package.json" ] && \
-         ! jq -e --arg n "$PACK_NAME" '.dependencies[$n]' "$CRIBL_PATH/package.json" >/dev/null 2>&1; then
-        jq --arg n "$PACK_NAME" --arg v 'file:$CRIBL_HOME/default/'"$PACK_NAME" \
-          '.dependencies |= ((if type == "object" then . else {} end) + {($n): $v})' \
-          "$CRIBL_PATH/package.json" > "$CRIBL_PATH/package.json.tmp"
-        mv "$CRIBL_PATH/package.json.tmp" "$CRIBL_PATH/package.json"
-        /usr/sbin/chown ${user}:${group} "$CRIBL_PATH/package.json"
-        if [ "$STATUS" = "unchanged" ]; then
-          STATUS="registered"
-        else
-          STATUS="$STATUS and registered"
-        fi
-      fi
-
-      echo "$STATUS"
-    '';
+    text = builtins.readFile ./scripts/cribl-edge-deploy-pack.sh;
   };
 in
 {
@@ -93,17 +50,29 @@ in
       example = "4.17.0-7e952fa7";
     };
 
+    serviceUser = lib.mkOption {
+      type = lib.types.str;
+      default = "root";
+      description = "User to run the Cribl Edge service as.";
+    };
+
+    serviceGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "wheel";
+      description = "Group to run the Cribl Edge service as.";
+    };
+
     cloud = {
-      host = lib.mkOption {
+      orgIdCommand = lib.mkOption {
         type = lib.types.str;
-        description = "Cribl Cloud leader hostname.";
-        example = "main-stoic-kaminsky-d9o9i3r.cribl.cloud";
+        description = "Shell command that outputs the Cribl Cloud org ID.";
+        example = "doppler secrets get CRIBL_ORG_ID --plain -p iac-conf-mgmt -c prd";
       };
 
-      port = lib.mkOption {
-        type = lib.types.port;
-        default = 4200;
-        description = "Cribl Cloud leader port.";
+      workspaceIdCommand = lib.mkOption {
+        type = lib.types.str;
+        description = "Shell command that outputs the Cribl Cloud workspace ID.";
+        example = "doppler secrets get CRIBL_WORKSPACE_ID --plain -p iac-conf-mgmt -c prd";
       };
 
       group = lib.mkOption {
@@ -114,7 +83,7 @@ in
 
       tokenCommand = lib.mkOption {
         type = lib.types.str;
-        description = "Shell command that outputs the auth token. Only used on fresh installs (when instance.yml does not exist).";
+        description = "Shell command that outputs the fleet auth token.";
         example = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
       };
     };
@@ -151,129 +120,51 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-            # ── 1. Download and install the .pkg ──────────────────────────────────────
-            _pkg_url="https://cdn.cribl.io/dl/${major}/cribl-${cfg.version}-darwin-universal.pkg"
-            _pkg=$(mktemp /tmp/cribl-${cfg.version}.XXXXXX.pkg)
-            trap 'rm -f "$_pkg" "$_pkg.md5"' EXIT
+      _org="$(${cfg.cloud.orgIdCommand})"
+      _ws="$(${cfg.cloud.workspaceIdCommand})"
+      _token="$(${cfg.cloud.tokenCommand})"
+      ${activateScript}/bin/cribl-edge-activate \
+        "''${_ws}-''${_org}.cribl.cloud" \
+        "${cfg.cloud.group}" "$_token" \
+        "${cfg.version}" "${cfg.installPath}" \
+        "${cfg.serviceUser}" "${cfg.serviceGroup}"
 
-            echo "${ts} [INFO] Installing Cribl Edge ${cfg.version}..."
-            if ! curl -LSsfo "$_pkg" "$_pkg_url"; then
-              echo "${ts} [ERROR] Failed to download Cribl Edge .pkg" >&2
-              exit 1
+      ${lib.optionalString (cfg.packs != { }) ''
+        _packs_changed=0
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: src: ''
+            _result=$(${deployPackScript}/bin/cribl-deploy-pack \
+              "${name}" "${src}" "${cfg.installPath}" \
+              "${cfg.serviceUser}" "${cfg.serviceGroup}")
+            if [ "$_result" != "unchanged" ]; then
+              _packs_changed=1
+              echo "${ts} [INFO] Cribl Edge pack ${name}: $_result"
             fi
-            if curl -LSsfo "$_pkg.md5" "$_pkg_url.md5"; then
-              _expected=$(awk '{print $1}' "$_pkg.md5")
-              _actual=$(md5 -q "$_pkg")
-              if [ "$_expected" != "$_actual" ]; then
-                echo "${ts} [ERROR] Cribl .pkg checksum mismatch (expected=$_expected actual=$_actual)" >&2
-                rm -f "$_pkg" "$_pkg.md5"
-                exit 1
-              fi
-            else
-              echo "${ts} [WARN] Could not fetch .md5 — skipping checksum verification"
-            fi
-
-            # Stop Nix-managed service before installing
-            /bin/launchctl bootout system/com.nix-darwin.cribl-edge 2>/dev/null || true
-
-            if ! installer -pkg "$_pkg" -target /; then
-              echo "${ts} [ERROR] Cribl .pkg installation failed" >&2
-              rm -f "$_pkg" "$_pkg.md5"
-              exit 1
-            fi
-
-            # Installer auto-starts its own plist — tear it down, Nix manages the service
-            /bin/launchctl bootout system/io.cribl 2>/dev/null || true
-            rm -f /Library/LaunchDaemons/io.cribl.plist "$_pkg" "$_pkg.md5"
-            echo "${ts} [INFO] Cribl Edge ${cfg.version} installed"
-
-            # ── 2. Ownership ──────────────────────────────────────────────────────────
-            /usr/sbin/chown -R ${user}:${group} "${path}"
-
-            # ── 3. Remove cribl user/group ────────────────────────────────────────────
-            if /usr/bin/dscl . -read /Users/cribl >/dev/null 2>&1; then
-              /usr/bin/dscl . -delete /Users/cribl 2>/dev/null || true
-              echo "${ts} [INFO] Removed cribl user (service now runs as root)"
-            fi
-            if /usr/bin/dscl . -read /Groups/cribl >/dev/null 2>&1; then
-              /usr/bin/dscl . -delete /Groups/cribl 2>/dev/null || true
-              echo "${ts} [INFO] Removed cribl group"
-            fi
-
-            # ── 4. Fleet enrollment (fresh installs only) ─────────────────────────────
-            _instance_yml="${path}/local/_system/instance.yml"
-            if [ ! -f "$_instance_yml" ]; then
-              echo "${ts} [INFO] Writing fleet enrollment config..."
-              mkdir -p "${path}/local/_system"
-              _token=$(eval "${cfg.cloud.tokenCommand}") || {
-                echo "${ts} [ERROR] Failed to fetch Cribl auth token" >&2
-                exit 1
-              }
-              cat > "$_instance_yml" <<INSTANCEEOF
-      distributed:
-        mode: managed-edge
-        master:
-          host: ${cfg.cloud.host}
-          port: ${toString cfg.cloud.port}
-          authToken: $_token
-          tls:
-            disabled: false
-        group: ${cfg.cloud.group}
-        tags: []
-      INSTANCEEOF
-              /usr/sbin/chown ${user}:${group} "$_instance_yml"
-              echo "${ts} [INFO] Fleet enrollment config written"
-            fi
-
-            # ── 5. Clean up stale cribl ACLs (one-time, idempotent) ───────────────────
-            _acl="cribl allow read,readattr,readextattr,readsecurity,list,search"
-            for _p in /var/log /var/log/asl /var/log/DiagnosticMessages /var/audit /Library/Logs /Library/Logs/DiagnosticReports; do
-              if [ -e "$_p" ]; then
-                /bin/chmod -a "$_acl" "$_p" 2>/dev/null || true
-              fi
-            done
-
-            # ── 6. Deploy packs ───────────────────────────────────────────────────────
-            ${lib.optionalString (cfg.packs != { }) ''
-              _packs_changed=0
-              ${lib.concatStringsSep "\n" (
-                lib.mapAttrsToList (name: src: ''
-                  _result=$(${deployPack}/bin/cribl-deploy-pack "${name}" "${src}" "${path}")
-                  if [ "$_result" != "unchanged" ]; then
-                    _packs_changed=1
-                    echo "${ts} [INFO] Cribl Edge pack ${name}: $_result"
-                  fi
-                '') cfg.packs
-              )}
-              if [ "$_packs_changed" -eq 1 ]; then
-                echo "${ts} [INFO] Packs updated"
-              fi
-            ''}
-
-            # bootout (step 1) removed the job from the bootstrap context;
-            # re-bootstrap the plist so kickstart can find the service.
-            /bin/launchctl bootstrap system /Library/LaunchDaemons/com.nix-darwin.cribl-edge.plist 2>/dev/null || true
-            /bin/launchctl kickstart system/com.nix-darwin.cribl-edge 2>/dev/null || true
-            echo "${ts} [INFO] Cribl Edge service started"
+          '') cfg.packs
+        )}
+        if [ "$_packs_changed" -eq 1 ]; then
+          echo "${ts} [INFO] Packs updated"
+        fi
+      ''}
     '';
 
     launchd.daemons.cribl-edge = {
       serviceConfig = {
         Label = "com.nix-darwin.cribl-edge";
         ProgramArguments = [
-          "${path}/bin/cribl"
+          "${cfg.installPath}/bin/cribl"
           "server"
         ];
         RunAtLoad = true;
         KeepAlive = true;
         ThrottleInterval = 10;
-        UserName = user;
-        GroupName = group;
-        WorkingDirectory = path;
-        StandardOutPath = "${path}/log/cribl-stdout.log";
-        StandardErrorPath = "${path}/log/cribl-stderr.log";
+        UserName = cfg.serviceUser;
+        GroupName = cfg.serviceGroup;
+        WorkingDirectory = cfg.installPath;
+        StandardOutPath = "${cfg.installPath}/log/cribl-stdout.log";
+        StandardErrorPath = "${cfg.installPath}/log/cribl-stderr.log";
         EnvironmentVariables = {
-          CRIBL_HOME = path;
+          CRIBL_HOME = cfg.installPath;
         };
       };
     };

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -154,14 +154,15 @@ in
             _major="${cfg.version}"
             _major="''${_major%%-*}"
             _pkg_url="https://cdn.cribl.io/dl/$_major/cribl-${cfg.version}-darwin-universal.pkg"
-            _pkg="/tmp/cribl-${cfg.version}.pkg"
+            _pkg=$(mktemp /tmp/cribl-${cfg.version}.XXXXXX.pkg)
+            trap 'rm -f "$_pkg" "$_pkg.md5"' EXIT
 
             echo "${ts} [INFO] Installing Cribl Edge ${cfg.version}..."
-            if ! curl -Lso "$_pkg" "$_pkg_url"; then
+            if ! curl -LSsfo "$_pkg" "$_pkg_url"; then
               echo "${ts} [ERROR] Failed to download Cribl Edge .pkg" >&2
               exit 1
             fi
-            if curl -Lso "$_pkg.md5" "$_pkg_url.md5"; then
+            if curl -LSsfo "$_pkg.md5" "$_pkg_url.md5"; then
               _expected=$(awk '{print $1}' "$_pkg.md5")
               _actual=$(md5 -q "$_pkg")
               if [ "$_expected" != "$_actual" ]; then
@@ -250,7 +251,10 @@ in
               fi
             ''}
 
-            # ── 7. Start service ──────────────────────────────────────────────────────
+            # ── 7. Re-bootstrap and start service ────────────────────────────────────
+            # bootout (step 1) removed the job from the bootstrap context;
+            # re-bootstrap the plist so kickstart can find the service.
+            /bin/launchctl bootstrap system /Library/LaunchDaemons/com.nix-darwin.cribl-edge.plist 2>/dev/null || true
             /bin/launchctl kickstart system/com.nix-darwin.cribl-edge 2>/dev/null || true
             echo "${ts} [INFO] Cribl Edge service started"
     '';

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -23,6 +23,7 @@ let
   path = cfg.installPath;
   user = "root";
   group = "wheel";
+  major = builtins.head (builtins.splitString "-" cfg.version);
   ts = "$(date '+%Y-%m-%d %H:%M:%S')";
 
   # Build a deploy script per pack — each invocation is idempotent
@@ -151,9 +152,7 @@ in
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
             # ── 1. Download and install the .pkg ──────────────────────────────────────
-            _major="${cfg.version}"
-            _major="''${_major%%-*}"
-            _pkg_url="https://cdn.cribl.io/dl/$_major/cribl-${cfg.version}-darwin-universal.pkg"
+            _pkg_url="https://cdn.cribl.io/dl/${major}/cribl-${cfg.version}-darwin-universal.pkg"
             _pkg=$(mktemp /tmp/cribl-${cfg.version}.XXXXXX.pkg)
             trap 'rm -f "$_pkg" "$_pkg.md5"' EXIT
 
@@ -251,7 +250,6 @@ in
               fi
             ''}
 
-            # ── 7. Re-bootstrap and start service ────────────────────────────────────
             # bootout (step 1) removed the job from the bootstrap context;
             # re-bootstrap the plist so kickstart can find the service.
             /bin/launchctl bootstrap system /Library/LaunchDaemons/com.nix-darwin.cribl-edge.plist 2>/dev/null || true

--- a/modules/darwin/apps/scripts/cribl-edge-activate.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-activate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# cribl-edge-activate.sh - Install Cribl Edge via the Cribl Cloud install script
+#
+# Uses the official Cribl install-edge.sh endpoint which handles:
+# - Binary download and installation via .pkg
+# - Fleet enrollment (writes instance.yml)
+# - Version management
+#
+# Arguments:
+#   $1 - Cloud host (e.g., "main-orgid.cribl.cloud")
+#   $2 - Fleet group name (e.g., "default_fleet")
+#   $3 - Auth token
+#   $4 - Version string (e.g., "4.17.0-7e952fa7")
+#   $5 - Install path (e.g., "/opt/cribl")
+#   $6 - Service user (e.g., "root")
+#   $7 - Service group (e.g., "wheel")
+#
+# Exit codes:
+#   0 - Installation successful
+#   1 - Installation failed
+
+CLOUD_HOST="$1"
+FLEET_GROUP="$2"
+TOKEN="$3"
+VERSION="$4"
+INSTALL_PATH="$5"
+SERVICE_USER="$6"
+SERVICE_GROUP="$7"
+
+TS="$(date '+%Y-%m-%d %H:%M:%S')"
+
+INSTALL_URL="https://${CLOUD_HOST}/init/install-edge.sh?group=${FLEET_GROUP}&token=${TOKEN}&user=${SERVICE_USER}&user_group=${SERVICE_GROUP}&version=${VERSION}"
+
+# Stop Nix-managed service before install
+/bin/launchctl bootout system/com.nix-darwin.cribl-edge 2>/dev/null || true
+
+# Use Cribl Cloud's official install script
+echo "${TS} [INFO] Installing Cribl Edge ${VERSION}..."
+curl -fsSL "${INSTALL_URL}" | bash -
+
+# Installer drops its own plist — tear it down, Nix manages the service
+/bin/launchctl bootout system/io.cribl 2>/dev/null || true
+rm -f /Library/LaunchDaemons/io.cribl.plist
+echo "${TS} [INFO] Cribl Edge ${VERSION} installed"
+
+# Fix ownership
+/usr/sbin/chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "${INSTALL_PATH}"
+
+# Remove cribl user/group if present (created by pkg, not needed when running as root)
+if /usr/bin/dscl . -read /Users/cribl >/dev/null 2>&1; then
+  /usr/bin/dscl . -delete /Users/cribl 2>/dev/null || true
+  echo "${TS} [INFO] Removed cribl user (service runs as root)"
+fi
+if /usr/bin/dscl . -read /Groups/cribl >/dev/null 2>&1; then
+  /usr/bin/dscl . -delete /Groups/cribl 2>/dev/null || true
+  echo "${TS} [INFO] Removed cribl group"
+fi
+
+# Clean up stale cribl ACLs from previous user-based install (idempotent)
+ACL="cribl allow read,readattr,readextattr,readsecurity,list,search"
+for p in /var/log /var/log/asl /var/log/DiagnosticMessages /var/audit /Library/Logs /Library/Logs/DiagnosticReports; do
+  [ -e "$p" ] && /bin/chmod -a "$ACL" "$p" 2>/dev/null || true
+done
+
+# Re-bootstrap plist (bootout above removed it from bootstrap context)
+# and start the Nix-managed service
+/bin/launchctl bootstrap system /Library/LaunchDaemons/com.nix-darwin.cribl-edge.plist 2>/dev/null || true
+/bin/launchctl kickstart system/com.nix-darwin.cribl-edge 2>/dev/null || true
+echo "${TS} [INFO] Cribl Edge service started"

--- a/modules/darwin/apps/scripts/cribl-edge-deploy-pack.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-deploy-pack.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# cribl-edge-deploy-pack.sh - Deploy a Cribl Edge pack idempotently
+#
+# Copies a pack from the Nix store to the Cribl Edge packs directory,
+# registers it in package.json if missing, and reports deployment status.
+#
+# Arguments:
+#   $1 - Pack name (simple basename, no slashes — validated)
+#   $2 - Pack source path (Nix store derivation)
+#   $3 - Cribl install path (e.g., "/opt/cribl")
+#   $4 - Service user
+#   $5 - Service group
+#
+# Output (stdout): "unchanged" | "deployed" | "registered" | "deployed and registered"
+# Exit codes:
+#   0 - Success
+#   1 - Invalid pack name
+
+PACK_NAME="$1"
+PACK_SRC="$2"
+CRIBL_PATH="$3"
+SERVICE_USER="$4"
+SERVICE_GROUP="$5"
+STATUS="unchanged"
+
+# Validate pack name (activation runs as root — prevent directory traversal)
+case "$PACK_NAME" in
+  ""|*/*|*..*)
+    echo "Invalid pack name '$PACK_NAME': must be a simple basename" >&2
+    exit 1
+    ;;
+esac
+
+TARGET="$CRIBL_PATH/default/$PACK_NAME"
+MARKER="$TARGET/.nix-store-path"
+
+# Deploy if store path changed (stage to tmp dir, then atomic mv)
+if [ ! -f "$MARKER" ] || [ "$(cat "$MARKER" 2>/dev/null)" != "$PACK_SRC" ]; then
+  STAGING="${TARGET}.tmp.$$"
+  rm -rf "$STAGING" "$TARGET"
+  cp -R "$PACK_SRC" "$STAGING"
+  /usr/sbin/chown -R "$SERVICE_USER:$SERVICE_GROUP" "$STAGING"
+  mv "$STAGING" "$TARGET"
+  echo "$PACK_SRC" > "$MARKER"
+  STATUS="deployed"
+fi
+
+# Register in package.json if missing (uses jq --arg to keep $CRIBL_HOME literal)
+if [ -f "$CRIBL_PATH/package.json" ] && \
+   ! jq -e --arg n "$PACK_NAME" '.dependencies[$n]' "$CRIBL_PATH/package.json" >/dev/null 2>&1; then
+  jq --arg n "$PACK_NAME" --arg v "file:\$CRIBL_HOME/default/$PACK_NAME" \
+    '.dependencies |= ((if type == "object" then . else {} end) + {($n): $v})' \
+    "$CRIBL_PATH/package.json" > "$CRIBL_PATH/package.json.tmp"
+  mv "$CRIBL_PATH/package.json.tmp" "$CRIBL_PATH/package.json"
+  /usr/sbin/chown "$SERVICE_USER:$SERVICE_GROUP" "$CRIBL_PATH/package.json"
+  if [ "$STATUS" = "unchanged" ]; then
+    STATUS="registered"
+  else
+    STATUS="$STATUS and registered"
+  fi
+fi
+
+echo "$STATUS"

--- a/renovate.json5
+++ b/renovate.json5
@@ -27,6 +27,28 @@
     "enabled": true
   },
 
+  // Custom datasource: Cribl Edge CDN version feed
+  // https://cdn.cribl.io/versions.json → {"version":"4.17.0-7e952fa7",...}
+  "customDatasources": {
+    "cribl-edge": {
+      "defaultRegistryUrlTemplate": "https://cdn.cribl.io/versions.json",
+      "format": "json",
+      "transformTemplates": ["{\"releases\":[{\"version\":value.version}]}"]
+    }
+  },
+
+  // Custom regex manager: track Cribl Edge version in host config
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["hosts/macbook-m4/default\\.nix$"],
+      "matchStrings": ["version = \"(?<currentValue>[^\"]+)\"; # cribl-edge"],
+      "depNameTemplate": "cribl-edge",
+      "datasourceTemplate": "custom.cribl-edge",
+      "versioningTemplate": "loose"
+    }
+  ],
+
   // Package grouping and scheduling strategy
   "packageRules": [
     // GROUP 1: Critical infrastructure (Daily 7am with automerge)
@@ -67,6 +89,16 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "schedule": ["after 7am on Monday"]
+    },
+
+    // GROUP 4: Cribl Edge - Weekly Monday 7am
+    {
+      "description": "Cribl Edge version - weekly at 7am Monday",
+      "matchDatasources": ["custom.cribl-edge"],
+      "groupName": "cribl-edge",
+      "schedule": ["after 7am on Monday"],
+      "commitMessageTopic": "Cribl Edge",
+      "commitMessageExtra": "to {{newVersion}}"
     }
   ],
 


### PR DESCRIPTION
# Cribl Edge Declarative Management + Renovate Tracking

## Summary

This PR adds declarative Cribl Edge management to nix-darwin with automated
version tracking. The new `cribl-edge` module downloads and installs Cribl Edge
as a LaunchDaemon that runs as root:wheel, handles fleet enrollment
idempotently, and deploys Cribl packs declaratively. Version bumps are now
tracked automatically via Renovate.

## Changes

1. **New `modules/darwin/apps/cribl-edge.nix` module**:
   - Downloads and installs the darwin-universal `.pkg` on every rebuild
   - Service runs as `root:wheel` (temporary; revert `user`/`group` when ready)
   - `cribl` user and group deleted on every activation (idempotent, handles
     `.pkg` recreating them)
   - Fleet enrollment via new `cloud.*` options; `instance.yml` written only on
     fresh installs
   - Stale cribl ACLs cleaned up from previously monitored paths
   - `acls` option removed (root needs no ACLs)

2. **Updated `hosts/macbook-m4/default.nix`**:
   - Enables the module with `version`, cloud config, and packs options

3. **Updated `renovate.json5`**:
   - Custom datasource polling `cdn.cribl.io/versions.json`
   - Regex manager to track `version = "..."; # cribl-edge` in host config
   - Weekly automated version bump PRs when new releases are published

4. **Robustness improvements**:
   - `mktemp` + `trap` for race-free temp file handling
   - `curl -f` to fail on HTTP errors
   - Bootstrap before kickstart in LaunchDaemon lifecycle (re-add job to
     context after bootout)

## Test plan

- [ ] `darwin-rebuild switch --flake .` completes without error
- [ ] `sudo launchctl print system/com.nix-darwin.cribl-edge` shows
      `UserName = root`
- [ ] `/opt/cribl/bin/cribl version` outputs expected version
- [ ] `dscl . -read /Users/cribl` fails (user removed)
- [ ] Node appears online in Cribl Cloud default fleet
- [ ] Second `darwin-rebuild switch` is idempotent (reinstalls clean, no
      enrollment re-write)
- [ ] Verify Renovate config parses without errors
