### PR TITLE
fix(ci): update jacobpevans-cc-plugins, not anthropics claude-code-plugins

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update JacobPEvans flake inputs
         if: inputs.target == 'jacobpevans'
-        run: nix flake update nix-home nix-ai ai-assistant-instructions claude-code-plugins
+        run: nix flake update nix-home nix-ai ai-assistant-instructions jacobpevans-cc-plugins
 
       - name: Validate flake
         run: nix flake check --no-build

--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1779010155,
-        "narHash": "sha256-uO9A5QpW7ArFRtSPVOooe3s7FPRmXbeKgTJiBNb/4OM=",
+        "lastModified": 1779109519,
+        "narHash": "sha256-l1ObfpqYgRdT4N5xEq5WCd1tDwNeIRhpwQMDpqRTpxo=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "465f1126175573f846adc67dd401530028454ab3",
+        "rev": "dd6e78ebdf1dd7a7eab823ac2ceae525d8ea9af9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- `deps-update-flake.yml` (target=jacobpevans) listed `claude-code-plugins` as a JacobPEvans input. In `flake.nix`, that name belongs to `github:anthropics/claude-code`. The JacobPEvans repo is aliased as `jacobpevans-cc-plugins`, so every `target=jacobpevans` run silently skipped the JacobPEvans claude-code-plugins input.
- Fix the workflow to update `jacobpevans-cc-plugins`, and bump `flake.lock` to catch up (`465f1126` → `dd6e78eb`, picks up PRs #311 and #312).
- The anthropics `claude-code-plugins` input is managed by Renovate's nix manager (per the file's header comment) and was already current, so dropping it from the JacobPEvans target is correct.

## Discovered while

Running PR #1116 today (the same workflow on `target=jacobpevans`) — it bumped 3 of 4 JacobPEvans inputs and silently left `jacobpevans-cc-plugins` 1 day behind upstream.

## Test plan

- [x] `nix flake check --no-build` clean locally
- [ ] CI Gate (Nix Validate / Nix Build / CodeQL / File Size / Verify package freshness) green
- [ ] After merge, next `target=jacobpevans` run picks up all four JacobPEvans inputs