### PR TITLE
fix(launchd): disable orbstack-background agent and remove procps shadow

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -41,7 +41,6 @@ Source: `modules/darwin/common.nix`
 | jq | JSON parsing |
 | ncdu | NCurses disk usage analyzer |
 | ngrep | Network packet grep |
-| procps | Process utilities (pgrep, pkill) |
 | ripgrep | Fast grep alternative (rg) |
 | tldr | Simplified, community-driven man pages |
 | tree | Directory tree visualization |

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -56,6 +56,8 @@ in
       # Previously, nixpkgs installed a symlink to a /nix/store path that changes on
       # every rebuild, forcing TCC re-granting each time.
       package.enable = false;
+      # orb start exits 0 in <1s; KeepAlive=true was throttle-respawning it into
+      # a runningboardd assertion flood. OrbStack.app manages its own startup.
       background.enable = false;
       dataVolume = {
         enable = true;

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -56,7 +56,7 @@ in
       # Previously, nixpkgs installed a symlink to a /nix/store path that changes on
       # every rebuild, forcing TCC re-granting each time.
       package.enable = false;
-      background.enable = true;
+      background.enable = false;
       dataVolume = {
         enable = true;
         name = "ContainerData";

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -66,7 +66,6 @@ in
     # Network & process tools
     # ========================================================================
     ngrep # Network packet grep (useful for debugging)
-    procps # Process utilities including pgrep, pkill
 
     # ========================================================================
     # Audio libraries (system-level dependencies)


### PR DESCRIPTION
## Summary

Disable the OrbStack launchd background agent and remove procps from system packages. Both were causing silent failures: launchd throttle-respawning a one-shot CLI, and procps shadowing Apple's setuid-root binaries without proper entitlements.

## Changes

- Disable `programs.orbstack.background.enable` (hosts/macbook-m4/default.nix:59): `orb start` is a one-shot CLI that exits in <1s; with `KeepAlive=true`, launchd throttle-respawned it 139 times at T-0 of the 2026-05-10 WindowServer freeze. OrbStack.app's login-item already handles startup.
- Remove `procps` from `environment.systemPackages` (modules/darwin/common.nix:69): nixpkgs' build shadows `/usr/bin/top` and `/bin/ps` without the `com.apple.system-task-ports.read` entitlement Apple's binaries carry, silently breaking `perf-snapshot` memory sampling. macOS provides `pgrep` and `pkill` natively.
- Remove `procps` from MANIFEST.md.

## Test Plan

- [ ] `nix flake check` passes in CI
- [ ] `sudo darwin-rebuild switch --flake .` succeeds
- [ ] `launchctl print gui/$(id -u)/com.nix-darwin.orbstack-background` → "Could not find service"
- [ ] `which top` → `/usr/bin/top`; `top -l 1 -n 0 | head -5` exits without permission error
- [ ] `which pgrep pkill` → `/usr/bin/pgrep` `/usr/bin/pkill` (Apple binaries, still present)
- [ ] OrbStack continues to work normally (`orb status`, `docker ps`)