### PR TITLE
feat(macbook-m4): enable programs.mlx

### DIFF
--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -59,6 +59,12 @@
   };
 
   programs = {
+    # Local MLX inference server (vllm-mlx + llama-swap proxy on :11434).
+    # Brings the existing vllm-mlx LaunchAgent under Nix management — without
+    # this, the registry at services.aiStack.models is materialized to nothing
+    # and llama-swap.json drifts from whatever was last activated by hand.
+    mlx.enable = true;
+
     claude = {
       # Disable playwright plugin globally — only useful in specific projects.
       # playwright@claude-skills (skills-only, no MCP) stays enabled.

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -59,12 +59,6 @@
   };
 
   programs = {
-    # Local MLX inference server (vllm-mlx + llama-swap proxy on :11434).
-    # Brings the existing vllm-mlx LaunchAgent under Nix management — without
-    # this, the registry at services.aiStack.models is materialized to nothing
-    # and llama-swap.json drifts from whatever was last activated by hand.
-    mlx.enable = true;
-
     claude = {
       # Disable playwright plugin globally — only useful in specific projects.
       # playwright@claude-skills (skills-only, no MCP) stays enabled.
@@ -100,6 +94,12 @@
           };
         };
     };
+
+    # Local MLX inference server (vllm-mlx + llama-swap proxy on :11434).
+    # Brings the existing vllm-mlx LaunchAgent under Nix management — without
+    # this, the registry at services.aiStack.models is materialized to nothing
+    # and llama-swap.json drifts from whatever was last activated by hand.
+    mlx.enable = true;
 
     # macOS-specific zsh overrides
     # Base zsh config provided by nix-home (sharedModule).


### PR DESCRIPTION
## Summary

Enables `programs.mlx` in the macbook-m4 Home Manager configuration, bringing the existing vllm-mlx + llama-swap stack under Nix module management.

## Changes

- Enable `programs.mlx.enable = true` in `hosts/macbook-m4/home.nix`
- Sorted `programs` attribute blocks alphabetically (`claude → mlx → zsh`)

## Context

The vllm-mlx + llama-swap stack was already running on this host, but via a stale LaunchAgent plist from a prior home-manager generation with the MLX module never enabled. Effects:

- The `seedLlamaSwapConfig` and `discoverMlxModels` activation hooks were not in the home-manager activation graph
- `~/.config/mlx/llama-swap.json` drifted from `services.aiStack.models` (the capability-class registry in nix-ai)
- Calls to the gateway by capability-class name (e.g. `model: "default"`) worked only because llama-swap had stale aliases from a prior generation

## Fix

Enable the module on this host. On the next `darwin-rebuild switch`:

- The LaunchAgent plist is rendered from the current Nix derivation (vllm-mlx 0.2.9 wrapper, current llama-swap binary)
- `llama-swap.json` is re-seeded from the registry — capability-class aliases now reflect the current `services.aiStack.models` mapping
- The running vllm-mlx is hot-swapped when launchd reloads the new plist

## Dependencies

This PR depends on nix-ai activation pipeline fixes being merged first:

- JacobPEvans/nix-ai#681 — removes the runtimeCleanup activation hook
- JacobPEvans/nix-ai#682 — fixes `discover-models.py` alias resolution

## Test Plan

- [x] `nix flake check` — all checks pass on this host config
- [ ] After all dependent PRs land + `darwin-rebuild switch`:
  - `ps -ef | grep vllm-mlx` shows `vllm-mlx==0.2.9` (current pin)
  - `jq -r '.models | to_entries[] | "\(.key) -> \(.value.aliases // [])"' ~/.config/mlx/llama-swap.json` shows distinct alias groups per the registry
  - `curl -sf http://localhost:11434/v1/chat/completions -d '{"model":"default","messages":[{"role":"user","content":"hi"}],"max_tokens":1}'` returns 200

(claude)