### PR TITLE
feat(cribl-edge): bump to 4.18.0 and fix cloud enrollment (URL + port)

### DIFF
--- a/modules/darwin/apps/scripts/cribl-edge-start.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-start.sh
@@ -5,15 +5,19 @@
 #   $1 = path to sops-rendered KEY=value secrets file (root-only 0400)
 #   $2 = CRIBL_VOLUME_DIR (mutable state / data dir)
 #   $3 = CRIBL_HOME (read-only path into the Nix store package)
-#   $4 = Cribl fleet group name
+#   $4 = Cribl fleet group name (default; overridden by the URL's `?group=` if present)
 #
 # Responsibilities:
-#   1. Safely load CRIBL_ORG_ID / CRIBL_WORKSPACE_ID / CRIBL_TOKEN from the
-#      secrets file without shell eval (no `source` of arbitrary content).
+#   1. Safely load credentials from the secrets file without shell eval.
+#      Two formats are honored, in order of preference:
+#        a) CRIBL_DIST_MASTER_URL=tls://TOKEN@HOST:PORT?group=GROUP
+#           (the form Cribl Cloud's "Add Edge Node" panel displays today —
+#            one var carries token, host, port, and group)
+#        b) CRIBL_ORG_ID / CRIBL_WORKSPACE_ID / CRIBL_TOKEN (legacy 3-var flow)
 #   2. Ensure the data + log directories exist.
-#   3. On first start, enroll as a managed edge node with Cribl Cloud and
-#      drop an .enrolled marker so subsequent starts are a no-op. Enrollment
-#      failures are fatal — launchd will retry via ThrottleInterval.
+#   3. On first start, enroll as a managed edge node and drop an .enrolled
+#      marker so subsequent starts skip enrollment. Enrollment failures are
+#      fatal — launchd retries via ThrottleInterval.
 #   4. exec `cribl server`.
 
 set -euo pipefail
@@ -34,42 +38,78 @@ fi
 
 # Parse KEY=value without eval. Only whitelisted keys are honored; every other
 # line is silently ignored so a malformed or tampered file cannot inject shell.
+CRIBL_DIST_MASTER_URL=""
 CRIBL_ORG_ID=""
 CRIBL_WORKSPACE_ID=""
 CRIBL_TOKEN=""
 while IFS='=' read -r _key _value || [ -n "$_key" ]; do
   case "$_key" in
     ""|\#*) continue ;;
-    CRIBL_ORG_ID)       CRIBL_ORG_ID="$_value" ;;
-    CRIBL_WORKSPACE_ID) CRIBL_WORKSPACE_ID="$_value" ;;
-    CRIBL_TOKEN)        CRIBL_TOKEN="$_value" ;;
+    CRIBL_DIST_MASTER_URL) CRIBL_DIST_MASTER_URL="$_value" ;;
+    CRIBL_ORG_ID)          CRIBL_ORG_ID="$_value" ;;
+    CRIBL_WORKSPACE_ID)    CRIBL_WORKSPACE_ID="$_value" ;;
+    CRIBL_TOKEN)           CRIBL_TOKEN="$_value" ;;
   esac
 done < "$SECRETS_FILE"
-export CRIBL_ORG_ID CRIBL_WORKSPACE_ID CRIBL_TOKEN
+export CRIBL_DIST_MASTER_URL CRIBL_ORG_ID CRIBL_WORKSPACE_ID CRIBL_TOKEN
 
 mkdir -p "$CRIBL_VOLUME_DIR" "$CRIBL_VOLUME_DIR/logs"
 
-# Enroll once per data volume. The .enrolled marker guards idempotency so that
-# a hard failure of mode-managed-edge (missing/revoked token, network outage)
-# surfaces via launchd rather than being silently swallowed.
+# Enroll once per data volume. The .enrolled marker guards idempotency so a
+# hard failure (revoked token, network outage) surfaces via launchd rather
+# than being silently swallowed.
 if [ ! -f "$CRIBL_VOLUME_DIR/.enrolled" ] \
    && [ ! -f "$CRIBL_VOLUME_DIR/local/_system/instance.yml" ] \
    && [ ! -f "$CRIBL_VOLUME_DIR/local/edge/instance.yml" ]; then
   echo "$(ts) [INFO] Enrolling Cribl Edge to cloud..."
-  if [ -z "${CRIBL_WORKSPACE_ID:-}" ] || [ -z "${CRIBL_ORG_ID:-}" ] || [ -z "${CRIBL_TOKEN:-}" ]; then
-    echo "$(ts) [ERROR] Missing required Cribl secrets for enrollment." >&2
+
+  # Derive enrollment args. Prefer CRIBL_DIST_MASTER_URL since Cribl Cloud's
+  # "Add Edge Node" panel today displays the single-URL form by default. The
+  # legacy `${WORKSPACE}-${ORG}.cribl.cloud:443` enrollment is a pre-2025
+  # shape — Cribl Cloud has since moved worker-master comms to port 4200
+  # with a different host name pattern, so the legacy path is left only as
+  # a fallback for older secrets files.
+  if [ -n "$CRIBL_DIST_MASTER_URL" ]; then
+    # tls://TOKEN@HOST:PORT?group=GROUP — parse via bash parameter expansion,
+    # not eval, to keep the no-shell-injection guarantee.
+    _nopath="${CRIBL_DIST_MASTER_URL#*://}"
+    _enroll_token="${_nopath%%@*}"
+    _rest="${_nopath#*@}"
+    _enroll_host="${_rest%%:*}"
+    _portq="${_rest#*:}"
+    _enroll_port="${_portq%%\?*}"
+    if [[ "$_portq" == *"?group="* ]]; then
+      _enroll_group="${_portq#*\?group=}"
+      # Strip any trailing &key=val if Cribl adds more query params later.
+      _enroll_group="${_enroll_group%%&*}"
+    else
+      _enroll_group="$CRIBL_GROUP"
+    fi
+
+    if [ -z "$_enroll_token" ] || [ -z "$_enroll_host" ] || [ -z "$_enroll_port" ] || [ -z "$_enroll_group" ]; then
+      echo "$(ts) [ERROR] CRIBL_DIST_MASTER_URL is malformed (token/host/port/group): $CRIBL_DIST_MASTER_URL" >&2
+      exit 1
+    fi
+  elif [ -n "$CRIBL_WORKSPACE_ID" ] && [ -n "$CRIBL_ORG_ID" ] && [ -n "$CRIBL_TOKEN" ]; then
+    _enroll_token="$CRIBL_TOKEN"
+    _enroll_host="${CRIBL_WORKSPACE_ID}-${CRIBL_ORG_ID}.cribl.cloud"
+    _enroll_port="4200"
+    _enroll_group="$CRIBL_GROUP"
+  else
+    echo "$(ts) [ERROR] No Cribl enrollment credentials in secrets file." >&2
+    echo "$(ts) [ERROR] Set either CRIBL_DIST_MASTER_URL or all of CRIBL_ORG_ID, CRIBL_WORKSPACE_ID, CRIBL_TOKEN." >&2
     exit 1
   fi
 
   "$CRIBL_HOME/bin/cribl" mode-managed-edge \
-    -H "${CRIBL_WORKSPACE_ID}-${CRIBL_ORG_ID}.cribl.cloud" \
-    -p 443 \
-    -u "$CRIBL_TOKEN" \
-    -g "$CRIBL_GROUP" \
+    -H "$_enroll_host" \
+    -p "$_enroll_port" \
+    -u "$_enroll_token" \
+    -g "$_enroll_group" \
     -S true
 
   : > "$CRIBL_VOLUME_DIR/.enrolled"
-  echo "$(ts) [INFO] Cribl Edge enrolled."
+  echo "$(ts) [INFO] Cribl Edge enrolled to $_enroll_host:$_enroll_port (group=$_enroll_group)."
 fi
 
 exec "$CRIBL_HOME/bin/cribl" server

--- a/packages/cribl-edge.nix
+++ b/packages/cribl-edge.nix
@@ -8,11 +8,16 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "cribl-edge";
-  version = "4.17.0-7e952fa7"; # cribl-edge
+  version = "4.18.0-dfc74421"; # cribl-edge
+
+  # Release directory is the semver portion of `version` (before the `-build`).
+  # Renovate's customManager only rewrites `version`, so the URL must derive
+  # the dir from it — hardcoding `/dl/4.17.0/` once broke this on a 4.18 bump.
+  releaseDir = lib.head (lib.splitString "-" version);
 
   src = fetchurl {
-    url = "https://cdn.cribl.io/dl/4.17.0/cribl-${version}-darwin-universal.pkg";
-    hash = "sha256-A9oKAVzMCAW3cIcJpYTyu3EXmOrZLA5pPxv3FZyUbLY=";
+    url = "https://cdn.cribl.io/dl/${releaseDir}/cribl-${version}-darwin-universal.pkg";
+    hash = "sha256-szztWYz4F5E+T/gj7T2BU6TqMdQT3qa95IpUk3V3rtA=";
   };
 
   nativeBuildInputs = [

--- a/packages/cribl-edge.nix
+++ b/packages/cribl-edge.nix
@@ -10,10 +10,14 @@ stdenvNoCC.mkDerivation rec {
   pname = "cribl-edge";
   version = "4.18.0-dfc74421"; # cribl-edge
 
-  # Release directory is the semver portion of `version` (before the `-build`).
-  # Renovate's customManager only rewrites `version`, so the URL must derive
-  # the dir from it — hardcoding `/dl/4.17.0/` once broke this on a 4.18 bump.
-  releaseDir = lib.head (lib.splitString "-" version);
+  # Release directory is the semver portion of `version`. Renovate's
+  # customManager only rewrites `version`, so the URL must derive the dir
+  # from it — hardcoding `/dl/4.17.0/` once broke this on a 4.18 bump.
+  releaseDir = lib.concatStringsSep "." [
+    (lib.versions.major version)
+    (lib.versions.minor version)
+    (lib.versions.patch version)
+  ];
 
   src = fetchurl {
     url = "https://cdn.cribl.io/dl/${releaseDir}/cribl-${version}-darwin-universal.pkg";


### PR DESCRIPTION
## Summary

Two related changes needed to bring the macbook-m4 Cribl Edge → Cribl Cloud chain back online after it died silently on 2026-05-13:

1. **Bump Cribl Edge 4.17.0-7e952fa7 → 4.18.0-dfc74421.** Also derive the URL's release directory from the version string itself so Renovate's customManager (which only rewrites `version`) doesn't leave the URL stuck on the previous minor.
2. **Fix the enrollment script.** It hardcoded port `443` and built the master host from `\${WORKSPACE}-\${ORG}.cribl.cloud` — both stale. Cribl Cloud now ships a single-string URL of the form `tls://TOKEN@main-stoic-kaminsky-d9o9i3r.cribl.cloud:4200?group=default_fleet`. Honor that URL (`CRIBL_DIST_MASTER_URL`) as the preferred enrollment input; parse it with pure bash parameter expansions (no eval, preserves the no-shell-injection guarantee); fall back to the legacy 3-var flow with port bumped to 4200.

Without both fixes, the daemon loops on `\"authentication failed\"` + ECONNRESET, then exits and launchd's KeepAlive cannot recover. The pipeline has been silent since 2026-05-13.

## Verification

- \`nix flake check\` clean
- \`sudo darwin-rebuild switch --flake .\` succeeded; daemon now running from \`/nix/store/7azzcv0chn554nr0fqs62v1w9jfz4ngp-cribl-edge-4.18.0-dfc74421/opt/cribl/bin/cribl\`
- Hash verified via \`nix-prefetch-url\` + \`nix-hash --to-sri\`
- Bash parser verified against the real URL: emits the correct token / host / port / group fields

## To deploy the fix

After this PR merges:

\`\`\`
sudo rm /opt/cribl-data/local/_system/instance.yml /opt/cribl-data/.enrolled
sudo darwin-rebuild switch --flake .
\`\`\`

The daemon will then re-enroll using \`CRIBL_DIST_MASTER_URL\` from sops, and the chain comes back online.

## Test plan

- [x] \`nix flake check\`
- [x] \`darwin-rebuild switch\` (already running locally)
- [x] Bash parser unit-tested against the real URL
- [ ] CI macOS Nix Build (auto-runs on this PR)
- [ ] Post-merge: delete stale instance.yml, verify Cribl Cloud reports \`macbook-m4\` as online in the \`default_fleet\` fleet
- [ ] Post-merge: verify Splunk \`index=os host=macbook-m4\` resumes receiving data

🤖 Generated with [Claude Code](https://claude.com/claude-code)