### PR TITLE
fix(deps): update ClaudeBar to 0.4.59

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -32,7 +32,8 @@ on:
 jobs:
   update:
     name: Update (${{ inputs.target || 'custom' }})
-    runs-on: ubuntu-latest
+    # claudebar is an aarch64-darwin package; nix-update must prefetch it on Darwin.
+    runs-on: ${{ (inputs.target || 'custom') == 'jacobpevans' && 'ubuntu-latest' || 'macos-latest' }}
     environment: automation
     permissions:
       contents: write

--- a/packages/claudebar.nix
+++ b/packages/claudebar.nix
@@ -8,11 +8,11 @@
 stdenvNoCC.mkDerivation rec {
   pname = "ClaudeBar";
   # managed by: nix-update (deps-update-flake.yml)
-  version = "0.4.57";
+  version = "0.4.59";
 
   src = fetchurl {
     url = "https://github.com/tddworks/ClaudeBar/releases/download/v${version}/ClaudeBar-${version}.dmg";
-    hash = "sha256-YkG9AnVGt8/QkhSj+alBBFNbhgccvy6DRola+CRXA4w=";
+    hash = "sha256-aKmIy8OC9rCv5lHGPp7v4Acw9uj/yC9W8HgpCPnqw90=";
   };
 
   nativeBuildInputs = [ undmg ];


### PR DESCRIPTION
## Summary
- Updates the custom ClaudeBar package to upstream v0.4.59.
- Moves the custom ClaudeBar updater path to a macOS runner so `nix-update --system aarch64-darwin` can prefetch the Darwin source.
- Keeps the JacobPEvans flake-input update path on `ubuntu-latest`.

## Changes
- Bump `packages/claudebar.nix` from `0.4.57` to `0.4.59` and refresh the fixed-output DMG hash.
- Select `macos-latest` for `target=custom` in `deps-update-flake.yml`; `target=jacobpevans` still uses `ubuntu-latest`.

## Test Plan
- `nix build --no-link .#claudebar`
- `nix fmt -- --ci`
- `nix build --no-link .#checks.aarch64-darwin.formatting .#checks.aarch64-darwin.statix .#checks.aarch64-darwin.deadnix .#checks.aarch64-darwin.shellcheck .#checks.aarch64-darwin.shell-tests`
- `nix run nixpkgs#actionlint -- .github/workflows/deps-update-flake.yml`
- `nix run nixpkgs#nix-update -- --flake --system aarch64-darwin claudebar`
- `nix flake check --no-build`

Resolves failing custom dependency update job: https://github.com/JacobPEvans/nix-darwin/actions/runs/24665993368/job/72123649281