### PR TITLE
feat(homebrew): add firefox cask and add to dock

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -189,6 +189,7 @@ via LaunchAgent) always installs the latest version rather than deferring to bui
 | postman | yes | API development environment (moved from nixpkgs — version lag caused schema mismatch) |
 | orbstack | yes | Container/Linux VM runtime — cask for TCC permission stability |
 | microsoft-teams | yes | Teams desktop app (not available on Mac App Store) |
+| firefox | yes | Mozilla Firefox browser |
 
 ### Mac App Store
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -189,7 +189,7 @@ via LaunchAgent) always installs the latest version rather than deferring to bui
 | postman | yes | API development environment (moved from nixpkgs — version lag caused schema mismatch) |
 | orbstack | yes | Container/Linux VM runtime — cask for TCC permission stability |
 | microsoft-teams | yes | Teams desktop app (not available on Mac App Store) |
-| firefox | yes | Mozilla Firefox browser |
+| firefox | yes | Mozilla Firefox browser — cask for TCC permission stability |
 
 ### Mac App Store
 

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -56,6 +56,7 @@ in
       # Browsers
       "/Applications/Safari.app"
       "/Applications/Brave Browser.app"
+      "/Applications/Firefox.app"
 
       # NOTE: Ollama runs headless via LaunchAgent, no dock icon needed.
       # NOTE: Additional AI tools (ChatGPT, Cursor) can be found in

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -183,7 +183,7 @@ in
       {
         name = "firefox";
         greedy = true;
-      } # Mozilla Firefox browser
+      }
 
       # --- Office Suite (for Claude document-skills) ---
       # LibreOffice provides the `soffice` CLI that /document-skills:{docx,xlsx,pptx}

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -176,6 +176,15 @@ in
         greedy = true;
       }
 
+      # --- Browsers ---
+      # Firefox is in nixpkgs (firefox-bin) but installs to /nix/store/<hash>
+      # which changes every rebuild — resets macOS TCC grants (camera, mic,
+      # screen recording). Cask installs to stable /Applications/Firefox.app.
+      {
+        name = "firefox";
+        greedy = true;
+      } # Mozilla Firefox browser
+
       # --- Office Suite (for Claude document-skills) ---
       # LibreOffice provides the `soffice` CLI that /document-skills:{docx,xlsx,pptx}
       # use to convert Office docs to PDF. nixpkgs does NOT build libreoffice for


### PR DESCRIPTION
## Summary

- Add `firefox` homebrew cask (`greedy = true`) in a new `# --- Browsers ---` section in `modules/darwin/homebrew.nix`
- Add `/Applications/Firefox.app` to the Dock after Brave Browser in `modules/darwin/dock/persistent-apps.nix`
- Add `firefox` row to the casks table in `MANIFEST.md`

## Why homebrew cask over nixpkgs

Firefox 150.0.x is available in nixpkgs (`firefox-bin`) but installs to `/nix/store/<hash>/` — a path that changes on every `darwin-rebuild`. This resets macOS TCC grants (camera, mic, screen recording) on each rebuild. The homebrew cask installs to `/Applications/Firefox.app` (stable path), matching the same pattern used for Claude, OrbStack, and Postman.

## Test plan

- [ ] CI (`nix flake check` + `darwin-rebuild switch`) passes on macOS runner
- [ ] `brew list --cask | grep firefox` returns `firefox` after rebuild
- [ ] `/Applications/Firefox.app` exists
- [ ] Dock shows Firefox after Brave Browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)