### PR TITLE
fix(checks): make module-eval compatible with nix flake check --no-build

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -86,12 +86,20 @@
 
 }
 // pkgs.lib.optionalAttrs (darwinConfigurations != { }) {
-  # Evaluate darwinConfigurations to catch import errors, type errors, and assertion failures
-  # Uses .system.drvPath for eval-only (no full build)
-  module-eval = pkgs.runCommand "check-module-eval" { } ''
-    ${pkgs.lib.concatStringsSep "\n" (
-      pkgs.lib.mapAttrsToList (name: cfg: "echo \"${name}: ${cfg.system.drvPath}\"") darwinConfigurations
-    )}
-    touch $out
-  '';
+  # Evaluate darwinConfigurations to catch import errors, type errors, and assertion failures.
+  # Uses unsafeDiscardStringContext on system.drvPath so the check is compatible with
+  # `nix flake check --no-build` (the reusable workflow runs with --no-build to avoid
+  # disk exhaustion on linux runners). Without discarding context, --no-build refuses
+  # to realise the input closure of the referenced .drv and reports "path is not valid".
+  # Module evaluation still happens (catching import/type/assertion errors); only the
+  # string context is dropped so the runCommand output doesn't require realisation.
+  module-eval =
+    let
+      drvPaths = pkgs.lib.concatStringsSep "\n" (
+        pkgs.lib.mapAttrsToList (
+          name: cfg: "${name}: ${builtins.unsafeDiscardStringContext (toString cfg.system.drvPath)}"
+        ) darwinConfigurations
+      );
+    in
+    pkgs.writeText "check-module-eval" drvPaths;
 }


### PR DESCRIPTION
## Summary
- Switch \`module-eval\` from \`pkgs.runCommand\` with \`\${cfg.system.drvPath}\` to \`pkgs.writeText\` with \`unsafeDiscardStringContext\`
- Preserves the evaluation behavior (catches import / type / assertion errors) while dropping the string context that broke \`nix flake check --no-build\`

## Why
The \`.github\` reusable workflow \`_nix-validate.yml\` now runs:
\`nix flake check --all-systems --no-build --print-build-logs --show-trace --keep-going\`

The \`--no-build\` flag is needed to avoid disk exhaustion on linux runners when evaluating \`checks.aarch64-darwin.*\` (where darwin packages like rustc-src, cctools, apple-sdk would otherwise be substituted, filling the runner's ~14GB free disk).

But with \`--no-build\`, the previous \`\${cfg.system.drvPath}\` in the runCommand build script carries string context — the input closure of that .drv — and Nix refuses to realise it, reporting:

\`\`\`
error: path 'jkmlj4k6pxh42nyx9x5bmirzvcshwx9y-inputs' is not valid
\`\`\`

Wrapping with \`unsafeDiscardStringContext (toString cfg.system.drvPath)\` evaluates \`system.drvPath\` (so module errors still surface) but drops the context. Output is then \`pkgs.writeText\`-emitted, which doesn't require realisation.

This matches the pattern used in \`JacobPEvans/nix-home/lib/checks.nix\` for the same reason.

## Test plan
- [ ] CI Gate / Nix Validate passes on this PR
- [ ] After merge, re-trigger CI on #1091 and #1086 — should turn green

Assisted-by: Claude <noreply@anthropic.com>