### PR TITLE
feat(homebrew): consume nix-ai lib.brewFormulae for per-agent formulae

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,12 @@
         assert _stateVersionCheck;
         darwin.lib.darwinSystem {
           system = "aarch64-darwin";
-          specialArgs = { };
+          # Pass nix-ai through so the homebrew module can pull
+          # `lib.brewFormulae` (formulae required by per-agent home-manager
+          # modules whose preferred install path is brew, e.g. qwen-code).
+          # Keeps the agent module self-contained for future flake graduation —
+          # see nix-ai/docs/architecture/per-agent-flakes.md.
+          specialArgs = { inherit nix-ai; };
           modules = [
             ./hosts/macbook-m4/default.nix
 

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -31,11 +31,18 @@
 # NOTE: nix-darwin does NOT support version pinning for individual homebrew packages.
 # To prevent upgrades for a specific package, pin it via `brew pin <package>`.
 
-{ lib, ... }:
+{ lib, nix-ai, ... }:
 
 let
   # 30 hours in seconds — brew autoupdate requires interval in seconds
   autoupdateInterval = 108000;
+
+  # Brew formulae required by per-agent nix-ai modules whose preferred
+  # install source is Homebrew (e.g. programs.qwen-code with
+  # installVia = "brew"). The list is owned by the agent's module in
+  # nix-ai and exported as a flake output, so each module stays
+  # self-contained. See nix-ai/docs/architecture/per-agent-flakes.md.
+  agentBrewFormulae = nix-ai.lib.brewFormulae or [ ];
 in
 {
   homebrew = {
@@ -71,7 +78,10 @@ in
       # Swift native on-device speech recognition (Apple Silicon, requires Xcode build - not in nixpkgs)
       # Pairs with whisper-cpp + openai-whisper (those are in nix-ai home.packages as Nix derivations)
       "whisperkit-cli"
-    ];
+    ]
+    # Append formulae required by nix-ai's per-agent modules. Currently:
+    # qwen-code (Alibaba's CLI agent — see modules/qwen-code in nix-ai).
+    ++ agentBrewFormulae;
     casks = [
       # GUI applications (only if not available in nixpkgs)
       #

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -81,7 +81,11 @@ in
     ]
     # Append formulae required by nix-ai's per-agent modules. Currently:
     # qwen-code (Alibaba's CLI agent — see modules/qwen-code in nix-ai).
-    ++ agentBrewFormulae;
+    # `lib.unique` deduplicates in case a formula migrates between the
+    # static list above and nix-ai's exported list during a transition
+    # — `brew bundle` is idempotent but the duplicate noise is worth
+    # eliminating at the Nix layer.
+    ++ lib.unique agentBrewFormulae;
     casks = [
       # GUI applications (only if not available in nixpkgs)
       #


### PR DESCRIPTION
## Summary

Consume `inputs.nix-ai.lib.brewFormulae` in `modules/darwin/homebrew.nix`
so per-agent home-manager modules in nix-ai can declare their required
Homebrew formulae alongside their config — no more hand-syncing brew
formulae here whenever an agent module is added or removed.

Today this lands `qwen-code` (Alibaba's terminal coding agent CLI),
required by nix-ai's new `programs.qwen-code` module
(`installVia = "brew"` default). Tomorrow it'll naturally extend to any
new per-agent module that prefers brew per the install-order rule
(nixpkgs → brew → uvx/npm).

## Changes

- **`flake.nix`** — pass `nix-ai` through `specialArgs` so the
  homebrew module can read its flake outputs.
- **`modules/darwin/homebrew.nix`** — accept `nix-ai` as a module
  param, append `nix-ai.lib.brewFormulae or [ ]` to the existing
  `brews` list. The static brews above remain hand-maintained for
  packages whose home-manager modules don't (yet) declare them via
  the per-agent flake-output pattern (`ccusage`, `gemini-cli`,
  `block-goose-cli`, `whisperkit-cli`).

## Why this pattern

Pattern documented in nix-ai's
[`docs/architecture/per-agent-flakes.md`](https://github.com/JacobPEvans/nix-ai/blob/feature/registry-file/docs/architecture/per-agent-flakes.md).
The short version: each AI agent module follows a uniform layout
(`default.nix`, `options.nix`, `packages.nix`, `settings.nix`,
`README.md`) and either pre-warms its install in user-space (uvx/npm)
or — when brew is the right home — exports the formula name via
`lib.brewFormulae` for nix-darwin to consume. Keeps each agent module
self-contained and ready for future graduation to a standalone flake.

## Test plan

- [x] `nix eval ... lib.brewFormulae` → `[ "qwen-code" ]`
- [ ] `darwin-rebuild switch --override-input nix-ai $WORKTREE`
      (blocked on the pre-existing python3-3.13/3.14 `buildEnv`
      conflict documented in JacobPEvans/nix-ai#719 — independent of
      this change)
- [ ] Live `qwen --version` post-rebuild + brew install
- [ ] Live `qwen` routes through llama-swap (local MLX) per the
      generated `~/.qwen/settings.json`

## Related

- **Companion**: JacobPEvans/nix-ai#719 (registry refactor +
  Aider→cecli migration + Qwen Code module).
- **Follow-up**: apply the per-agent flake-output pattern to existing
  agent declarations (gemini-cli, claude-code etc. that today live
  hand-maintained in `homebrew.brews`/`homebrew.casks`).

Assisted-by: Claude <noreply@anthropic.com>