### PR TITLE
fix(ci): opt out of --all-systems for nix-validate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -103,6 +103,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      # darwinConfigurations references in module-eval are platform-specific
+      # (require darwin binaries to build), so --all-systems fails on linux
+      # with "platform mismatch". Evaluate the current system only.
+      all_systems: false
 
   markdown-lint:
     name: Markdown Lint

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -20,3 +20,7 @@ jobs:
   validate:
     name: Validate
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      # Same rationale as ci-gate.yml — darwinConfigurations checks fail with
+      # --all-systems on the linux runner (platform mismatch).
+      all_systems: false


### PR DESCRIPTION
## Summary
- Pass \`all_systems: false\` to \`_nix-validate.yml\` in both \`ci-gate.yml\` and \`ci-validate.yml\`
- Restores pre-#294 behavior where nix flake check evaluates the current system only

## Why
nix-darwin's \`module-eval\` (and other checks via \`darwinConfigurations\`) reference \`cfg.system.drvPath\`, which transitively requires darwin binaries to build. With \`--all-systems\` (introduced in JacobPEvans/.github#294), \`nix flake check\` attempted those builds on the linux runner and failed:

\`\`\`
error: Cannot build '<hash>-check-module-eval.drv'.
       Reason: platform mismatch
       Required system: 'aarch64-darwin'
       Current system: 'x86_64-linux'
\`\`\`

JacobPEvans/.github#300 made \`--all-systems\` opt-in via an \`all_systems\` workflow input (default true). This PR opts out for this repo.

If you later want cross-platform validation back, the right approach is a dedicated darwin runner job (not building darwin closures on linux).

## Test plan
- [ ] CI Gate / Nix Validate passes
- [ ] After merge, re-trigger CI on #1091 (feature/add-firefox) and #1086 (chore/flake-update-2026-05-10) — both should turn green

Assisted-by: Claude <noreply@anthropic.com>