### PR TITLE
fix(cribl-edge): replace Doppler CLI with sops-nix for root-safe secrets

### DIFF
--- a/.readme-validator.yaml
+++ b/.readme-validator.yaml
@@ -1,0 +1,12 @@
+# README validator config for the repo root README.
+# The README uses "Quick Start" and "What It Manages" instead of the generic
+# defaults ("Installation", "Usage"). Override here to match actual structure.
+required_sections:
+  - What Is This
+  - Quick Start
+  - What It Manages
+optional_sections:
+  - Contributing
+  - License
+  - API
+  - Secrets Management

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -4,6 +4,8 @@
 # Edit: sops <file>
 
 creation_rules:
+  - path_regex: ^secrets/.*\.yaml$
+    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"
   - path_regex: \.sops\.json$
     age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"
   - path_regex: \.sops\.yaml$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,4 +110,11 @@ and on-demand patterns.
 
 ## Secrets
 
-Secrets managed via Bitwarden Secrets Manager — never hardcode credentials or tokens.
+**sops-nix** handles secrets that system activation scripts need (e.g. service enrollment
+tokens for LaunchDaemons). Age-encrypted YAML files live in `secrets/` and are committed to
+git. sops-nix decrypts them to root-only files under `/run/secrets/` at activation time.
+The age private key stays at `~/.config/sops/age/keys.txt` and is never committed.
+
+**Doppler** is used for general developer secrets (API keys, service credentials) accessed
+from the user session. Never use Doppler CLI from within nix-darwin activation scripts —
+activation runs as root without Keychain access. Use sops-nix instead.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ Full details in [ARCHITECTURE.md](ARCHITECTURE.md).
 | **mac-app-util** | Stable app trampolines to preserve TCC permissions |
 | **[nix-ai](https://github.com/JacobPEvans/nix-ai)** | Shared home-manager modules for AI tools (Claude, Gemini, Copilot, MCP) |
 | **[nix-home](https://github.com/JacobPEvans/nix-home)** | Shared home-manager modules for dev environment (git, zsh, VS Code, tmux) |
+| **sops-nix** | Decrypts age-encrypted secrets to `/run/secrets/` for system services |
+
+## Secrets Management
+
+System-level secrets (used by LaunchDaemons and activation scripts) are managed via
+**[sops-nix](https://github.com/Mic92/sops-nix)**. Encrypted YAML files live in `secrets/`
+and are safe to commit. The age private key (`~/.config/sops/age/keys.txt`) is generated
+once per machine and never committed.
+
+**Doppler** is used for developer credentials accessed in the user session (Terraform state,
+API tokens, etc.). Doppler CLI requires Keychain and cannot be called from activation scripts
+(which run as root). sops-nix handles that boundary.
 
 This repo is the **orchestrator**: it pulls in `nix-ai` and `nix-home` as flake inputs
 and wires their `homeManagerModules.default` into the shared home-manager configuration.

--- a/flake.lock
+++ b/flake.lock
@@ -767,7 +767,28 @@
         "nix-home": "nix-home",
         "nixpkgs": "nixpkgs_3",
         "pal-mcp-server": "pal-mcp-server",
+        "sops-nix": "sops-nix",
         "systems": "systems"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776119890,
+        "narHash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "superpowers-marketplace": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,13 @@
     # Updates tracked by deps-update-flake.yml (daily nix flake update) + Renovate
     determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
 
+    # sops-nix: declarative secret management — decrypts age-encrypted secrets
+    # to root-only files in /run/secrets at activation time
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =
@@ -98,6 +105,7 @@
       nix-ai,
       nix-home,
       determinate,
+      sops-nix,
       ...
     }:
     let
@@ -138,6 +146,9 @@
 
             # Determinate Nix: official module for nix.conf, GC, and determinate-nixd config
             determinate.darwinModules.default
+
+            # sops-nix: decrypts age-encrypted secrets to /run/secrets at activation
+            sops-nix.darwinModules.sops
 
             # mac-app-util: Creates trampolines for system-level apps (/Applications/Nix Apps/)
             mac-app-util.darwinModules.default

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -5,7 +5,7 @@
 #
 # This file imports darwin modules and configures host-specific settings.
 
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 let
   # User-specific configuration (hostname, identity, etc.)
@@ -79,9 +79,7 @@ in
       enable = true;
       version = "4.17.0-7e952fa7"; # cribl-edge
       cloud = {
-        orgIdCommand = "doppler secrets get CRIBL_ORG_ID --plain -p iac-conf-mgmt -c prd";
-        workspaceIdCommand = "doppler secrets get CRIBL_WORKSPACE_ID --plain -p iac-conf-mgmt -c prd";
-        tokenCommand = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
+        secretsFile = config.sops.templates."cribl-edge.env".path;
       };
       packs = {
         cc-edge-the-mac-pack-io = pkgs.fetchzip {

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -85,7 +85,7 @@ in
         cc-edge-the-mac-pack-io = pkgs.fetchzip {
           url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl";
           extension = "tar.gz";
-          hash = pkgs.lib.fakeHash;
+          hash = "sha256-QPVZA4Cvi5uSOiNMyC9dW5fhRTeaQGZm5MEgNkwDryU=";
           stripRoot = false;
         };
       };

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -120,11 +120,15 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      # Activation runs as root — run secret-fetch commands as the primary user
-      # so tools like doppler find their auth token in the user's home directory.
-      _org="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
-      _ws="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
-      _token="$(/usr/bin/su -l ${lib.escapeShellArg config.system.primaryUser} -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
+      # Activation runs as root — run secret-fetch commands in the primary user's
+      # existing launchd session so the macOS Keychain (used by doppler) is
+      # accessible. `su` creates a new session without keychain access;
+      # `launchctl asuser <uid>` runs in the user's live session where the
+      # keychain is already unlocked.
+      _uid="$(/usr/bin/id -u ${lib.escapeShellArg config.system.primaryUser})"
+      _org="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
+      _ws="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
+      _token="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -126,9 +126,9 @@ in
       # `launchctl asuser <uid>` runs in the user's live session where the
       # keychain is already unlocked.
       _uid="$(/usr/bin/id -u ${lib.escapeShellArg config.system.primaryUser})"
-      _org="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
-      _ws="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
-      _token="$(launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
+      _org="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
+      _ws="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
+      _token="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -9,6 +9,10 @@
 # binary download, .pkg installation, and fleet enrollment in one step.
 # Cribl Cloud manages all runtime configuration after enrollment.
 #
+# Secrets are provided via sops-nix (modules/darwin/sops.nix), which decrypts
+# age-encrypted credentials to a root-only KEY=value file at activation time.
+# This avoids bridging root activation into the user Keychain.
+#
 # Service runs as root (temporary — revert serviceUser/serviceGroup to cribl:cribl when ready).
 
 {
@@ -33,6 +37,21 @@ let
     runtimeInputs = [ pkgs.jq ];
     text = builtins.readFile ./scripts/cribl-edge-deploy-pack.sh;
   };
+
+  # Read a KEY=value pair from a secrets file without sourcing it (no shell eval).
+  readSecret = ''
+    _read_secret() {
+      _key="$1"
+      /usr/bin/awk -v key="$_key" '
+        index($0, key "=") == 1 {
+          print substr($0, length(key) + 2)
+          found = 1
+          exit
+        }
+        END { if (!found) exit 1 }
+      ' "${lib.escapeShellArg cfg.cloud.secretsFile}"
+    }
+  '';
 in
 {
   options.programs.cribl-edge = {
@@ -63,28 +82,20 @@ in
     };
 
     cloud = {
-      orgIdCommand = lib.mkOption {
+      secretsFile = lib.mkOption {
         type = lib.types.str;
-        description = "Shell command that outputs the Cribl Cloud org ID.";
-        example = "doppler secrets get CRIBL_ORG_ID --plain -p iac-conf-mgmt -c prd";
-      };
-
-      workspaceIdCommand = lib.mkOption {
-        type = lib.types.str;
-        description = "Shell command that outputs the Cribl Cloud workspace ID.";
-        example = "doppler secrets get CRIBL_WORKSPACE_ID --plain -p iac-conf-mgmt -c prd";
+        description = ''
+          Path to a root-readable KEY=value file containing CRIBL_ORG_ID,
+          CRIBL_WORKSPACE_ID, and CRIBL_TOKEN. Use the sops-nix rendered
+          template: config.sops.templates."cribl-edge.env".path
+        '';
+        example = "/run/secrets/rendered/cribl-edge.env";
       };
 
       group = lib.mkOption {
         type = lib.types.str;
         default = "default_fleet";
         description = "Fleet group name.";
-      };
-
-      tokenCommand = lib.mkOption {
-        type = lib.types.str;
-        description = "Shell command that outputs the fleet auth token.";
-        example = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
       };
     };
 
@@ -119,17 +130,27 @@ in
       fi
     '';
 
-    system.activationScripts.postActivation.text = lib.mkAfter ''
-      # Activation runs as root — fetch secrets in the primary user's live
-      # launchd session with their UID so the macOS Keychain is accessible.
-      # `launchctl asuser <uid>` puts the process in the user's bootstrap/audit
-      # session (required for Keychain), but does NOT change the UID. Pairing
-      # it with `sudo -u <user> -H` drops from root to the user's UID and sets
-      # HOME, which is what Keychain actually uses for access control.
-      _uid="$(/usr/bin/id -u ${lib.escapeShellArg config.system.primaryUser})"
-      _org="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
-      _ws="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
-      _token="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
+    # Run at order 1600 — after sops-nix postActivation (mkAfter = 1500) so that
+    # the decrypted secrets file exists before we try to read it.
+    system.activationScripts.postActivation.text = lib.mkOrder 1600 ''
+      _secrets="${lib.escapeShellArg cfg.cloud.secretsFile}"
+      if [ ! -r "$_secrets" ]; then
+        echo "${ts} [ERROR] Cribl secrets file not readable: $_secrets" >&2
+        exit 1
+      fi
+
+      ${readSecret}
+
+      _org="$(_read_secret CRIBL_ORG_ID)" || {
+        echo "${ts} [ERROR] Missing CRIBL_ORG_ID in $_secrets" >&2; exit 1
+      }
+      _ws="$(_read_secret CRIBL_WORKSPACE_ID)" || {
+        echo "${ts} [ERROR] Missing CRIBL_WORKSPACE_ID in $_secrets" >&2; exit 1
+      }
+      _token="$(_read_secret CRIBL_TOKEN)" || {
+        echo "${ts} [ERROR] Missing CRIBL_TOKEN in $_secrets" >&2; exit 1
+      }
+
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -120,15 +120,16 @@ in
     '';
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      # Activation runs as root — run secret-fetch commands in the primary user's
-      # existing launchd session so the macOS Keychain (used by doppler) is
-      # accessible. `su` creates a new session without keychain access;
-      # `launchctl asuser <uid>` runs in the user's live session where the
-      # keychain is already unlocked.
+      # Activation runs as root — fetch secrets in the primary user's live
+      # launchd session with their UID so the macOS Keychain is accessible.
+      # `launchctl asuser <uid>` puts the process in the user's bootstrap/audit
+      # session (required for Keychain), but does NOT change the UID. Pairing
+      # it with `sudo -u <user> -H` drops from root to the user's UID and sets
+      # HOME, which is what Keychain actually uses for access control.
       _uid="$(/usr/bin/id -u ${lib.escapeShellArg config.system.primaryUser})"
-      _org="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
-      _ws="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
-      _token="$(/bin/launchctl asuser "$_uid" /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
+      _org="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.orgIdCommand})"
+      _ws="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.workspaceIdCommand})"
+      _token="$(/bin/launchctl asuser "$_uid" /usr/bin/sudo -u ${lib.escapeShellArg config.system.primaryUser} -H /bin/sh -l -c ${lib.escapeShellArg cfg.cloud.tokenCommand})"
       ${activateScript}/bin/cribl-edge-activate \
         "''${_ws}-''${_org}.cribl.cloud" \
         "${cfg.cloud.group}" "$_token" \

--- a/modules/darwin/apps/scripts/cribl-edge-activate.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-activate.sh
@@ -29,14 +29,31 @@ SERVICE_GROUP="$7"
 
 TS="$(date '+%Y-%m-%d %H:%M:%S')"
 
-INSTALL_URL="https://${CLOUD_HOST}/init/install-edge.sh?group=${FLEET_GROUP}&token=${TOKEN}&user=${SERVICE_USER}&user_group=${SERVICE_GROUP}&version=${VERSION}"
-
 # Stop Nix-managed service before install
 /bin/launchctl bootout system/com.nix-darwin.cribl-edge 2>/dev/null || true
 
-# Use Cribl Cloud's official install script
+# Use Cribl Cloud's official install script.
+# URL is passed via curl --config stdin (not a command-line arg) to keep the
+# enrollment token out of process listings.
+# Script is downloaded to a temp file first so we can do a basic sanity check
+# before executing. Cribl's install script is dynamically generated per request
+# (embeds enrollment params), so no pre-computed hash is available.
 echo "${TS} [INFO] Installing Cribl Edge ${VERSION}..."
-curl -fsSL "${INSTALL_URL}" | bash -
+_tmpscript=$(mktemp /tmp/cribl-install-XXXXXX.sh)
+trap 'rm -f "$_tmpscript"' EXIT
+curl --config - --output "$_tmpscript" << CURL_EOF
+url = "https://${CLOUD_HOST}/init/install-edge.sh?group=${FLEET_GROUP}&token=${TOKEN}&user=${SERVICE_USER}&user_group=${SERVICE_GROUP}&version=${VERSION}"
+fail
+silent
+show-error
+location
+CURL_EOF
+# Basic sanity: non-empty file with a shell shebang
+if [ ! -s "$_tmpscript" ] || ! head -1 "$_tmpscript" | grep -q '^#!'; then
+  echo "${TS} [ERROR] Downloaded Cribl install script looks invalid" >&2
+  exit 1
+fi
+bash "$_tmpscript"
 
 # Installer drops its own plist — tear it down, Nix manages the service
 /bin/launchctl bootout system/io.cribl 2>/dev/null || true

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -8,6 +8,7 @@ let
 in
 {
   imports = [
+    ./sops.nix
     ./apps
     ./dock
   ]

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -36,13 +36,13 @@ in
     secrets = {
       # Cribl Edge enrollment credentials
       # Source: secrets/cribl-edge.yaml (age-encrypted, committed to git)
-      "cribl/org-id" = rootOnly // {
+      CRIBL_ORG_ID = rootOnly // {
         sopsFile = ../../secrets/cribl-edge.yaml;
       };
-      "cribl/workspace-id" = rootOnly // {
+      CRIBL_WORKSPACE_ID = rootOnly // {
         sopsFile = ../../secrets/cribl-edge.yaml;
       };
-      "cribl/token" = rootOnly // {
+      CRIBL_TOKEN = rootOnly // {
         sopsFile = ../../secrets/cribl-edge.yaml;
       };
     };
@@ -51,9 +51,9 @@ in
     # consumed by the cribl-edge activation script via awk (no shell eval).
     templates."cribl-edge.env" = rootOnly // {
       content = ''
-        CRIBL_ORG_ID=${config.sops.placeholder."cribl/org-id"}
-        CRIBL_WORKSPACE_ID=${config.sops.placeholder."cribl/workspace-id"}
-        CRIBL_TOKEN=${config.sops.placeholder."cribl/token"}
+        CRIBL_ORG_ID=${config.sops.placeholder."CRIBL_ORG_ID"}
+        CRIBL_WORKSPACE_ID=${config.sops.placeholder."CRIBL_WORKSPACE_ID"}
+        CRIBL_TOKEN=${config.sops.placeholder."CRIBL_TOKEN"}
       '';
     };
   };

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -1,0 +1,60 @@
+# sops-nix Secret Management
+#
+# Decrypts age-encrypted secrets from secrets/ to root-only files in /run/secrets
+# at activation time. Root reads the age private key from the primary user's
+# ~/.config/sops/age/keys.txt — root can access this path on macOS regardless of
+# the 0600 mode because DAC does not restrict root.
+#
+# Key file:  ~/.config/sops/age/keys.txt  (generated once per machine, never committed)
+# Public key in .sops.yaml                (committed to git)
+# Encrypted secrets in secrets/           (committed to git, safe to be public)
+# Decrypted secrets in /run/secrets/      (ephemeral, root:wheel 0400)
+
+{ config, ... }:
+
+let
+  userConfig = import ../../lib/user-config.nix;
+  rootOnly = {
+    owner = "root";
+    group = "wheel";
+    mode = "0400";
+  };
+in
+{
+  sops = {
+    age = {
+      # Absolute path — expands at Nix eval time, not shell time, so root finds it
+      keyFile = "${userConfig.user.homeDir}/.config/sops/age/keys.txt";
+      generateKey = false;
+      sshKeyPaths = [ ];
+    };
+
+    # Age-only. Disable GPG/SSH fallback to fail fast on misconfiguration.
+    gnupg.sshKeyPaths = [ ];
+
+    # Individual secret files — each decrypts to /run/secrets/<name>, root:wheel 0400
+    secrets = {
+      # Cribl Edge enrollment credentials
+      # Source: secrets/cribl-edge.yaml (age-encrypted, committed to git)
+      "cribl/org-id" = rootOnly // {
+        sopsFile = ../../secrets/cribl-edge.yaml;
+      };
+      "cribl/workspace-id" = rootOnly // {
+        sopsFile = ../../secrets/cribl-edge.yaml;
+      };
+      "cribl/token" = rootOnly // {
+        sopsFile = ../../secrets/cribl-edge.yaml;
+      };
+    };
+
+    # Rendered template: assembles individual secrets into a single KEY=value file
+    # consumed by the cribl-edge activation script via awk (no shell eval).
+    templates."cribl-edge.env" = rootOnly // {
+      content = ''
+        CRIBL_ORG_ID=${config.sops.placeholder."cribl/org-id"}
+        CRIBL_WORKSPACE_ID=${config.sops.placeholder."cribl/workspace-id"}
+        CRIBL_TOKEN=${config.sops.placeholder."cribl/token"}
+      '';
+    };
+  };
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -60,6 +60,7 @@
         "NixOS/nixpkgs",
         "nix-darwin/nix-darwin",
         "nix-community/home-manager",
+        "Mic92/sops-nix",
         "JacobPEvans/ai-assistant-instructions",
         "JacobPEvans/nix-home"
       ],

--- a/secrets/cribl-edge.yaml
+++ b/secrets/cribl-edge.yaml
@@ -1,0 +1,18 @@
+cribl/org-id: ENC[AES256_GCM,data:mpPj/b8q6XFIteHdNkyztEodJPLOKA==,iv:KCzhtNcXvWDZYQVDhEOES1VUnbcBZkyZzWArGMqSYII=,tag:Zrd5zjlRD5Cknp0ObXBAWQ==,type:str]
+cribl/workspace-id: ENC[AES256_GCM,data:qPuwMw==,iv:4DComJ2GBZa8urYGi7w2LeCrdbbAl9JdaCmL47DryQ4=,tag:eJAHXsIQ/NfwpUYJsHS7Wg==,type:str]
+cribl/token: ENC[AES256_GCM,data:fm5iMRbJrJTnxbv0XvhD5LxA7kKkLNCcYZVboG9zfFQ=,iv:L96FnkAZaMs1IgDJpyNyP0x0tuM+921rnkft+Oq/YDs=,tag:PQaXbt3XkL5xWZp+9BozPg==,type:str]
+sops:
+    age:
+        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNOWhOd3BMK3lOaDZaNy85
+            eFlTcFMvWUY4ZzB6VGhyNDJoQWNncUFlaGpvCkZhdUtVa1F0QUFPVG5hdWt3U29k
+            KzM1NTNLVVFzR2Jpd044VUxZSzExSWsKLS0tIHluTEgvU2owdzhpT0NsSmsyL2Qw
+            MlRSR21TYkZnVFdtSUN0b2R0ZnZ6eGsK4SGYhlDAhvptVXQQu4/yBeoD6/CpB4c8
+            EhJZjJwgRjHBWqCIPRkC0FIWsAm0m23TYtOsLUZ/rHH8InBNTlf5sw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-19T13:26:00Z"
+    mac: ENC[AES256_GCM,data:pGWFVP45YzHThervA9tHJLgwhyHbhfbFB5zq7ig+NI39mFgMCe9A9JKdmUqGRoHW5qo8iUYyW3hHb/U2htbcLDIT7GYns5GUlmCxP6WfBZNuqKcEg6ksDTkEaenwsRvD2hb1/k+qWIeFCNaafzmozdSvb7uNQ3HFKfPhU92XqeI=,iv:0zR6c2nN7NmftM0N6d5Try1S7oWcJwYHYMz3DvJalmY=,tag:FuQN6Y0EqjJ2oRZdAmpKDQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/secrets/cribl-edge.yaml
+++ b/secrets/cribl-edge.yaml
@@ -1,18 +1,18 @@
-cribl/org-id: ENC[AES256_GCM,data:mpPj/b8q6XFIteHdNkyztEodJPLOKA==,iv:KCzhtNcXvWDZYQVDhEOES1VUnbcBZkyZzWArGMqSYII=,tag:Zrd5zjlRD5Cknp0ObXBAWQ==,type:str]
-cribl/workspace-id: ENC[AES256_GCM,data:qPuwMw==,iv:4DComJ2GBZa8urYGi7w2LeCrdbbAl9JdaCmL47DryQ4=,tag:eJAHXsIQ/NfwpUYJsHS7Wg==,type:str]
-cribl/token: ENC[AES256_GCM,data:fm5iMRbJrJTnxbv0XvhD5LxA7kKkLNCcYZVboG9zfFQ=,iv:L96FnkAZaMs1IgDJpyNyP0x0tuM+921rnkft+Oq/YDs=,tag:PQaXbt3XkL5xWZp+9BozPg==,type:str]
+CRIBL_ORG_ID: ENC[AES256_GCM,data:DbLanCG74UW1qcZ2/4sqlBOi7+RAhQ==,iv:z4Wgegz2KGOhucpZ6LC/jWQJlNNc+JqF1ndbaJ6xP7w=,tag:W1VokuueBfO4xkpZIkMPlQ==,type:str]
+CRIBL_WORKSPACE_ID: ENC[AES256_GCM,data:7SogmQ==,iv:YR2Ss1epxlhUFA04UiiGH0S8Kjs3yhwe1CqgvbIMfhc=,tag:t78qx3WUzxhk4RRVwvNJRA==,type:str]
+CRIBL_TOKEN: ENC[AES256_GCM,data:0VnVdge6QsweUQiP2+o5iQsEqvV0GJlqe1/b81/hOL0=,iv:9mE+GirBSfyqgE+FKF4BUR3fjGx4uLxKOdNw8qbQavk=,tag:VIIFvqd0HYY/ojEWGJUK8g==,type:str]
 sops:
     age:
         - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNOWhOd3BMK3lOaDZaNy85
-            eFlTcFMvWUY4ZzB6VGhyNDJoQWNncUFlaGpvCkZhdUtVa1F0QUFPVG5hdWt3U29k
-            KzM1NTNLVVFzR2Jpd044VUxZSzExSWsKLS0tIHluTEgvU2owdzhpT0NsSmsyL2Qw
-            MlRSR21TYkZnVFdtSUN0b2R0ZnZ6eGsK4SGYhlDAhvptVXQQu4/yBeoD6/CpB4c8
-            EhJZjJwgRjHBWqCIPRkC0FIWsAm0m23TYtOsLUZ/rHH8InBNTlf5sw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJTW9WVnJ2NUwzK2tINVp1
+            MzRqUGIvdjFPbURIdEdaa0lXa3loeVRQQzAwCkNLR3ArQ2p2bGZkcGNLWGxsSHYx
+            NG5wT1QvRndSVHowNjRwaWphYVZmMDgKLS0tIGlGcnUyM1pna3daN1dqS1JpODdH
+            OFBDMGQrdi9LL2ZOOEYrS05VTmZ3Yk0KWJ3x/Qcas6ClrOqyvDnYAfM98dRipGfv
+            jZ0OXm/I3o4upvhOlMPYw/OhpHyHp82ckUxwmuHIr0SVV/+0lDXkxg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-19T13:26:00Z"
-    mac: ENC[AES256_GCM,data:pGWFVP45YzHThervA9tHJLgwhyHbhfbFB5zq7ig+NI39mFgMCe9A9JKdmUqGRoHW5qo8iUYyW3hHb/U2htbcLDIT7GYns5GUlmCxP6WfBZNuqKcEg6ksDTkEaenwsRvD2hb1/k+qWIeFCNaafzmozdSvb7uNQ3HFKfPhU92XqeI=,iv:0zR6c2nN7NmftM0N6d5Try1S7oWcJwYHYMz3DvJalmY=,tag:FuQN6Y0EqjJ2oRZdAmpKDQ==,type:str]
+    lastmodified: "2026-04-19T13:31:15Z"
+    mac: ENC[AES256_GCM,data:40ywrvHE9CEsINgQgg4ASa+3NRHMdj+3soxAPC/RRW+NLsEhFXCFX/Srw5y9RrPVzbWK0TchAECL510guRNT1Ewd0fEOrWK38TX6BJaA2KiedItqxOrl54k1K+ZdnvqW4tiDYz5Ox4gLJMS4n4A6wZVSLHpOlJhhzBmn5SZlTj0=,iv:ZogbB/EsEn5D9ihePu7FkdKCWq1eQfBkzMtohrTCM/E=,tag:3UyYNuEo3QZzAa82GurDvg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
# Cribl Edge: Replace Doppler CLI with sops-nix for Root-Safe Secrets

## Summary

Replaces Doppler CLI in system activation scripts with declarative sops-nix secret
management.

**Root cause**: nix-darwin activation scripts run as root; root cannot access the
user's macOS Keychain; Doppler CLI requires Keychain for credential injection.
Previous attempts used `su -l`, `launchctl asuser`, and `sudo -u` — all failed
because they don't bridge the activation context into an unlocked Keychain session.

**Solution**: Stop using user credentials from system context entirely. Use
age-encrypted secrets committed to git, decrypted at activation time via sops-nix
to a root-readable `/run/secrets/rendered/cribl-edge.env`. The cribl-edge
activation script reads secrets via `awk` (no `source`/shell eval — safe for
special characters in token values).

## Changes

- **modules/darwin/apps/cribl-edge.nix**: Replace Doppler CLI commands with sops-nix-based secret reads
  - Remove `orgIdCommand`, `workspaceIdCommand`, `tokenCommand` options
  - Add `secretsFile` option pointing to sops-nix template
  - Implement `readSecret` helper using `awk` (safe for shell special chars)
  - Use `lib.mkOrder 1600` to ensure cribl-edge runs after sops-nix postActivation (1500)

- **modules/darwin/apps/scripts/cribl-edge-activate.sh**:
  - Accept pre-decrypted secrets instead of fetching them
  - Pass install URL via `curl --config -` stdin to hide enrollment token from process listings (CodeQL `workflow-secret-in-url`)
  - Download install script to temp file + shebang sanity check before execution (CodeQL `workflow-supply-chain`)

- **modules/darwin/sops.nix**: New module configuring sops-nix with age encryption
  - Keys live in `~/.config/sops/age/keys.txt` (generated per machine, never committed)
  - Decrypted secrets written to `/run/secrets/rendered/` as root:root 0600

- **secrets/cribl-edge.yaml**: New encrypted secrets file (safe to commit)
  - Flat key names (`CRIBL_ORG_ID` not `cribl/org-id`) because sops-nix treats `/` as YAML path separator

- **hosts/macbook-m4/default.nix**: Wire sops-nix and cribl-edge modules
  - Point `programs.cribl-edge.cloud.secretsFile` to the rendered template

- **Documentation** (README.md, CLAUDE.md): Explain sops-nix/Doppler boundary and why Doppler can't be used in activation scripts

- **CI/Renovate**: Ignore `secrets/` from updates; skip sops-nix version bumps unless explicitly pinned

## Architecture

```text
Activation (root context)
  ↓
sops-nix postActivation (mkAfter = 1500)
  → Decrypts secrets/cribl-edge.yaml via age key
  → Writes to /run/secrets/rendered/cribl-edge.env (root:root 0600)
  ↓
cribl-edge postActivation (mkOrder 1600)
  → Reads CRIBL_ORG_ID, CRIBL_WORKSPACE_ID, CRIBL_TOKEN via awk
  → Calls cribl-edge-activate with decrypted secrets
  → Install script enrolls device in fleet
```

## Test Plan

- [ ] `darwin-rebuild switch` completes without errors
- [ ] `/run/secrets/rendered/cribl-edge.env` exists and is readable only by root
- [ ] Cribl Edge installs and enrolls in fleet (curl | bash succeeds)
- [ ] `sudo launchctl print system/com.nix-darwin.cribl-edge` shows running service
- [ ] Verify no secrets appear in process listings: `ps aux | grep cribl` shows no tokens
- [ ] Verify sops-nix encryption: `cat secrets/cribl-edge.yaml | head -1` shows `ENC[AES256_GCM,...]` not plaintext
