### PR TITLE
chore(dock): replace Firefox with Windows App

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -197,6 +197,7 @@ via LaunchAgent) always installs the latest version rather than deferring to bui
 |-----|-----|
 | Toggl Track | 1291898086 |
 | Monarch Money Tweaks | 6753774259 |
+| Windows App | 1295203466 |
 | Microsoft Word | 462054704 |
 | Microsoft Excel | 462058435 |
 | Microsoft PowerPoint | 462062816 |

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -56,7 +56,9 @@ in
       # Browsers
       "/Applications/Safari.app"
       "/Applications/Brave Browser.app"
-      "/Applications/Firefox.app"
+
+      # Remote Desktop
+      "/Applications/Windows App.app"
 
       # NOTE: Ollama runs headless via LaunchAgent, no dock icon needed.
       # NOTE: Additional AI tools (ChatGPT, Cursor) can be found in

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -224,6 +224,7 @@ in
     masApps = {
       "Toggl Track" = 1291898086; # Time tracking
       "Monarch Money Tweaks" = 6753774259; # Personal finance enhancements
+      "Windows App" = 1295203466; # Microsoft Remote Desktop / Windows 365 / AVD client
       # NOTE: GoPro Quik (561350520) removed - no longer needed
 
       # Microsoft 365 bundle (https://apps.apple.com/us/app-bundle/microsoft-365/id1450038993)


### PR DESCRIPTION
## Summary

- Drop Firefox from the dock; pin **Windows App** (Microsoft Remote Desktop / Windows 365 / AVD client) at the trailing slot
- Declare `Windows App` (id `1295203466`) in `masApps` so fresh machines install it from the Mac App Store
- Update `MANIFEST.md` to list Windows App alongside the other MAS apps

Firefox remains installed via the `firefox` homebrew cask (kept for TCC permission stability); it just no longer occupies a permanent dock slot.

## Test plan

- [ ] CI `nix flake check` passes on macOS runner
- [ ] After merge: `darwin-rebuild switch` shows Windows App at the end of the dock, Firefox removed
- [ ] `mas list | grep 1295203466` confirms MAS-declared install survives a future fresh provision