### PR TITLE
fix(flake): scope checks to x86_64-linux; restore --all-systems default

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -103,11 +103,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
-    with:
-      # darwinConfigurations references in module-eval are platform-specific
-      # (require darwin binaries to build), so --all-systems fails on linux
-      # with "platform mismatch". Evaluate the current system only.
-      all_systems: false
 
   markdown-lint:
     name: Markdown Lint

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -20,7 +20,3 @@ jobs:
   validate:
     name: Validate
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
-    with:
-      # Same rationale as ci-gate.yml — darwinConfigurations checks fail with
-      # --all-systems on the linux runner (platform mismatch).
-      all_systems: false

--- a/flake.nix
+++ b/flake.nix
@@ -213,29 +213,38 @@
       # Formatter for `nix fmt` command
       formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;
 
-      # Quality checks for `nix flake check` (DRY principle)
-      # Single source of truth for pre-commit hooks and GitHub Actions
-      # Definitions in lib/checks.nix for better modularity
-      # Cross-platform: works on all systems
+      # Quality checks for `nix flake check` (DRY principle).
+      #
+      # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
+      # from a single linux runner. All checks in lib/checks.nix are source-only
+      # (formatting, statix, deadnix, shellcheck, shell-tests) — they operate
+      # on the same source files regardless of target system, so running once
+      # on the CI system is sufficient and equivalent. Other systems
+      # intentionally have no `checks` entries.
+      #
+      # Cross-platform breakage (e.g. darwin-only `meta.broken` in nixpkgs) is
+      # still caught by `--all-systems` evaluating `packages.aarch64-darwin`,
+      # `devShells.aarch64-darwin`, `formatter.aarch64-darwin`, and the
+      # `darwinConfigurations.*.system` derivations during flake evaluation.
+      #
+      # The darwin module-eval (only populated when `darwinConfigurations` is
+      # non-empty) was previously gated on `system == aarch64-darwin`; combined
+      # with the prior `all_systems: false` workaround, it never actually ran
+      # in CI. Dropping it here is therefore no regression. If on-runner darwin
+      # module-eval coverage is desired, run it as a post-merge job on a darwin
+      # runner or via a dedicated workflow.
       checks =
-        nixpkgs.lib.genAttrs
-          [
-            "aarch64-darwin"
-            "x86_64-darwin"
-            "x86_64-linux"
-            "aarch64-linux"
-          ]
-          (
-            system:
-            let
-              pkgs = nixpkgs.legacyPackages.${system};
-            in
-            import ./lib/checks.nix {
-              inherit pkgs;
-              src = ./.;
-              darwinConfigurations = if system == "aarch64-darwin" then { default = darwinConfig; } else { };
-            }
-          );
+        let
+          system = "x86_64-linux";
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          ${system} = import ./lib/checks.nix {
+            inherit pkgs;
+            src = ./.;
+            darwinConfigurations = { };
+          };
+        };
 
       # Development shell for CI and local nix tooling
       devShells.aarch64-darwin.default = nixpkgs.legacyPackages.aarch64-darwin.mkShell {


### PR DESCRIPTION
## Summary

This repo had been opting out of `--all-systems` via `all_systems: false` in `ci-gate.yml` and `ci-validate.yml` to dodge "platform mismatch" errors on the linux runner. That workaround loses the cross-platform evaluation that motivated `--all-systems` in the first place (catching darwin-only `meta.broken` packages in nixpkgs).

This PR applies the same root-cause fix used in [nix-home#241](https://github.com/JacobPEvans/nix-home/pull/241):

- **`flake.nix`**: scope `checks` to `x86_64-linux` only. All checks in `lib/checks.nix` are source-only (formatting, statix, deadnix, shellcheck, shell-tests) — running them once on the CI system is sufficient.
- **`flake.nix`**: drop `darwinConfigurations` from the check args. The darwin `module-eval` check was already gated on `system == aarch64-darwin` and never ran in CI under the prior `all_systems: false` workaround, so this is no regression.
- **`ci-gate.yml` / `ci-validate.yml`**: remove `all_systems: false` so the `_nix-validate.yml` default (`true`) takes effect.

With these changes, `nix flake check --all-systems` succeeds on x86_64-linux runners and still evaluates `packages.aarch64-darwin.*`, `devShells.aarch64-darwin.default`, `formatter.aarch64-darwin`, and the `darwinConfigurations.*` graph cross-system — so darwin breakage in nixpkgs continues to be caught at PR time.

## Verification

Local `nix flake check --all-systems --print-build-logs --show-trace --keep-going` confirms:

- `darwinConfigurations.{default,jevans-mbp}` ✅ (build skipped — cross-system)
- `packages.aarch64-darwin.{cribl-edge,claudebar}` ✅
- `formatter.aarch64-darwin` ✅
- `devShells.aarch64-darwin.default` ✅
- Only `checks.x86_64-linux.*` are declared
- The local "Cannot build x86_64-linux drv on aarch64-darwin" errors are expected on my machine and will not appear on the CI runner

## Test plan

- [ ] CI on this PR: `Nix Validate / Validate` passes with `--all-systems` enabled (no platform-mismatch errors)
- [ ] `Nix Build` job still passes (darwin runner, separate workflow)
- [ ] Cross-system evaluation continues to catch darwin-only `meta.broken` packages

## Companion PRs

- [JacobPEvans/.github#313](https://github.com/JacobPEvans/.github/pull/313) — adds `all_systems` passthrough to `_ci-gate.yml` (defensive lever)
- [JacobPEvans/nix-home#241](https://github.com/JacobPEvans/nix-home/pull/241) — same flake-level fix in nix-home (unblocks #240 there)