### PR TITLE
fix(cribl-edge): use primaryUser for doppler access in activation

### DIFF
--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -120,6 +120,11 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
+      # Activation runs as root — extend PATH to include per-user Nix profiles
+      # so tools like doppler (in home.packages) are resolvable.
+      for _p in /etc/profiles/per-user/*/bin; do PATH="$_p:$PATH"; done
+      export PATH
+
       _org="$(${cfg.cloud.orgIdCommand})"
       _ws="$(${cfg.cloud.workspaceIdCommand})"
       _token="$(${cfg.cloud.tokenCommand})"

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -120,10 +120,10 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      # Activation runs as root — extend PATH to include per-user Nix profiles
+      # Activation runs as root — extend PATH with the primary user's Nix profile
       # so tools like doppler (in home.packages) are resolvable.
-      for _p in /etc/profiles/per-user/*/bin; do PATH="$_p:$PATH"; done
-      export PATH
+      _profile_bin="/etc/profiles/per-user/${config.system.primaryUser}/bin"
+      if [ -d "$_profile_bin" ]; then PATH="$_profile_bin:$PATH"; export PATH; fi
 
       _org="$(${cfg.cloud.orgIdCommand})"
       _ws="$(${cfg.cloud.workspaceIdCommand})"


### PR DESCRIPTION
# Fix Cribl Edge Activation Script

## Summary

Fixes activation script failure when provisioning Cribl Edge nodes via declarative
NixOS configuration.

The activation script runs as root with a sanitized PATH that excludes per-user Nix
profiles. `doppler` is installed in `home.packages` (home-manager managed), making it
inaccessible during activation. This caused the three secret-fetch commands to return
empty strings, producing malformed installation URLs like `https://-.cribl.cloud/...`
and subsequent DNS failures.

## Changes

- Extend `PATH` in `postActivation` to include `/etc/profiles/per-user/*/bin` before
  running secret-fetch commands
- Use `config.system.primaryUser` with existence check instead of globbing all users
  (security improvement: avoids executing commands with secrets across multiple user
  profiles)
- Allows doppler access from home.packages during root-privilege activation
- Maintains zero-trust: secrets only flow through the intended primary user's profile

## Test Plan

- [ ] `darwin-rebuild switch` completes successfully with Cribl Edge service
      installing
- [ ] Cribl Cloud UI displays node as online in correct fleet group
- [ ] `sudo launchctl print system/com.nix-darwin.cribl-edge` shows running service
- [ ] No extraneous user profiles are executed
