### PR TITLE
chore(renovate): simplify scheduling config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,6 @@
 
   // Repository settings
   "baseBranches": ["main"],
-  "timezone": "America/New_York",
   "labels": ["dependencies", "renovate"],
   "assignees": ["@JacobPEvans"],
   "reviewers": ["@JacobPEvans"],


### PR DESCRIPTION
## Summary

Drop an explicit field that's not needed; defaults work.

## Test plan

- [x] File parses (json5)
- [ ] Renovate continues to apply repo's package rules

Assisted-by: Claude <noreply@anthropic.com>