### PR TITLE
feat(cribl): add Cribl Edge deadman watchdog (Healthchecks)

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -93,6 +93,17 @@ in
       };
     };
 
+    # --- Cribl Edge Watchdog (deadman) ---
+    # Posts a heartbeat to each configured Healthchecks endpoint every 5 min
+    # iff the Cribl Edge daemon is alive AND writing logs. When the chain is
+    # down — Mac off, daemon dead, daemon wedged — the heartbeats stop and
+    # both upstream Healthchecks instances (SaaS + self-hosted LXC) fire
+    # alerts independently of Splunk's own silence detector.
+    cribl-edge-watchdog = {
+      enable = true;
+      secretsFile = config.sops.templates."cribl-edge-watchdog.env".path;
+    };
+
     # --- Streamline Login Items ---
     # Persistently disable unwanted updaters and remove junk plists.
     # Edit these lists to add/remove services — enforced on every rebuild.

--- a/modules/darwin/apps/cribl-edge-watchdog.nix
+++ b/modules/darwin/apps/cribl-edge-watchdog.nix
@@ -28,10 +28,12 @@ let
 
   watchdogScript = pkgs.writeShellApplication {
     name = "cribl-edge-watchdog";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.curl
-    ];
+    # No runtimeInputs — the script intentionally calls every system tool
+    # by absolute path (/bin/launchctl, /usr/bin/grep, /usr/bin/curl,
+    # /usr/bin/stat, /bin/date). This keeps the closure tiny and uses the
+    # macOS BSD variants, which is the right behavior on this platform
+    # (stat -f %m is BSD-specific; GNU coreutils would not understand it).
+    runtimeInputs = [ ];
     text = ''
       exec ${./scripts/cribl-edge-watchdog.sh} \
         "${cfg.secretsFile}" \
@@ -103,6 +105,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Ensure the log directory exists with the right ownership before launchd
+    # tries to open the stdout/stderr paths. /var/log exists by default on
+    # macOS so the no-op case is cheap; custom logDir overrides need this.
+    # Unique activation key avoids collision with other modules' postActivation.
+    system.activationScripts.cribl-edge-watchdog-logdir.text = ''
+      /bin/mkdir -p "${cfg.logDir}"
+    '';
+
     launchd.daemons.cribl-edge-watchdog = {
       serviceConfig = {
         Label = "com.nix-darwin.cribl-edge-watchdog";

--- a/modules/darwin/apps/cribl-edge-watchdog.nix
+++ b/modules/darwin/apps/cribl-edge-watchdog.nix
@@ -1,0 +1,125 @@
+# Cribl Edge Deadman Watchdog
+#
+# A LaunchDaemon that posts a heartbeat to one or more Healthchecks endpoints
+# every `interval` seconds — but only when the Cribl Edge daemon on this host
+# is alive AND its log file shows recent writes. Acts as a deadman's switch:
+# if the Mac is hard-down, the daemon dies, or the daemon wedges, the pings
+# stop and the upstream Healthchecks instance fires its alert.
+#
+# Why a separate module from programs.cribl-edge:
+#   Coupling them would risk a bug in the cribl-edge module taking the
+#   watchdog down with it — the whole point of the watchdog is to observe
+#   cribl-edge as a black box. They share a host but no Nix-level state.
+#
+# Two URLs are intentionally supported (one external SaaS, one self-hosted)
+# so the alerting infrastructure itself is redundant — losing either does not
+# leave the operator blind. Either may be unset; an unset URL means the
+# corresponding upstream deadman simply was never armed.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.cribl-edge-watchdog;
+
+  watchdogScript = pkgs.writeShellApplication {
+    name = "cribl-edge-watchdog";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.curl
+    ];
+    text = ''
+      exec ${./scripts/cribl-edge-watchdog.sh} \
+        "${cfg.secretsFile}" \
+        "${cfg.daemonLabel}" \
+        "${cfg.daemonLogFile}" \
+        "${toString cfg.logMtimeThresholdSeconds}"
+    '';
+  };
+in
+{
+  options.programs.cribl-edge-watchdog = {
+    enable = lib.mkEnableOption "Cribl Edge deadman watchdog";
+
+    secretsFile = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        Path to a root-readable KEY=value file. Recognized keys:
+          HEALTHCHECKS_IO_URL    — external SaaS check URL
+          HEALTHCHECKS_LOCAL_URL — self-hosted check URL
+        Either may be empty; both empty means the watchdog no-ops cleanly.
+        Use the sops-nix rendered template:
+          config.sops.templates."cribl-edge-watchdog.env".path
+      '';
+      example = "/run/secrets/rendered/cribl-edge-watchdog.env";
+    };
+
+    daemonLabel = lib.mkOption {
+      type = lib.types.str;
+      default = "com.nix-darwin.cribl-edge";
+      description = "launchd label of the daemon whose liveness gates the heartbeat.";
+    };
+
+    daemonLogFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/cribl-data/log/cribl.log";
+      description = ''
+        Absolute path to the Cribl Edge log file. Used as a "doing work"
+        liveness signal in addition to launchctl state — a launchctl-running
+        daemon that has stopped writing logs is treated as wedged.
+      '';
+    };
+
+    logMtimeThresholdSeconds = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 300;
+      description = ''
+        Maximum acceptable age of the daemon log file's mtime, in seconds.
+        Older than this and the daemon is considered wedged (no heartbeat
+        sent). Should be >= the heartbeat interval so a single quiet polling
+        cycle does not look like a wedge.
+      '';
+    };
+
+    interval = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 300;
+      description = ''
+        launchd StartInterval in seconds — how often the watchdog runs.
+        Defaults to 300s (5 min). Tune in concert with the upstream
+        Healthchecks "grace period" (e.g. ping every 5 min, alert after 15 min).
+      '';
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/log";
+      description = "Directory for the watchdog's own stdout/stderr launchd logs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.daemons.cribl-edge-watchdog = {
+      serviceConfig = {
+        Label = "com.nix-darwin.cribl-edge-watchdog";
+        ProgramArguments = [ "${watchdogScript}/bin/cribl-edge-watchdog" ];
+        # Run on a fixed interval rather than KeepAlive — this is a poll, not
+        # a long-running daemon. RunAtLoad ensures the first ping happens
+        # immediately after darwin-rebuild instead of waiting `interval` seconds.
+        RunAtLoad = true;
+        StartInterval = cfg.interval;
+        # Run as root so the secrets file (root:wheel 0400) is readable.
+        # The script makes no network changes and only POSTs to URLs from the
+        # whitelist-parsed secrets file, so root privilege is contained.
+        UserName = "root";
+        GroupName = "wheel";
+        StandardOutPath = "${cfg.logDir}/cribl-edge-watchdog.log";
+        StandardErrorPath = "${cfg.logDir}/cribl-edge-watchdog.log";
+      };
+    };
+  };
+}

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -12,6 +12,7 @@ _:
     ./ai-volumes.nix
     ./auto-update-prevention.nix
     ./cribl-edge.nix
+    ./cribl-edge-watchdog.nix
     ./orbstack.nix
     ./raycast.nix
     ./streamline-login.nix

--- a/modules/darwin/apps/scripts/cribl-edge-watchdog.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-watchdog.sh
@@ -48,12 +48,12 @@ if [ -z "$HEALTHCHECKS_IO_URL" ] && [ -z "$HEALTHCHECKS_LOCAL_URL" ]; then
 fi
 
 # Liveness gate 1: launchd reports the daemon as running.
-# `launchctl print` exits non-zero if the label isn't bootstrapped.
-if ! /bin/launchctl print "system/${DAEMON_LABEL}" >/dev/null 2>&1; then
+# Single `launchctl print` call — capture both exit status (daemon not
+# bootstrapped) and stdout (daemon state) in one syscall.
+if ! daemon_info=$(/bin/launchctl print "system/${DAEMON_LABEL}" 2>/dev/null); then
   exit 0
 fi
-if ! /bin/launchctl print "system/${DAEMON_LABEL}" 2>/dev/null \
-     | grep -q "state = running"; then
+if ! printf '%s\n' "$daemon_info" | /usr/bin/grep -q "state = running"; then
   exit 0
 fi
 

--- a/modules/darwin/apps/scripts/cribl-edge-watchdog.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-watchdog.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Cribl Edge deadman heartbeat.
+#
+# Polled by launchd every 5 minutes. Sends a heartbeat ping to each
+# configured Healthchecks endpoint *only* when the local Cribl Edge daemon
+# is alive AND its log file has been written to in the last 5 minutes.
+#
+# When the daemon dies, wedges, or the Mac goes hard-down, the heartbeats
+# stop and the upstream Healthchecks instance fires its alert.
+#
+# Arguments (set by the Nix wrapper in cribl-edge-watchdog.nix):
+#   $1 = path to sops-rendered KEY=value file
+#        (whitelisted keys: HEALTHCHECKS_IO_URL, HEALTHCHECKS_LOCAL_URL)
+#   $2 = launchd label of the daemon to monitor
+#   $3 = absolute path to the daemon's log file (used as the "is it doing
+#        work?" liveness signal — recent mtime means cribl is awake)
+#   $4 = mtime threshold in seconds (logs older than this -> daemon wedged)
+#
+# Exits 0 in every "deadman fires upstream" path so launchd does not retry
+# this script — the deadman *should* fire when this script chose not to ping.
+
+set -euo pipefail
+
+SECRETS_FILE="${1:?secrets file path required}"
+DAEMON_LABEL="${2:?launchd daemon label required}"
+LOG_FILE="${3:?daemon log file path required}"
+LOG_MTIME_THRESHOLD="${4:?log mtime threshold (seconds) required}"
+
+HEALTHCHECKS_IO_URL=""
+HEALTHCHECKS_LOCAL_URL=""
+
+# Whitelist-only parse; ignores comments, blanks, and any unknown keys so a
+# stale or tampered secrets file cannot inject shell.
+if [ -r "$SECRETS_FILE" ]; then
+  while IFS='=' read -r _k _v || [ -n "$_k" ]; do
+    case "$_k" in
+      ""|\#*) continue ;;
+      HEALTHCHECKS_IO_URL)    HEALTHCHECKS_IO_URL="$_v" ;;
+      HEALTHCHECKS_LOCAL_URL) HEALTHCHECKS_LOCAL_URL="$_v" ;;
+    esac
+  done < "$SECRETS_FILE"
+fi
+
+# No URLs configured -> nothing to ping. Exit cleanly; the upstream
+# Healthchecks endpoints have not been armed yet, so this is not an error.
+if [ -z "$HEALTHCHECKS_IO_URL" ] && [ -z "$HEALTHCHECKS_LOCAL_URL" ]; then
+  exit 0
+fi
+
+# Liveness gate 1: launchd reports the daemon as running.
+# `launchctl print` exits non-zero if the label isn't bootstrapped.
+if ! /bin/launchctl print "system/${DAEMON_LABEL}" >/dev/null 2>&1; then
+  exit 0
+fi
+if ! /bin/launchctl print "system/${DAEMON_LABEL}" 2>/dev/null \
+     | grep -q "state = running"; then
+  exit 0
+fi
+
+# Liveness gate 2: the daemon's log file was touched recently.
+# A pgrep-alive daemon that has stopped writing logs is wedged — treat as down.
+if [ ! -f "$LOG_FILE" ]; then
+  exit 0
+fi
+log_mtime=$(/usr/bin/stat -f %m "$LOG_FILE")
+now=$(/bin/date +%s)
+log_age=$((now - log_mtime))
+if [ "$log_age" -gt "$LOG_MTIME_THRESHOLD" ]; then
+  exit 0
+fi
+
+# Both gates passed — daemon is alive and doing work. Fan out the heartbeat.
+# Non-fatal on individual failure: if healthchecks.io is unreachable but the
+# self-hosted endpoint succeeds, we still want the latter to be marked alive.
+# --max-time caps total time so a stuck endpoint can't block the second ping.
+if [ -n "$HEALTHCHECKS_IO_URL" ]; then
+  /usr/bin/curl -fsS --max-time 10 -o /dev/null "$HEALTHCHECKS_IO_URL" || true
+fi
+if [ -n "$HEALTHCHECKS_LOCAL_URL" ]; then
+  /usr/bin/curl -fsS --max-time 10 -o /dev/null "$HEALTHCHECKS_LOCAL_URL" || true
+fi

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -45,6 +45,15 @@ in
       CRIBL_TOKEN = rootOnly // {
         sopsFile = ../../secrets/cribl-edge.yaml;
       };
+      # Cribl Edge watchdog heartbeat targets (Healthchecks URLs).
+      # Either may be empty in the encrypted file; an empty URL means the
+      # watchdog skips that endpoint (the upstream deadman was never armed).
+      HEALTHCHECKS_IO_URL = rootOnly // {
+        sopsFile = ../../secrets/cribl-edge.yaml;
+      };
+      HEALTHCHECKS_LOCAL_URL = rootOnly // {
+        sopsFile = ../../secrets/cribl-edge.yaml;
+      };
     };
 
     # Rendered template: assembles individual secrets into a single KEY=value file
@@ -54,6 +63,17 @@ in
         CRIBL_ORG_ID=${config.sops.placeholder."CRIBL_ORG_ID"}
         CRIBL_WORKSPACE_ID=${config.sops.placeholder."CRIBL_WORKSPACE_ID"}
         CRIBL_TOKEN=${config.sops.placeholder."CRIBL_TOKEN"}
+      '';
+    };
+
+    # Rendered template for the cribl-edge-watchdog LaunchDaemon. Kept
+    # separate from cribl-edge.env so the watchdog has no static dependency
+    # on the cribl-edge module's secrets shape — they are independent
+    # consumers that happen to share an encrypted source file.
+    templates."cribl-edge-watchdog.env" = rootOnly // {
+      content = ''
+        HEALTHCHECKS_IO_URL=${config.sops.placeholder."HEALTHCHECKS_IO_URL"}
+        HEALTHCHECKS_LOCAL_URL=${config.sops.placeholder."HEALTHCHECKS_LOCAL_URL"}
       '';
     };
   };

--- a/secrets/cribl-edge.yaml
+++ b/secrets/cribl-edge.yaml
@@ -1,10 +1,11 @@
 CRIBL_ORG_ID: ENC[AES256_GCM,data:DbLanCG74UW1qcZ2/4sqlBOi7+RAhQ==,iv:z4Wgegz2KGOhucpZ6LC/jWQJlNNc+JqF1ndbaJ6xP7w=,tag:W1VokuueBfO4xkpZIkMPlQ==,type:str]
 CRIBL_WORKSPACE_ID: ENC[AES256_GCM,data:7SogmQ==,iv:YR2Ss1epxlhUFA04UiiGH0S8Kjs3yhwe1CqgvbIMfhc=,tag:t78qx3WUzxhk4RRVwvNJRA==,type:str]
 CRIBL_TOKEN: ENC[AES256_GCM,data:0VnVdge6QsweUQiP2+o5iQsEqvV0GJlqe1/b81/hOL0=,iv:9mE+GirBSfyqgE+FKF4BUR3fjGx4uLxKOdNw8qbQavk=,tag:VIIFvqd0HYY/ojEWGJUK8g==,type:str]
+HEALTHCHECKS_IO_URL: ""
+HEALTHCHECKS_LOCAL_URL: ""
 sops:
     age:
-        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJTW9WVnJ2NUwzK2tINVp1
             MzRqUGIvdjFPbURIdEdaa0lXa3loeVRQQzAwCkNLR3ArQ2p2bGZkcGNLWGxsSHYx
@@ -12,7 +13,8 @@ sops:
             OFBDMGQrdi9LL2ZOOEYrS05VTmZ3Yk0KWJ3x/Qcas6ClrOqyvDnYAfM98dRipGfv
             jZ0OXm/I3o4upvhOlMPYw/OhpHyHp82ckUxwmuHIr0SVV/+0lDXkxg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-19T13:31:15Z"
-    mac: ENC[AES256_GCM,data:40ywrvHE9CEsINgQgg4ASa+3NRHMdj+3soxAPC/RRW+NLsEhFXCFX/Srw5y9RrPVzbWK0TchAECL510guRNT1Ewd0fEOrWK38TX6BJaA2KiedItqxOrl54k1K+ZdnvqW4tiDYz5Ox4gLJMS4n4A6wZVSLHpOlJhhzBmn5SZlTj0=,iv:ZogbB/EsEn5D9ihePu7FkdKCWq1eQfBkzMtohrTCM/E=,tag:3UyYNuEo3QZzAa82GurDvg==,type:str]
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+    lastmodified: "2026-05-24T20:20:18Z"
+    mac: ENC[AES256_GCM,data:nHnA0fN0ivc4yNccFfXHpRXY6MauG28MeJW50ZK5yI4tU6NZfVZXLAoN9Pf/Gx/+C1v04oYittBD/T1nYxoW2saEfa22vZSNBBw/eVtpRYVhZIAdhZdiuV7oEhV2KTvdQZ4fLoIGY1LHO6IPNi8DI0HWoOrUPw0CO443ZYF3B9I=,iv:T3Q26SVbWSji9JkwGDhYutZqtKd1GE2/cjVyu/7ode8=,tag:1/XZNf0uJdE3+OAFeQERQg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

Adds a LaunchDaemon (`com.nix-darwin.cribl-edge-watchdog`) that posts a heartbeat to one or two Healthchecks endpoints every 5 minutes, but only when the Cribl Edge daemon on this host is alive AND its log file shows recent writes. When the chain goes hard-down (Mac off, daemon dead, daemon wedged) the heartbeats stop and the upstream Healthchecks instances fire their alerts independently of Splunk's silence detector.

## Why now

The Splunk-side `macos_edge_silence_detector` saved search (JacobPEvans/ansible-splunk#224, merged today) is layer 1 — it only fires when Splunk itself is up. The user explicitly required additional down-detection that survives "everything is hard down". This watchdog is the layer that survives losing the entire homelab.

## Layered detection (full picture)

| Layer | Where | Fires when... | Survives... |
|---|---|---|---|
| L1 | Splunk `macos_edge_silence_detector` | tstats shows no `macos:*` events in 15m | Cribl Edge crashes / Cribl Cloud rejects / HEC stalls |
| L4a | healthchecks.io SaaS check | This watchdog stops pinging | Whole homelab off, ISP down at LXC site |
| L4b | Self-hosted Healthchecks LXC (next PR in ansible-proxmox-apps) | This watchdog stops pinging | SaaS unreachable / account locked / vendor sunset |

L2 (Mac-local ntfy push) and L3 (GHA cron probe via tailscale) were intentionally skipped per user direction.

## Why a separate module from `programs.cribl-edge`

The watchdog must observe `cribl-edge` as a black box. Coupling them would risk a bug in the `cribl-edge` module taking down the very monitor meant to detect `cribl-edge` problems. They share a host but no Nix-level state.

## Liveness gates

The script sends a heartbeat only when **both** are true:
1. `launchctl print system/com.nix-darwin.cribl-edge` returns `state = running`
2. `/opt/cribl-data/log/cribl.log` mtime is within the last 300 seconds

Catches the wedged-but-running daemon case (process up, no log writes) — would be invisible to a pgrep-only check.

## Secrets

Two new SOPS-managed values land via a new rendered template (`cribl-edge-watchdog.env`), kept separate from `cribl-edge.env` so the watchdog has no Nix-level dependency on the `cribl-edge` module's secrets shape:

- `HEALTHCHECKS_IO_URL` — external SaaS endpoint
- `HEALTHCHECKS_LOCAL_URL` — self-hosted endpoint

Both are seeded as empty strings in the encrypted file. The script no-ops cleanly when both are empty. You provide real URLs after creating the checks on each Healthchecks instance.

## Changes

- `modules/darwin/apps/scripts/cribl-edge-watchdog.sh` (new) — shellcheck-clean, no-eval, whitelist-only secrets parse
- `modules/darwin/apps/cribl-edge-watchdog.nix` (new) — module with `programs.cribl-edge-watchdog.{enable, secretsFile, daemonLabel, daemonLogFile, logMtimeThresholdSeconds, interval, logDir}` options
- `modules/darwin/apps/default.nix` — import new module
- `modules/darwin/sops.nix` — add `HEALTHCHECKS_IO_URL`, `HEALTHCHECKS_LOCAL_URL` secrets + `cribl-edge-watchdog.env` template
- `secrets/cribl-edge.yaml` — add empty placeholders for new keys (re-encrypted)
- `hosts/macbook-m4/default.nix` — enable the watchdog on this host

## Test plan

- [x] `nix flake check` clean
- [x] `sudo darwin-rebuild switch --flake .` clean
- [x] `launchctl print system/com.nix-darwin.cribl-edge-watchdog` shows the daemon loaded with `state = not running` (correct — periodic poll), `last exit code = 0`, `run interval = 300 seconds`
- [x] `/var/log/cribl-edge-watchdog.log` created at run time (empty because URLs are empty — no-op as designed)
- [ ] After SOPS URLs are populated: tail the log, confirm curl POSTs land at the Healthchecks endpoints (visible as a "ping received" event in each Healthchecks UI)
- [ ] Smoke: `sudo launchctl unload -w /Library/LaunchDaemons/com.nix-darwin.cribl-edge.plist` — wait 15+ min — confirm both Healthchecks UIs show "no ping received" and fire alerts

## Follow-up

- Self-hosted Healthchecks LXC role in `ansible-proxmox-apps` (next PR)
- User: sign up at healthchecks.io free tier, create one check on each instance, paste both URLs into `secrets/cribl-edge.yaml` via `sops edit`