### PR TITLE
chore(deps): update nix-home to 806e7bc (kvazaar test-skip fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -619,11 +619,11 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1777768210,
-        "narHash": "sha256-FywkHHzSsB9T6DR5ZtE5eNfJHbBsrngIrUk4vFBpbi4=",
+        "lastModified": 1777830060,
+        "narHash": "sha256-XHXEldVSkL5uMgMYiZkBeaNSzeS+Q2gQ656ZhwSs95Y=",
         "owner": "JacobPEvans",
         "repo": "nix-home",
-        "rev": "68470475e355830d00054bde4383a2fafcf881f5",
+        "rev": "806e7bc3387d5de51696f288158110ca956bae0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Updates `nix-home` flake input from `6847047` to `806e7bc`
- Picks up [nix-home PR #214](https://github.com/JacobPEvans/nix-home/pull/214) which adds `darwin-test-skips.nix` overlay
- Fixes `darwin-rebuild switch` failure caused by kvazaar CMake tests being SIGKILLed in the macOS Nix sandbox

**Root cause**: `markitdown` (used for PPTX text extraction in Claude document-skills) transitively pulls in `ffmpeg-full → kvazaar`. The kvazaar test suite shells out to `ffmpeg` to produce test frames; the sandbox kills those subprocesses with SIGKILL before they write output. The `darwin-test-skips.nix` overlay in nix-home sets `doCheck = false` for kvazaar and chromaprint, unblocking the build.

## Test plan

- [x] `sudo darwin-rebuild switch --flake ~/git/nix-darwin/chore/update-nix-home-lock` succeeded locally — kvazaar no longer attempts to build its test suite
- [x] PAL health check: ALL PASSED (6 checks)
- [x] `claude --version` still works post-rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)