### PR TITLE
feat(homebrew): add openwebstart cask for iDRAC6 vKVM access

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -191,7 +191,7 @@ in
       # iDRAC6 Virtual Console requires NPAPI Java plugin, dropped by all
       # modern browsers (Chrome 2015, Safari, Firefox, Brave). OpenWebStart
       # runs the .jnlp file that the iDRAC web UI downloads on "Launch Virtual
-      # Console". greedy = true because OpenWebStart has no built-in updater.
+      # Console".
       {
         name = "openwebstart";
         greedy = true;

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -185,6 +185,17 @@ in
         name = "libreoffice";
         greedy = true;
       }
+
+      # --- Out-of-band server management ---
+      # Java Web Start replacement for iDRAC6 vKVM .jnlp launches.
+      # iDRAC6 Virtual Console requires NPAPI Java plugin, dropped by all
+      # modern browsers (Chrome 2015, Safari, Firefox, Brave). OpenWebStart
+      # runs the .jnlp file that the iDRAC web UI downloads on "Launch Virtual
+      # Console". greedy = true because OpenWebStart has no built-in updater.
+      {
+        name = "openwebstart";
+        greedy = true;
+      }
     ];
 
     # Mac App Store apps (requires signed into App Store)


### PR DESCRIPTION
## Summary

Adds `openwebstart` Homebrew cask to enable iDRAC6 Virtual Console
access from macOS. iDRAC6 delivers its KVM as a Java Web Start `.jnlp`
file requiring the NPAPI Java plugin, which all modern browsers dropped
(Chrome 2015; Safari, Firefox, Brave followed).

## Changes

- `modules/darwin/homebrew.nix`: adds `openwebstart` with `greedy = true`
  to the casks list under a new "Out-of-band server management" section

## Usage

Browse to `https://<idrac_ip>` → Login → Launch Virtual Console →
browser downloads `viewer.jnlp` → OpenWebStart opens the KVM window.

Note: iDRAC6 uses legacy TLS — OpenWebStart may require ITWConfig
cipher overrides on first launch.

## Test Plan

- [x] `nix flake check` passes (Nix Validate CI)
- [x] `darwin-rebuild switch --flake .` succeeds (Nix Build CI)
- [x] CodeQL: no new alerts introduced
- [ ] `brew list --cask | grep openwebstart` shows installed after rebuild
- [ ] iDRAC6 `.jnlp` opens successfully in OpenWebStart

Generated with [Claude Code](https://claude.com/claude-code)