### PR TITLE
fix(renovate): correct cribl-edge customManager file path and schema

### DIFF
--- a/packages/cribl-edge.nix
+++ b/packages/cribl-edge.nix
@@ -8,7 +8,7 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "cribl-edge";
-  version = "4.17.0-7e952fa7";
+  version = "4.17.0-7e952fa7"; # cribl-edge
 
   src = fetchurl {
     url = "https://cdn.cribl.io/dl/4.17.0/cribl-${version}-darwin-universal.pkg";

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,11 +37,11 @@
     }
   },
 
-  // Custom regex manager: track Cribl Edge version in host config
+  // Custom regex manager: track Cribl Edge version
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["hosts/macbook-m4/default\\.nix$"],
+      "managerFilePatterns": ["/packages/cribl-edge\\.nix$/"],
       "matchStrings": ["version = \"(?<currentValue>[^\"]+)\"; # cribl-edge"],
       "depNameTemplate": "cribl-edge",
       "datasourceTemplate": "custom.cribl-edge",


### PR DESCRIPTION
## Summary

Fix Renovate `customManagers` for cribl-edge: the regex pointed at the wrong file and the version line lacked the required comment marker. Also migrates `fileMatch` → `managerFilePatterns` to match the org preset modernization from 2026-05-03.

## Changes

- `renovate.json5`: change `fileMatch` → `managerFilePatterns`, update pattern from `hosts/macbook-m4/default\.nix$` to `/packages/cribl-edge\.nix$/`
- `packages/cribl-edge.nix`: add `# cribl-edge` marker to `version` line so `matchStrings` regex matches

## Test Plan

- [ ] Next Renovate run detects `cribl-edge` on the dependency dashboard (previously silently untracked)
- [ ] If `cdn.cribl.io/versions.json` shows a newer version, Renovate opens a PR targeting `packages/cribl-edge.nix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)