### PR TITLE
fix(cribl-edge): run secret-fetch commands as primaryUser

### DIFF
--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -122,9 +122,9 @@ in
     system.activationScripts.postActivation.text = lib.mkAfter ''
       # Activation runs as root — run secret-fetch commands as the primary user
       # so tools like doppler find their auth token in the user's home directory.
-      _org="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.orgIdCommand}')"
-      _ws="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.workspaceIdCommand}')"
-      _token="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.tokenCommand}')"
+      _org="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
+      _ws="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
+      _token="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -120,14 +120,11 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      # Activation runs as root — extend PATH with the primary user's Nix profile
-      # so tools like doppler (in home.packages) are resolvable.
-      _profile_bin="/etc/profiles/per-user/${config.system.primaryUser}/bin"
-      if [ -d "$_profile_bin" ]; then PATH="$_profile_bin:$PATH"; export PATH; fi
-
-      _org="$(${cfg.cloud.orgIdCommand})"
-      _ws="$(${cfg.cloud.workspaceIdCommand})"
-      _token="$(${cfg.cloud.tokenCommand})"
+      # Activation runs as root — run secret-fetch commands as the primary user
+      # so tools like doppler find their auth token in the user's home directory.
+      _org="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.orgIdCommand}')"
+      _ws="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.workspaceIdCommand}')"
+      _token="$(su -l ${config.system.primaryUser} -c '${cfg.cloud.tokenCommand}')"
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \


### PR DESCRIPTION
## Summary

- Doppler stores its auth token in the user's home directory (`~/.config/doppler/`)
- Running secret-fetch commands as root causes doppler to look in `/var/root/.config/doppler/` where no token exists → `Doppler Error: you must provide a token`
- The previous fix (PATH extension) solved the binary lookup but not the auth context

## Changes

- Wrap each secret-fetch command in `su -l <primaryUser> -c '...'` so doppler runs with the user's HOME and PATH
- Use `lib.escapeShellArg` to safely escape command arguments passed to `su -c`
- Reference `/usr/bin/su` by absolute path for clarity and to avoid PATH surprises in activation scripts
- Replaces the PATH extension block (no longer needed — `su -l` sets up the full user environment)

## Test Plan

- [ ] `darwin-rebuild switch` completes without `Doppler Error: you must provide a token`
- [ ] Cribl Edge installs and enrolls in fleet
- [ ] `sudo launchctl print system/com.nix-darwin.cribl-edge` shows running service
