### PR TITLE
fix(cribl-edge): replace cc-edge-macos-power with cc-edge-the-mac-pack-io

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -87,7 +87,7 @@ in
         cc-edge-the-mac-pack-io = pkgs.fetchzip {
           url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl";
           extension = "tar.gz";
-          hash = lib.fakeHash;
+          hash = pkgs.lib.fakeHash;
           stripRoot = false;
         };
       };

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -84,10 +84,10 @@ in
         tokenCommand = "doppler secrets get CRIBL_TOKEN --plain -p iac-conf-mgmt -c prd";
       };
       packs = {
-        cc-edge-macos-power = pkgs.fetchzip {
-          url = "https://github.com/JacobPEvans/cc-edge-macos-power/releases/download/v1.0.0/cc-edge-macos-power-v1.0.0.crbl";
+        cc-edge-the-mac-pack-io = pkgs.fetchzip {
+          url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl";
           extension = "tar.gz";
-          hash = "sha256-fzuekOUHCjxajzozGDhAk1jQHP6bLatTvSfF2fI0afA=";
+          hash = lib.fakeHash;
           stripRoot = false;
         };
       };

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -98,8 +98,8 @@ in
       '';
       example = lib.literalExpression ''
         {
-          cc-edge-macos-power = pkgs.fetchzip {
-            url = "https://github.com/JacobPEvans/cc-edge-macos-power/releases/download/v1.0.0/cc-edge-macos-power-v1.0.0.crbl";
+          cc-edge-the-mac-pack-io = pkgs.fetchzip {
+            url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl";
             extension = "tar.gz";
             hash = "sha256-...";
             stripRoot = false;


### PR DESCRIPTION
## Summary

- Replaces the archived `cc-edge-macos-power` fetchzip block with the consolidated `cc-edge-the-mac-pack-io` (v0.1.0)
- Updates the example in `cribl-edge.nix` option docs to match
- `cc-edge-macos-system` and `cc-edge-macos-power` have both been merged into the new pack and their repos archived

## Hash status

`lib.fakeHash` is used as a placeholder — the real sri hash must be substituted once the v0.1.0 release asset is published:

```bash
nix-prefetch-url --unpack \
  https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl
```

Then update `hash = lib.fakeHash;` → `hash = "sha256-<result>";` in `hosts/macbook-m4/default.nix`.

## Test plan

- [ ] Publish v0.1.0 release on `cc-edge-the-mac-pack-io`
- [ ] Fetch real hash and update `hosts/macbook-m4/default.nix`
- [ ] `nix flake check` passes
- [ ] CI green
- [ ] `darwin-rebuild switch` deploys pack without errors

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)