### PR TITLE
feat(cribl): bump mac pack v0.1.0 -> v0.3.0 (native 4.18 sources)

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -85,9 +85,9 @@ in
       };
       packs = {
         cc-edge-the-mac-pack-io = pkgs.fetchzip {
-          url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.1.0/cc-edge-the-mac-pack-io-v0.1.0.crbl";
+          url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.3.0/cc-edge-the-mac-pack-io-v0.3.0.crbl";
           extension = "tar.gz";
-          hash = "sha256-QPVZA4Cvi5uSOiNMyC9dW5fhRTeaQGZm5MEgNkwDryU=";
+          hash = "sha256-rPPAkedltxT8RWgP2xXil1o6x13HQK+SRgihuheJAks=";
           stripRoot = false;
         };
       };


### PR DESCRIPTION
## Summary

Bumps the `cc-edge-the-mac-pack-io` pack pinned by macbook-m4's nix-darwin config from **v0.1.0 → v0.3.0**. v0.3.0 adopts Cribl Edge 4.18.0 native macOS Source types (`apple_unified_logs`, `system_metrics`) which were merged in JacobPEvans/cc-edge-the-mac-pack-io#8 and released today as https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/tag/v0.3.0.

The previous v0.1.0 pinned the original exec-based collection (`vm_stat`, `iostat`, `top -l 1`, `log show`, `pmset -g therm`, etc.). v0.3.0 replaces 7 of those exec sources with 2 native sources; powermetrics + battery + NDJSON perf snapshots remain as exec (no 4.18 equivalent).

## Changes

- `hosts/macbook-m4/default.nix` — update `programs.cribl-edge.packs.cc-edge-the-mac-pack-io` URL and hash to v0.3.0.

## Test plan

- [x] `nix flake check` clean
- [x] `sudo darwin-rebuild switch --flake .` clean
- [x] `/opt/cribl-data/default/cc-edge-the-mac-pack-io/package.json` reports `"version": "0.3.0"` on macbook-m4
- [x] Daemon stays healthy (`launchctl print system/com.nix-darwin.cribl-edge` returns 0)
- [ ] Cribl UI on macbook-m4 shows `apple_unified_logs` + `system_metrics` sources emitting (manual UI check after merge)
- [ ] `index=os host=macbook-m4 earliest=-15m | stats count by sourcetype` shows non-zero counts in Splunk (verify after pack reload)

## Related

- Pack v0.3.0 release: https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/tag/v0.3.0
- Source PR (pack content): JacobPEvans/cc-edge-the-mac-pack-io#8
- Predecessor: #1123 (Cribl Edge 4.18.0 bump + enrollment fix)