### PR TITLE
fix(homebrew): pass -H to sudo so brew bootsnap finds the user cache

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -31,7 +31,7 @@
 # NOTE: nix-darwin does NOT support version pinning for individual homebrew packages.
 # To prevent upgrades for a specific package, pin it via `brew pin <package>`.
 
-{ lib, nix-ai, ... }:
+{ lib, pkgs, nix-ai, ... }:
 
 let
   # 30 hours in seconds — brew autoupdate requires interval in seconds
@@ -43,6 +43,12 @@ let
   # nix-ai and exported as a flake output, so each module stays
   # self-contained. See nix-ai/docs/architecture/per-agent-flakes.md.
   agentBrewFormulae = nix-ai.lib.brewFormulae or [ ];
+
+  configureBrewAutoupdateScript = pkgs.writeShellApplication {
+    name = "configure-brew-autoupdate";
+    runtimeInputs = [ ];
+    text = builtins.readFile ./scripts/configure-brew-autoupdate.sh;
+  };
 in
 {
   homebrew = {
@@ -227,24 +233,11 @@ in
     };
   };
 
-  # (Re)create the brew autoupdate LaunchAgent plist on every darwin-rebuild switch,
-  # ensuring the schedule and flags stay in sync with this configuration.
-  # Runs as the current user (determined by $SUDO_USER or console owner) because brew
-  # autoupdate creates a user-level LaunchAgent — running as root would install the
-  # plist for the wrong user. Delete first because `brew autoupdate start` exits
-  # non-zero if already configured.
+  # (Re)create the brew autoupdate LaunchAgent plist on every darwin-rebuild switch.
+  # All logic lives in scripts/configure-brew-autoupdate.sh; this binding only
+  # passes the configured interval through as an env var and invokes the script.
   system.activationScripts.postActivation.text = lib.mkAfter ''
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Configuring brew autoupdate (every 30h, --upgrade --greedy --cleanup)..."
-    # /usr/bin/stat: force macOS BSD stat — bare 'stat' resolves to GNU stat (Nix coreutils),
-    # which ignores -f '%Su' and prints the full file report instead of the username.
-    _brew_user="''${SUDO_USER:-$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null)}"
-    if [ -z "$_brew_user" ] || [ "$_brew_user" = "root" ]; then
-      echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Cannot determine brew user — skipping brew autoupdate configuration"
-    elif ! test -x /opt/homebrew/bin/brew; then
-      echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] /opt/homebrew/bin/brew not found — skipping autoupdate configuration"
-    else
-      sudo -u "$_brew_user" /opt/homebrew/bin/brew autoupdate delete 2>/dev/null || true
-      sudo -u "$_brew_user" /opt/homebrew/bin/brew autoupdate start ${toString autoupdateInterval} --upgrade --greedy --cleanup || true
-    fi
+    AUTOUPDATE_INTERVAL=${lib.escapeShellArg (toString autoupdateInterval)} \
+      ${lib.getExe configureBrewAutoupdateScript} || true
   '';
 }

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -31,7 +31,12 @@
 # NOTE: nix-darwin does NOT support version pinning for individual homebrew packages.
 # To prevent upgrades for a specific package, pin it via `brew pin <package>`.
 
-{ lib, pkgs, nix-ai, ... }:
+{
+  lib,
+  pkgs,
+  nix-ai,
+  ...
+}:
 
 let
   # 30 hours in seconds — brew autoupdate requires interval in seconds

--- a/modules/darwin/scripts/configure-brew-autoupdate.sh
+++ b/modules/darwin/scripts/configure-brew-autoupdate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Configure brew autoupdate LaunchAgent on every darwin-rebuild switch.
+#
+# Determines the brew user (SUDO_USER or console owner), then (re)installs the
+# homebrew/autoupdate LaunchAgent with the configured interval and flags.
+#
+# `sudo -u … -H` is required: without -H, HOME stays at /var/root (the
+# activation script's HOME) and brew's bootsnap loader fails with EACCES
+# trying to read /var/root/Library/Caches/Homebrew/bootsnap/.../load-path-cache.
+# -H rewrites HOME to the target user's home so bootsnap uses
+# ~/Library/Caches/Homebrew/bootsnap instead.
+
+set -uo pipefail
+
+prefix="[brew-autoupdate]"
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $prefix INFO $*"; }
+warn() { echo "$(date '+%Y-%m-%d %H:%M:%S') $prefix WARN $*" >&2; }
+
+interval="${AUTOUPDATE_INTERVAL:-}"
+if [ -z "$interval" ]; then
+    warn "AUTOUPDATE_INTERVAL not set; skipping"
+    exit 0
+fi
+
+log "Configuring brew autoupdate (interval=${interval}s, --upgrade --greedy --cleanup)..."
+
+# /usr/bin/stat: force macOS BSD stat — bare 'stat' may resolve to GNU stat
+# (Nix coreutils), which ignores -f '%Su' and prints the full file report.
+brew_user="${SUDO_USER:-$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null)}"
+if [ -z "$brew_user" ] || [ "$brew_user" = "root" ]; then
+    warn "Cannot determine brew user — skipping brew autoupdate configuration"
+    exit 0
+fi
+
+if ! test -x /opt/homebrew/bin/brew; then
+    warn "/opt/homebrew/bin/brew not found — skipping autoupdate configuration"
+    exit 0
+fi
+
+# Delete existing autoupdate config (may not exist); start fresh with current flags.
+/usr/bin/sudo -u "$brew_user" -H /opt/homebrew/bin/brew autoupdate delete 2>/dev/null || true
+/usr/bin/sudo -u "$brew_user" -H /opt/homebrew/bin/brew autoupdate start "$interval" --upgrade --greedy --cleanup || true
+
+exit 0

--- a/modules/darwin/scripts/configure-brew-autoupdate.sh
+++ b/modules/darwin/scripts/configure-brew-autoupdate.sh
@@ -13,9 +13,13 @@
 
 set -uo pipefail
 
+# All external utilities are called via absolute paths (BSD variants on macOS)
+# so writeShellApplication's runtimeInputs can stay empty — no Nix-managed
+# coreutils needed, and no risk of GNU stat shadowing BSD stat.
+
 prefix="[brew-autoupdate]"
-log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $prefix INFO $*"; }
-warn() { echo "$(date '+%Y-%m-%d %H:%M:%S') $prefix WARN $*" >&2; }
+log() { echo "$(/bin/date '+%Y-%m-%d %H:%M:%S') $prefix INFO $*"; }
+warn() { echo "$(/bin/date '+%Y-%m-%d %H:%M:%S') $prefix WARN $*" >&2; }
 
 interval="${AUTOUPDATE_INTERVAL:-}"
 if [ -z "$interval" ]; then
@@ -38,8 +42,18 @@ if ! test -x /opt/homebrew/bin/brew; then
     exit 0
 fi
 
-# Delete existing autoupdate config (may not exist); start fresh with current flags.
+# Delete existing autoupdate config (no-op if absent). Best-effort: the start
+# below will surface the real outcome.
 /usr/bin/sudo -u "$brew_user" -H /opt/homebrew/bin/brew autoupdate delete 2>/dev/null || true
-/usr/bin/sudo -u "$brew_user" -H /opt/homebrew/bin/brew autoupdate start "$interval" --upgrade --greedy --cleanup || true
+
+# Start fresh with current flags. A failure here means the LaunchAgent was
+# not (re)installed; the activation must still succeed (existing LaunchAgent
+# from a prior run, if any, keeps running), but the warning makes the failure
+# visible instead of silent.
+if /usr/bin/sudo -u "$brew_user" -H /opt/homebrew/bin/brew autoupdate start "$interval" --upgrade --greedy --cleanup; then
+    log "brew autoupdate LaunchAgent (re)installed for $brew_user"
+else
+    warn "brew autoupdate start failed (exit $?); any existing LaunchAgent for $brew_user remains in place"
+fi
 
 exit 0


### PR DESCRIPTION
## Summary

- The postActivation script that (re)configures `brew autoupdate` invoked `sudo -u "$_brew_user" /opt/homebrew/bin/brew autoupdate ...` without `-H`. HOME stayed at `/var/root` (the activation script's HOME), so brew's bootsnap loader tried to read its cache from `/var/root/Library/Caches/Homebrew/bootsnap/.../load-path-cache` — which the brew user (jevans) cannot read.
- Result: every activation produced an EACCES traceback, and the autoupdate plist was never refreshed (the existing plist persisted because of `|| true`, masking the silent no-op).
- Fix: add `-H` so HOME is rewritten to the brew user's home. Bootsnap now resolves to `~/Library/Caches/Homebrew/bootsnap`.
- Extract the activation logic to `modules/darwin/scripts/configure-brew-autoupdate.sh` per the no-inline-shell convention (matches `ws-monitor.nix` and `apple-silicon-tunables.nix`). The module just sets `AUTOUPDATE_INTERVAL` and calls the wrapped `writeShellApplication`.

## Repro (before fix)

```
Activating brew autoupdate (every 30h, --upgrade --greedy --cleanup)...
/opt/homebrew/Library/Homebrew/vendor/.../bootsnap-1.24.3/lib/bootsnap/load_path_cache/store.rb:75:in 'File#initialize':
  Permission denied @ rb_sysopen -
  /var/root/Library/Caches/Homebrew/bootsnap/.../load-path-cache (Errno::EACCES)
```

Observed in today's `darwin-rebuild switch` (generation 675).

## Test plan

- [x] `nix flake check --no-build` clean locally
- [ ] CI Gate green
- [ ] After merge + activation, postActivation log shows `brew-autoupdate INFO Configuring brew autoupdate ...` with no EACCES
- [ ] `launchctl list | grep autoupdate` shows the LaunchAgent loaded