### PR TITLE
chore(deps): update all flake inputs (2026-05-06 snapshot)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1777769870,
-        "narHash": "sha256-rS29ELwZuWtjo7UL2h0VL1Gci70VuRxSPpC4LKKNlms=",
+        "lastModified": 1778079068,
+        "narHash": "sha256-9WipSZ7UGHyleeiAqzRXL+defk1WP+vgYIxCWyqWM9g=",
         "owner": "JacobPEvans",
         "repo": "ai-assistant-instructions",
-        "rev": "7e5bceceafa0662cd4a9adb96b8089a7c21b9553",
+        "rev": "6dcc4829c89b07e86a51d55c218e841f4b7f778e",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "anthropic-agent-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1776964038,
-        "narHash": "sha256-xFsg66TCtKzSgRIW6Ab771FWEIhei3jPgfE4byMiB44=",
+        "lastModified": 1777816720,
+        "narHash": "sha256-6GyoLtVWna20TrLg7Y2R6wCWD6C4GbDtIB0jbl5VESY=",
         "owner": "anthropics",
         "repo": "skills",
-        "rev": "5128e1865d670f5d6c9cef000e6dfc4e951fb5b9",
+        "rev": "d230a6dd6eb1a0dbee9fec55e2f00a96e28dff81",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "bitwarden-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1777017020,
-        "narHash": "sha256-FWZRq53J9JZAA7iLCVI52fgtkjlbVLk+83i/T80O/QI=",
+        "lastModified": 1777556392,
+        "narHash": "sha256-3Dy9swpUhIeNAcKxdkqjYIWA8AhD1G5vkCGZ1VmgMFo=",
         "owner": "bitwarden",
         "repo": "ai-plugins",
-        "rev": "fc8eea80fff88b77592c65f25256df6e095fa28f",
+        "rev": "57b8aa92a27d63fde2a1281812d96955937dad48",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     "browser-use-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1777222747,
-        "narHash": "sha256-sKL1Sct9vON0WwuRfCIipAkRfwdC4/CNOB+yo0qqcTQ=",
+        "lastModified": 1777773739,
+        "narHash": "sha256-WnurdJs1+ypAaClIvg+05TP8MplQZ4hmmM7ivF8l8Ks=",
         "owner": "browser-use",
         "repo": "browser-use",
-        "rev": "d19ec6ef20e5c68bf4ca198e8b0b5aea69280fe6",
+        "rev": "8fc4f34a66e7a1b7aaa78b5ba929efd66adcccb7",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "cc-dev-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1777270899,
-        "narHash": "sha256-LWP+LJX4+h8KzLkPFTr6+CrVuXUg4ss/fWYd/CNKsR0=",
+        "lastModified": 1777301179,
+        "narHash": "sha256-mLJftGTU06SLQ98g2yqYdNAWj2OPwjxNhuvDnITr9vM=",
         "owner": "Lucklyric",
         "repo": "cc-dev-tools",
-        "rev": "8e46b8035f96e6c9f963d21aa2689062430bc571",
+        "rev": "4503ef2ee3ee6ac5dcf58aea1ffe1148c81b9c87",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1777605092,
-        "narHash": "sha256-/TtsOBOyD+mhb3c1kF5BUfXVKUjo8co6vfqwTv2W4eY=",
+        "lastModified": 1778105288,
+        "narHash": "sha256-SWObJYseD3TuPbdZVeYUJvfjGteThdONgW9i5kN8qEE=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "5bf19945e4e9e38d298ddc2befd5c30a7d504fb8",
+        "rev": "60348c95361c632ea4898ae32a8eaae7bcfbb37a",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-code-plugins-plus": {
       "flake": false,
       "locked": {
-        "lastModified": 1776921897,
-        "narHash": "sha256-wDfJFzpqRYnwktYgF0n7p4TbuZOOFkARh8OhyS1q8s0=",
+        "lastModified": 1777869138,
+        "narHash": "sha256-3dCIQjEXQ5S6otCjFNM7jl1Q9fwO6AJ+HPgAb5sLNx0=",
         "owner": "jeremylongshore",
         "repo": "claude-code-plugins-plus",
-        "rev": "3076d78733bbdec692738872e8c960f95019449d",
+        "rev": "13d35b82857229a4cb610d5469a227a32536aae4",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "claude-code-workflows": {
       "flake": false,
       "locked": {
-        "lastModified": 1777236151,
-        "narHash": "sha256-Yw6yFRqpx2//EcrWUdPvNKxrQzhYUHdKyVNQ8hPKvTc=",
+        "lastModified": 1777757712,
+        "narHash": "sha256-6u6F3tsEg0TmaTfJN3ETBkkjGtg9kjOKwakHvtJDDEc=",
         "owner": "wshobson",
         "repo": "agents",
-        "rev": "adde832d8fc08cfb22ab44ec14661293c7ad9153",
+        "rev": "ece811f23310a37ceb43496dbac0e244fe6845b6",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1775867615,
-        "narHash": "sha256-sDC2q9iJcN+n/wPr1fItLf+vNxBW8euUJROb5cHc0xA=",
+        "lastModified": 1777323600,
+        "narHash": "sha256-HgTuypAI6Z1Mbm9uTQzjmc3VO8Pv5Xb8rozHbM5JL1c=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "753ddfe35fdc7e310a45cadcfe314ba6809672f8",
+        "rev": "33424c3eb476cd56379435be086ccc228af1050d",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1776980748,
-        "narHash": "sha256-ywyOB23pJaOQHf2nPvis1fNqpNPVUM59upxETzl6KCw=",
+        "lastModified": 1777667898,
+        "narHash": "sha256-zUogHhL7MWXqpRDzjKI3giqyWJMArQDoSKooxhwfj/8=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "020446a4294f09d9c32e60bff0c4ae8fb39205cb",
+        "rev": "b392f51899343f35a203260a4b344803de236d13",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "claude-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1775668456,
-        "narHash": "sha256-AGvjE398hSve2gctkVodCdcmMsN8/7OdwMTx4gR8rOo=",
+        "lastModified": 1777450934,
+        "narHash": "sha256-kCtjYCc9rARHoWPEebL/g4KnEj8Qdp3AjOXXm9ubvao=",
         "owner": "secondsky",
         "repo": "claude-skills",
-        "rev": "88da5ffe9767d2b75bd5a5545165ca4bcd868168",
+        "rev": "b30de6b7f8d72f3467282861a376d017025d044d",
         "type": "github"
       },
       "original": {
@@ -270,12 +270,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777422823,
-        "narHash": "sha256-FFtBMlb0L6557RRfFnKpUM73HfZ+mX73yXObac8YsS0=",
-        "rev": "2204e8061f57aa05d2bd09f952731af2de598ee8",
-        "revCount": 414,
+        "lastModified": 1777920462,
+        "narHash": "sha256-LcwRttYxf2u6WUQC53alL0mdEoAJjOZ3AVMVXj2SdgI=",
+        "rev": "f3e0ac2fd392912b6af164b61b9aeadb7a4c1ef1",
+        "revCount": 415,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.19.0/019dd6ab-9a6f-79b1-8c34-9987e1d093e3/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.19.1/019df455-18df-7300-905f-4cd973ae848d/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -285,37 +285,37 @@
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-oM8RMz8mgY4msJwWEXw9dZU+CvYuVkricMTu7dtcu4w=",
+        "narHash": "sha256-+d0XZPSqqTSPrSMSf1Vz/ipsZhnW+p27RH0d6XywOMU=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/macOS"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/macOS"
       }
     },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-FQKhMdsvxl1ycPAi5g9mILHc5nmvgO0RUpOzUg1niH0=",
+        "narHash": "sha256-oCCfgSQZBdiNBRolKQHap9En1JU+62pZd1M7kkvpqQ8=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/aarch64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/aarch64-linux"
       }
     },
     "determinate-nixd-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-WIv+d77Ese+R5wmfnWboS5SBcChq7OmSk0ETKOfehKE=",
+        "narHash": "sha256-F/Csmk0KQas8anb9nepMyqMptMHMoShmOljomLEK5Wo=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/x86_64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.0/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.19.1/x86_64-linux"
       }
     },
     "fabric-src": {
@@ -442,11 +442,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775425411,
-        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
         "type": "github"
       },
       "original": {
@@ -459,11 +459,11 @@
     "huggingface-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1776941956,
-        "narHash": "sha256-p8sMxWxn6r5wdGo+HAH0p76wO9SZO5pRXt6RkSSOV/8=",
+        "lastModified": 1777786781,
+        "narHash": "sha256-ibKTgPFiBP8zavPNXr+zCiSyUbnxlUVLiUQdq3KsdAI=",
         "owner": "huggingface",
         "repo": "skills",
-        "rev": "ddcf68038c45b78adda240b924a427f1e069f4b2",
+        "rev": "6bbfb54f32e58b9661f725de865927a274f01776",
         "type": "github"
       },
       "original": {
@@ -475,11 +475,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1777769764,
-        "narHash": "sha256-BuSBshIIEJ4RwRp4ISfcDenAOUWnWXwlgnRA199eqzg=",
+        "lastModified": 1778095980,
+        "narHash": "sha256-lssRwje+YTkkOr07HOUIYU90WhsQ24D+0znDe+gNi+w=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "a2ad0b0ba4e1dd0b1da343e8120fbf17945f3e29",
+        "rev": "5cd6e1fc4f388b521a887bcb5c46d67a32341f1e",
         "type": "github"
       },
       "original": {
@@ -491,11 +491,11 @@
     "lunar-claude": {
       "flake": false,
       "locked": {
-        "lastModified": 1777228212,
-        "narHash": "sha256-m8yo8zsWqCcPyRJ88G7pHF0IfrgD/eaHffP0SapKmFM=",
+        "lastModified": 1777788557,
+        "narHash": "sha256-hqdTeuvDAWcE0N53HNIdAS5dMRvokxfD/zkBlHbIWO0=",
         "owner": "basher83",
         "repo": "lunar-claude",
-        "rev": "febf0e5dcd5d1946582a0df0cf25b280b19b1a67",
+        "rev": "973dd25a172b898da9f2847e433dddd727699cf7",
         "type": "github"
       },
       "original": {
@@ -540,12 +540,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1777402229,
-        "narHash": "sha256-h6WzecM2+aBt0rrcvG5+8d11q+nZoDm60na/48NcJ6w=",
-        "rev": "5ab3bee6fa77196de319a0b7669def091fc82253",
-        "revCount": 25833,
+        "lastModified": 1777918043,
+        "narHash": "sha256-Zl229Ynd484malKv6UPbbjIgRZHThLH3NugvUD63M6M=",
+        "rev": "35185ec4d4dcdfe34e08f0e48f6a66afd3b95007",
+        "revCount": 25846,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.19.0/019dd5b5-57ba-7d72-be54-93608443f096/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.19.1/019df44d-015e-7013-9fce-a0a4d4a95c7b/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -595,11 +595,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1777770550,
-        "narHash": "sha256-cRuI4NGMoJMH9aW/QTxctCA82xcO8OEIw1mlF11XZ1A=",
+        "lastModified": 1778107482,
+        "narHash": "sha256-kCs2I4OQob9pij8N+8Ms7BfoMOKrQs2og+Az8+utObM=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "6b42fd202652c669a7b252899b2432f4f08e2751",
+        "rev": "38cb44f2c67af64ed2ad472749b1487705300f1e",
         "type": "github"
       },
       "original": {
@@ -619,11 +619,11 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1777830060,
-        "narHash": "sha256-XHXEldVSkL5uMgMYiZkBeaNSzeS+Q2gQ656ZhwSs95Y=",
+        "lastModified": 1778100544,
+        "narHash": "sha256-5y1XE0CwT/oVoIbsAW22EhCg/HoaXlUoYzy22LiPwGk=",
         "owner": "JacobPEvans",
         "repo": "nix-home",
-        "rev": "806e7bc3387d5de51696f288158110ca956bae0b",
+        "rev": "063f023f602a7cc86d80341ef1a91d4126e73fec",
         "type": "github"
       },
       "original": {
@@ -680,11 +680,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777395829,
-        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1777491697,
-        "narHash": "sha256-Pj+sRI/fKGHVOjKaaxSrSP32cU0ur3bveoBY+BAZ7UE=",
+        "lastModified": 1778030758,
+        "narHash": "sha256-8TXoMiLNpcYoKtglB6VK3zgcFw2elthUOL/1bmLBTkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dff32336677922ec9092e68eee6815b065ab0da7",
+        "rev": "e3f3598f6dcc165901cf6e07d0f7c22a09df6b1c",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777338324,
-        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {
@@ -812,11 +812,11 @@
     "superpowers-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1776189055,
-        "narHash": "sha256-Si+5ElF4daeGVwMiyWLEZWJ8gDCPJrH2zFcsJRvn6+c=",
+        "lastModified": 1777864418,
+        "narHash": "sha256-7z9nHAL0pfvEhUg0PVueCVn55RfZAEjSqjgtZt95pPE=",
         "owner": "obra",
         "repo": "superpowers-marketplace",
-        "rev": "403578f2d6873260fb8d27aee6ab1d4df103bb8d",
+        "rev": "439dbe3c2667d280da9cc7f5c7da688534e8fa70",
         "type": "github"
       },
       "original": {
@@ -879,11 +879,11 @@
     "visual-explainer-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1774753729,
-        "narHash": "sha256-gaFtCysH6k5ogkb+6yvnwnAeuJqR4kK5OHbHdr64/hk=",
+        "lastModified": 1777310126,
+        "narHash": "sha256-82RYY9txFLhj24oVyvvcXEm6F1RRyRTIXXf8vAJzeoE=",
         "owner": "nicobailon",
         "repo": "visual-explainer",
-        "rev": "9a97a5818bebbcb61cccf8941d533b82a1ce958b",
+        "rev": "8f1d0e38ab0f265632a31d2fd032f7b730c98c15",
         "type": "github"
       },
       "original": {
@@ -895,11 +895,11 @@
     "wakatime": {
       "flake": false,
       "locked": {
-        "lastModified": 1776260149,
-        "narHash": "sha256-6dO9waSpBky3xq+++SY6Tql/kLBtwZmGC9VembmNVn8=",
+        "lastModified": 1777816152,
+        "narHash": "sha256-W44dn1bAsVQCoaTPasMA7+JDU4yU2szy6ep05ywO1rE=",
         "owner": "wakatime",
         "repo": "claude-code-wakatime",
-        "rev": "b283f9171e6a510b5769eeeabce6cc399df6e017",
+        "rev": "9b9933dee1d1a40ae6405a921b02276c38f5947a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Draft opened during workspace sweep on 2026-05-22.

Commit summary:
- 3a63251 chore(deps): update all flake inputs

Branch is behind origin/main by 50 commits and has uncommitted local edits to flake.nix in its worktree at chore/flake-update-2026-05-06/ — review locally before deciding to ship or drop.