### PR TITLE
chore(deps): bump nix-ai to pull in claude-latest and AI aliases

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -573,15 +573,16 @@
           "pal-mcp-server"
         ],
         "superpowers-marketplace": "superpowers-marketplace",
+        "vct-cribl-pack-validator-skills": "vct-cribl-pack-validator-skills",
         "visual-explainer-marketplace": "visual-explainer-marketplace",
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1777045158,
-        "narHash": "sha256-ThZ/Rp6rbfZr4UJvWGKUb9WQlMCdO3uObBH8JR0Kb7c=",
+        "lastModified": 1777087020,
+        "narHash": "sha256-+04rstBFFIP45VumVRzoajO7/0SE7UFr8bFbyhgztQs=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "195870f69ad79c64339ebfc1c068675daf29646b",
+        "rev": "860f13401e17e91346b8638201604a42ea30d186",
         "type": "github"
       },
       "original": {
@@ -839,6 +840,22 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vct-cribl-pack-validator-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774484708,
+        "narHash": "sha256-cQEbj7K2HcFlL7vUVFYKsjlgZbzQqbVcAtw2QX7H4WQ=",
+        "owner": "VisiCore",
+        "repo": "vct-cribl-pack-validator",
+        "rev": "eaf3b3f17f77faf6825c587dfdd552f8a9837926",
+        "type": "github"
+      },
+      "original": {
+        "owner": "VisiCore",
+        "repo": "vct-cribl-pack-validator",
         "type": "github"
       }
     },


### PR DESCRIPTION
## Summary

Bumps `nix-ai` from `195870f` → `860f134` (and lockfile cleanup), activating the AI alias module on this host.

## Changes

This pulls in the merged work from nix-ai:
- **#619** — `feat(claude): bump effort to high, add claude-latest install, centralize AI aliases`
- **#628** — `feat(gemini): default sandboxAllowedPaths to ~/git`
- **#626** — `chore(deps): update custom packages` (gh-aw bumped to 0.71.0, requires Go 1.26)

After this rebuild, the following aliases are live in zsh:
- `claude-latest` → `~/.local/bin/claude` (native installer)
- `claude-d` → `claude --dangerously-skip-permissions`
- `claude-latest-d` → `claude-latest --dangerously-skip-permissions`
- `d-claude` / `tf-claude` — relocated from `nix-home` to `nix-ai` (single source of truth)

The `claude-latest` install module also enables a per-user LaunchAgent that runs the official installer at login, idempotent — no-op when the symlink at `~/.local/bin/claude` already points into `~/.local/share/claude/versions/`.

## Test plan

- [x] `sudo darwin-rebuild switch --flake .` — exit 0
- [x] `zsh -c 'alias claude-latest claude-d claude-latest-d d-claude tf-claude'` — all five resolve
- [x] `~/.local/bin/claude --version` — `2.1.119 (Claude Code)`
- [ ] CI: Nix Build, Nix Validate, CodeQL, Merge Gate

## Related

- nix-ai#619, nix-home#199 (already merged)