### PR TITLE
feat(darwin): :sparkles: apple-silicon-tunables for AI inference workloads

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -125,6 +125,11 @@ in
     };
   };
 
+  # --- Apple Silicon Tunables ---
+  # Wired-memory ceiling, App Nap, Spotlight + TM excludes for AI caches.
+  # See modules/darwin/apple-silicon-tunables.nix for option semantics.
+  system.appleSiliconTunables.enable = true;
+
   # --- Energy & Sleep Configuration ---
   system.energy = {
     enable = true;

--- a/modules/darwin/apple-silicon-tunables.nix
+++ b/modules/darwin/apple-silicon-tunables.nix
@@ -5,7 +5,12 @@
 # All knobs target native macOS surfaces (sysctl, pmset, mdutil, tmutil,
 # user defaults) — there is no first-class nix-darwin option for any of them.
 
-{ lib, config, pkgs, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.system.appleSiliconTunables;

--- a/modules/darwin/apple-silicon-tunables.nix
+++ b/modules/darwin/apple-silicon-tunables.nix
@@ -1,0 +1,90 @@
+# Apple Silicon System Tunables
+#
+# Boot-time and runtime knobs for Apple Silicon (M-series) hosts that run
+# heavy local AI inference workloads (vllm-mlx, screenpipe, etc.).
+# All knobs target native macOS surfaces (sysctl, pmset, mdutil, tmutil,
+# user defaults) — there is no first-class nix-darwin option for any of them.
+
+{ lib, config, pkgs, ... }:
+
+let
+  cfg = config.system.appleSiliconTunables;
+  userConfig = import ../../lib/user-config.nix;
+
+  applyScript = pkgs.writeShellApplication {
+    name = "apple-silicon-tunables-apply";
+    runtimeInputs = [ ];
+    text = builtins.readFile ./scripts/apple-silicon-tunables.sh;
+  };
+in
+{
+  options.system.appleSiliconTunables = {
+    enable = lib.mkEnableOption "Apple Silicon system tunables for AI workloads";
+
+    wiredLimitMb = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 118000;
+      description = ''
+        iogpu.wired_limit_mb — wired-memory ceiling for the IOGPU subsystem.
+        Default 118000 = ~92% of a 128 GB host. Re-applied at every boot via
+        a one-shot launchd daemon.
+      '';
+    };
+
+    huggingfaceVolume = lib.mkOption {
+      type = lib.types.str;
+      default = "/Volumes/HuggingFace";
+      description = "Path to the HuggingFace cache volume; Spotlight indexing is disabled here.";
+    };
+
+    timeMachineExcludes = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "${userConfig.user.homeDir}/.cache/uv"
+        "${userConfig.user.homeDir}/.cache/nix-screenpipe"
+        "${userConfig.user.homeDir}/.screenpipe/data"
+        "/Volumes/HuggingFace"
+      ];
+      description = "Absolute paths to add to the Time Machine exclusion list.";
+    };
+
+    appNapDisabledFor = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "dev.vllm-mlx.server" ];
+      description = ''
+        User-defaults bundle IDs to mark NSAppSleepDisabled=YES for, so macOS
+        does not throttle long-lived inference daemons via App Nap.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Boot-time: re-apply the wired-memory ceiling on every restart. The
+    # sysctl is volatile, so we rely on launchd RunAtLoad rather than
+    # baking it into a /etc/sysctl.conf-style mechanism.
+    launchd.daemons.set-iogpu-wired-limit = {
+      serviceConfig = {
+        Label = "dev.local.set-iogpu-wired-limit";
+        ProgramArguments = [
+          "/usr/sbin/sysctl"
+          "-w"
+          "iogpu.wired_limit_mb=${toString cfg.wiredLimitMb}"
+        ];
+        RunAtLoad = true;
+        KeepAlive = false;
+        StandardOutPath = "/var/log/set-iogpu-wired-limit.log";
+        StandardErrorPath = "/var/log/set-iogpu-wired-limit.log";
+      };
+    };
+
+    # darwin-rebuild switch: invoke the apply script with the configured knobs.
+    system.activationScripts.appleSiliconTunables.text = ''
+      WIRED_LIMIT_MB="${toString cfg.wiredLimitMb}" \
+      HF_VOLUME="${cfg.huggingfaceVolume}" \
+      TM_EXCLUDES="${lib.concatStringsSep ":" cfg.timeMachineExcludes}" \
+      APPNAP_BUNDLES="${lib.concatStringsSep ":" cfg.appNapDisabledFor}" \
+      USER_NAME="${userConfig.user.name}" \
+        ${lib.getExe applyScript} || true
+    '';
+  };
+}

--- a/modules/darwin/apple-silicon-tunables.nix
+++ b/modules/darwin/apple-silicon-tunables.nix
@@ -48,9 +48,21 @@ in
         "${userConfig.user.homeDir}/.cache/uv"
         "${userConfig.user.homeDir}/.cache/nix-screenpipe"
         "${userConfig.user.homeDir}/.screenpipe/data"
-        "/Volumes/HuggingFace"
+        cfg.huggingfaceVolume
       ];
-      description = "Absolute paths to add to the Time Machine exclusion list.";
+      defaultText = lib.literalExpression ''
+        [
+          "''${userConfig.user.homeDir}/.cache/uv"
+          "''${userConfig.user.homeDir}/.cache/nix-screenpipe"
+          "''${userConfig.user.homeDir}/.screenpipe/data"
+          config.system.appleSiliconTunables.huggingfaceVolume
+        ]
+      '';
+      description = ''
+        Absolute paths to add to the Time Machine exclusion list. The
+        HuggingFace volume default is sourced from huggingfaceVolume so
+        overriding that option keeps the exclusion in sync.
+      '';
     };
 
     appNapDisabledFor = lib.mkOption {
@@ -83,12 +95,14 @@ in
     };
 
     # darwin-rebuild switch: invoke the apply script with the configured knobs.
+    # All values escaped via lib.escapeShellArg — defense against unusual
+    # path characters or future user-configurable option values.
     system.activationScripts.appleSiliconTunables.text = ''
-      WIRED_LIMIT_MB="${toString cfg.wiredLimitMb}" \
-      HF_VOLUME="${cfg.huggingfaceVolume}" \
-      TM_EXCLUDES="${lib.concatStringsSep ":" cfg.timeMachineExcludes}" \
-      APPNAP_BUNDLES="${lib.concatStringsSep ":" cfg.appNapDisabledFor}" \
-      USER_NAME="${userConfig.user.name}" \
+      WIRED_LIMIT_MB=${lib.escapeShellArg (toString cfg.wiredLimitMb)} \
+      HF_VOLUME=${lib.escapeShellArg cfg.huggingfaceVolume} \
+      TM_EXCLUDES=${lib.escapeShellArg (lib.concatStringsSep ":" cfg.timeMachineExcludes)} \
+      APPNAP_BUNDLES=${lib.escapeShellArg (lib.concatStringsSep ":" cfg.appNapDisabledFor)} \
+      USER_NAME=${lib.escapeShellArg userConfig.user.name} \
         ${lib.getExe applyScript} || true
     '';
   };

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -29,6 +29,7 @@ in
     ./activation-error-tracking.nix
     ./nix-storage.nix
     ./ws-monitor.nix
+    ./apple-silicon-tunables.nix
   ];
 
   # --- Nixpkgs Configuration ---

--- a/modules/darwin/scripts/apple-silicon-tunables.sh
+++ b/modules/darwin/scripts/apple-silicon-tunables.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Apple Silicon System Tunables — runtime apply
+#
+# Reads tunables from environment variables passed by the nix-darwin
+# activation script. Each step is best-effort: a failure logs a warning
+# but does not abort the rest. Native macOS CLIs only — no third-party
+# dependencies.
+
+set -uo pipefail
+
+prefix="[apple-silicon-tunables]"
+log() { echo "$prefix INFO $*"; }
+warn() { echo "$prefix WARN $*" >&2; }
+
+# 1. Wired-memory ceiling for IOGPU.
+if /usr/sbin/sysctl -w "iogpu.wired_limit_mb=${WIRED_LIMIT_MB}" >/dev/null; then
+    log "iogpu.wired_limit_mb=${WIRED_LIMIT_MB}"
+else
+    warn "sysctl iogpu.wired_limit_mb failed"
+fi
+
+# 2. Low Power Mode off on every power source. Inference workloads stall
+#    badly when LPM throttles the SoC.
+if /usr/bin/pmset -a lowpowermode 0 >/dev/null 2>&1; then
+    log "lowpowermode=0 on all power sources"
+else
+    warn "pmset -a lowpowermode 0 failed"
+fi
+
+# 3. Spotlight indexing off on the HuggingFace volume — every model
+#    download otherwise re-indexes hundreds of GB.
+if [ -d "${HF_VOLUME}" ]; then
+    if /usr/bin/mdutil -i off "${HF_VOLUME}" >/dev/null 2>&1; then
+        log "mdutil indexing disabled on ${HF_VOLUME}"
+    else
+        warn "mdutil -i off ${HF_VOLUME} failed"
+    fi
+fi
+
+# 4. Time Machine excludes for the AI cache directories. TM_EXCLUDES is a
+#    colon-separated list of absolute paths.
+if [ -n "${TM_EXCLUDES:-}" ]; then
+    IFS=':' read -ra _excludes <<<"${TM_EXCLUDES}"
+    for _path in "${_excludes[@]}"; do
+        if [ -e "${_path}" ]; then
+            if /usr/bin/tmutil addexclusion "${_path}" >/dev/null 2>&1; then
+                log "tmutil exclude ${_path}"
+            else
+                warn "tmutil addexclusion ${_path} failed"
+            fi
+        fi
+    done
+fi
+
+# 5. App Nap off for inference daemons. Bundle IDs come in colon-separated.
+#    Defaults are per-user, so we shell out as the configured user.
+if [ -n "${APPNAP_BUNDLES:-}" ] && [ -n "${USER_NAME:-}" ]; then
+    IFS=':' read -ra _bundles <<<"${APPNAP_BUNDLES}"
+    for _bundle in "${_bundles[@]}"; do
+        if /usr/bin/sudo -u "${USER_NAME}" /usr/bin/defaults write \
+            "${_bundle}" NSAppSleepDisabled -bool YES >/dev/null 2>&1; then
+            log "NSAppSleepDisabled=YES for ${_bundle}"
+        else
+            warn "defaults write ${_bundle} NSAppSleepDisabled failed"
+        fi
+    done
+fi
+
+exit 0

--- a/modules/darwin/scripts/apple-silicon-tunables.sh
+++ b/modules/darwin/scripts/apple-silicon-tunables.sh
@@ -36,6 +36,8 @@ if [ -d "${HF_VOLUME}" ]; then
     else
         warn "mdutil -i off ${HF_VOLUME} failed"
     fi
+else
+    warn "HF volume ${HF_VOLUME} is missing or not mounted; skipping mdutil -i off"
 fi
 
 # 4. Time Machine excludes for the AI cache directories. TM_EXCLUDES is a
@@ -49,6 +51,8 @@ if [ -n "${TM_EXCLUDES:-}" ]; then
             else
                 warn "tmutil addexclusion ${_path} failed"
             fi
+        else
+            warn "tmutil exclusion skipped for missing path ${_path}; rerun activation after it is created"
         fi
     done
 fi


### PR DESCRIPTION
## Summary

New nix-darwin module \`system.appleSiliconTunables\` that bundles five Apple Silicon knobs we kept hand-applying every time the local AI stack started thrashing:

- \`iogpu.wired_limit_mb=118000\` — set both via \`system.activationScripts\` on every \`darwin-rebuild\` AND via a one-shot \`launchd.daemons.set-iogpu-wired-limit\` that re-applies on boot (sysctl is volatile).
- \`pmset -a lowpowermode 0\` — Low Power Mode tanks token throughput.
- \`mdutil -i off /Volumes/HuggingFace\` — stop re-indexing 100s of GB every time we pull a model.
- \`tmutil addexclusion\` for AI cache dirs (\`~/.cache/uv\`, \`~/.cache/nix-screenpipe\`, \`~/.screenpipe/data\`, \`/Volumes/HuggingFace\`).
- \`defaults write dev.vllm-mlx.server NSAppSleepDisabled -bool YES\` — App Nap throttles long-lived inference daemons.

Apply logic is extracted to \`modules/darwin/scripts/apple-silicon-tunables.sh\` following the \`ws-monitor\` pattern, so the \`.nix\` module stays declarative and the inline activation block is just env-var passthrough plus a script invocation.

## Test plan

- [ ] \`nix flake check\` evaluates without errors
- [ ] \`darwin-rebuild switch --flake .#macbook-m4\` applies cleanly
- [ ] \`sysctl iogpu.wired_limit_mb\` returns \`118000\`
- [ ] \`pmset -g | grep lowpowermode\` shows \`lowpowermode 0\`
- [ ] \`mdutil -s /Volumes/HuggingFace\` returns \`Indexing disabled\`
- [ ] \`tmutil isexcluded /Volumes/HuggingFace\` returns \`[Excluded]\`
- [ ] \`defaults read dev.vllm-mlx.server NSAppSleepDisabled\` returns \`1\`
- [ ] After reboot, \`sysctl iogpu.wired_limit_mb\` is still \`118000\` (launchd daemon ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)