### PR TITLE
feat(claude): populate autoMode.environment with homelab trust context

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "browser-use-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1779564354,
-        "narHash": "sha256-ChZBjEkQbiONTkp6qB7ONrFNEmlkVLJeTP78xzEuVGs=",
+        "lastModified": 1779315551,
+        "narHash": "sha256-+u/OlcsPeU+H+Qu9ZgjgQuVBwapQ1eQjHxcwAGcoPes=",
         "owner": "browser-use",
         "repo": "browser-use",
-        "rev": "d21b3da4ac9c341d66ee064264abda67af36eab3",
+        "rev": "5f99e737c5e7ef3d3d4cbb121cc501991fdee72e",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     "cc-dev-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1779687312,
-        "narHash": "sha256-G83sue12mUh78A/oe3wGMRIzUEB0eBbMmbSpzLJJTsM=",
+        "lastModified": 1777301179,
+        "narHash": "sha256-mLJftGTU06SLQ98g2yqYdNAWj2OPwjxNhuvDnITr9vM=",
         "owner": "Lucklyric",
         "repo": "cc-dev-tools",
-        "rev": "8d60780c972c10a903b1a553ca29d5dbc71ea2f2",
+        "rev": "4503ef2ee3ee6ac5dcf58aea1ffe1148c81b9c87",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "claude-code-plugins-plus": {
       "flake": false,
       "locked": {
-        "lastModified": 1779672981,
-        "narHash": "sha256-NtuCu16Z9bpeybo6or7XS/65b8d3ii4rnbKL6c04rcY=",
+        "lastModified": 1779336060,
+        "narHash": "sha256-I5PzUFhh8NVS9lMMiZRouVHLEKnFDuLdngD7Byx0Hgo=",
         "owner": "jeremylongshore",
         "repo": "claude-code-plugins-plus",
-        "rev": "c2cae823174b4ed9830f3c4d0282aa7e54b9cb10",
+        "rev": "b57e3facf0f37374e474dc073e3f36e1b8cb7cf4",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "claude-code-workflows": {
       "flake": false,
       "locked": {
-        "lastModified": 1779670854,
-        "narHash": "sha256-YpMOSgofEqheuu8beu8TroaT8JwQB+M1+bBV/hUeLls=",
+        "lastModified": 1779393697,
+        "narHash": "sha256-4P/3O7Yi05e579k2LUS9OnbrP35WRjV7TVYW7ylo4I4=",
         "owner": "wshobson",
         "repo": "agents",
-        "rev": "9b6b4c1254c42be711c1a58416201c9f78873ac8",
+        "rev": "4bb47e9eeb4e8564642eb23384ec8f7bf1855417",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     "claude-cookbooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1779659099,
-        "narHash": "sha256-ExC1ZFhhf7+74syQK96PZ7yYf0kyY756SJZZXXkacms=",
+        "lastModified": 1779215544,
+        "narHash": "sha256-lR7Tam+4t4/ulsmo+V+550sxjKQ7ILnWkZdLFD7JJYg=",
         "owner": "anthropics",
         "repo": "claude-cookbooks",
-        "rev": "3c30b020594de29a7f24ee579c511ac3ac45fb6a",
+        "rev": "39a350b6790c132337dcc3ec35240728fcc1dc0e",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     "claude-plugins-official": {
       "flake": false,
       "locked": {
-        "lastModified": 1779659326,
-        "narHash": "sha256-zKNCeUQoCVZaJfP+eVmFD9G6du8Iu8p7TZPBcdF3ujs=",
+        "lastModified": 1779396680,
+        "narHash": "sha256-UFlNhWQ5kz8zhOExXacgy+xNJ273dF3v3h1MKdPG5Jk=",
         "owner": "anthropics",
         "repo": "claude-plugins-official",
-        "rev": "1b527e2ee74e6dbd198e22cd41701c3b6f47dfec",
+        "rev": "1d5ba6426aa27bab9dcf69e89b2f119609ce0885",
         "type": "github"
       },
       "original": {
@@ -596,11 +596,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1779714826,
-        "narHash": "sha256-tfT20tSLox91AgLF5jQ88A6o/PrAZZAx+mkQBsWcgYY=",
+        "lastModified": 1779656375,
+        "narHash": "sha256-O0/7lrRGpkOn95MsTXn+3m6Ia8GZAZiJ+dNs2SjFgzA=",
         "owner": "JacobPEvans",
         "repo": "nix-ai",
-        "rev": "6c4ab7cc745e3126fa49c8a8717a747fc2bc4887",
+        "rev": "fa9680a6fd90bc428c71ebc38787425f35bca817",
         "type": "github"
       },
       "original": {
@@ -682,11 +682,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1779259093,
+        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
         "type": "github"
       },
       "original": {
@@ -745,11 +745,11 @@
     "obsidian-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1779638361,
-        "narHash": "sha256-KwmnZrHkl/LqMLF+P0YnIqEpL3lGa6DSRUTgqYK1fes=",
+        "lastModified": 1778185448,
+        "narHash": "sha256-2kr8fmkuxRLaTy2O+dTv9K+75mRIqkLmaArw2/hj5uc=",
         "owner": "kepano",
         "repo": "obsidian-skills",
-        "rev": "553ef99aa3306dd23f268e1ba9af752577684f69",
+        "rev": "ac9398734fe719565809f7a6048b05c36b1ca38f",
         "type": "github"
       },
       "original": {
@@ -846,11 +846,11 @@
     "superpowers-marketplace": {
       "flake": false,
       "locked": {
-        "lastModified": 1779510867,
-        "narHash": "sha256-nnApq4Eu/8N+Z34JxwRmDgdje2AIG6OR1nGHRS4WBQk=",
+        "lastModified": 1779399076,
+        "narHash": "sha256-z9CJEGVIocueriQ9fqqHzdnsJMwSScdFbvbhVYQY6Kw=",
         "owner": "obra",
         "repo": "superpowers-marketplace",
-        "rev": "6be22035d873c31ca246db4f4932a1098aea46fc",
+        "rev": "89e817bac876722a9e1a34f6c3919b8d27c231a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -62,8 +62,12 @@
 
     # AI CLI ecosystem (Claude, Gemini, Copilot, MCP, marketplace)
     # Self-contained: injects its own flake inputs via _module.args
+    #
+    # Pinned to feat/automode-options branch until JacobPEvans/nix-ai
+    # merges the autoMode option scaffold; flip to default branch and
+    # `nix flake update nix-ai` after that lands.
     nix-ai = {
-      url = "github:JacobPEvans/nix-ai";
+      url = "github:JacobPEvans/nix-ai/feat/automode-options";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -62,12 +62,8 @@
 
     # AI CLI ecosystem (Claude, Gemini, Copilot, MCP, marketplace)
     # Self-contained: injects its own flake inputs via _module.args
-    #
-    # Pinned to feat/automode-options branch until JacobPEvans/nix-ai
-    # merges the autoMode option scaffold; flip to default branch and
-    # `nix flake update nix-ai` after that lands.
     nix-ai = {
-      url = "github:JacobPEvans/nix-ai/feat/automode-options";
+      url = "github:JacobPEvans/nix-ai";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";

--- a/hosts/macbook-m4/automode-environment.nix
+++ b/hosts/macbook-m4/automode-environment.nix
@@ -9,16 +9,26 @@
 # Source-of-truth context lives at https://docs.jacobpevans.com
 # (source: github.com/JacobPEvans/docs). Update entries here when the
 # trusted infrastructure footprint changes.
+#
+# Sources the GitHub username from userConfig.user.fullName so the
+# value stays consistent with lib/user-config.nix. The secondary
+# `dryvist` org is hardcoded — it's a separate GitHub organization,
+# not part of the user's primary identity, so not modeled in userConfig.
+{ userConfig, lib }:
+let
+  ghUser = userConfig.user.fullName;
+  docsHost = "docs.${lib.toLower ghUser}.com";
+in
 [
   "$defaults"
-  "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://docs.jacobpevans.com (source github.com/JacobPEvans/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
-  "Source control: GitHub orgs github.com/JacobPEvans/* and github.com/dryvist/*. All public repos under both are trusted to clone, push, branch, and PR-mutate against. Force-push to feature branches is routine; force-push to main is off-limits."
+  "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://${docsHost} (source github.com/${ghUser}/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
+  "Source control: GitHub orgs github.com/${ghUser}/* and github.com/dryvist/*. All public repos under both are trusted to clone, push, branch, and PR-mutate against. Force-push to feature branches is routine; force-push to main is off-limits."
   "Workspace layout: ~/git/<repo>/main is the main-branch worktree. Feature work happens in ~/git/<repo>/<type>/<name>/ via git worktrees. Standard across every repo."
   "Cloud: AWS via aws-vault profiles (terraform-aws, terraform-aws-bedrock); Proxmox cluster on the home LAN (terraform-proxmox plus ansible-proxmox-*). No multi-tenant production."
   "Secrets stores: Doppler (ai-ci-automation/prd project carries AI/MCP keys); macOS Keychain (ai-secrets keychain holds ANTHROPIC_API_KEY etc.; elevate-access keychain holds elevated GH tokens via the RESTRICTED/PRIVATE/ADMIN tier system); Mozilla SOPS handles at-rest encryption; Bitwarden vault plus Bitwarden Secrets Manager. No long-lived AWS keys — OIDC handles CI."
   "AI runtimes: local MLX server on this Mac (mlx-server devenv shell); Claude / Codex / Gemini / Copilot CLIs all routed through local dev shells; PAL MCP proxy handles multi-model orchestration; HuggingFace CLI handles model management."
   "Observability stack: OpenTelemetry instrumentation → Cribl Stream → Splunk Enterprise (homelab). splunk-dev devenv shell on local Splunk work."
-  "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the JacobPEvans/.github v3 catalog. Jobs targeting RunsOn labels are routine."
+  "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the ${ghUser}/.github v3 catalog. Jobs targeting RunsOn labels are routine."
   "Container deployment: LXC on Proxmox is the default in production homelab workloads. Docker only on vendor-locked images that require it (high-throughput network traffic must never flow through Docker's virtualized networking)."
   "Nix-first: nix-darwin (macOS), nix-home (cross-platform user env), nix-ai (AI tooling), nix-devenv (reusable dev shells plus flakeModules.dev-hygiene), nix-claude-code (Claude Code declarative module). Flakes-only — never use nix-env."
   "Pre-commit, linting, format: pre-commit hooks come from nix-devenv.flakeModules.dev-hygiene in Nix repos. zizmor policy from dryvist/.github (trusted publishers: actions/*, DeterminateSystems/*, googleapis/* may use ref-pins; everything else requires hash-pins)."

--- a/hosts/macbook-m4/automode-environment.nix
+++ b/hosts/macbook-m4/automode-environment.nix
@@ -1,0 +1,25 @@
+# Claude Code auto-mode trusted-infrastructure context.
+#
+# Imported by programs.claude.settings.autoMode.environment in home.nix
+# and read by Claude's auto-mode classifier as prose rules. Without
+# these, the classifier blocks routine cross-repo, cross-org, cloud,
+# and homelab operations as potential exfiltration. Reference:
+# https://code.claude.com/docs/en/auto-mode-config.
+#
+# Source-of-truth context lives at https://docs.jacobpevans.com
+# (source: github.com/JacobPEvans/docs). Update entries here when the
+# trusted infrastructure footprint changes.
+[
+  "$defaults"
+  "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://docs.jacobpevans.com (source github.com/JacobPEvans/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
+  "Source control: GitHub orgs github.com/JacobPEvans/* and github.com/dryvist/*. All public repos under both are trusted to clone, push, branch, and PR-mutate against. Force-push to feature branches is routine; force-push to main is off-limits."
+  "Workspace layout: ~/git/<repo>/main is the main-branch worktree. Feature work happens in ~/git/<repo>/<type>/<name>/ via git worktrees. Standard across every repo."
+  "Cloud: AWS via aws-vault profiles (terraform-aws, terraform-aws-bedrock); Proxmox cluster on the home LAN (terraform-proxmox plus ansible-proxmox-*). No multi-tenant production."
+  "Secrets stores: Doppler (ai-ci-automation/prd project carries AI/MCP keys); macOS Keychain (ai-secrets keychain holds ANTHROPIC_API_KEY etc.; elevate-access keychain holds elevated GH tokens via the RESTRICTED/PRIVATE/ADMIN tier system); Mozilla SOPS handles at-rest encryption; Bitwarden vault plus Bitwarden Secrets Manager. No long-lived AWS keys — OIDC handles CI."
+  "AI runtimes: local MLX server on this Mac (mlx-server devenv shell); Claude / Codex / Gemini / Copilot CLIs all routed through local dev shells; PAL MCP proxy handles multi-model orchestration; HuggingFace CLI handles model management."
+  "Observability stack: OpenTelemetry instrumentation → Cribl Stream → Splunk Enterprise (homelab). splunk-dev devenv shell on local Splunk work."
+  "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the JacobPEvans/.github v3 catalog. Jobs targeting RunsOn labels are routine."
+  "Container deployment: LXC on Proxmox is the default in production homelab workloads. Docker only on vendor-locked images that require it (high-throughput network traffic must never flow through Docker's virtualized networking)."
+  "Nix-first: nix-darwin (macOS), nix-home (cross-platform user env), nix-ai (AI tooling), nix-devenv (reusable dev shells plus flakeModules.dev-hygiene), nix-claude-code (Claude Code declarative module). Flakes-only — never use nix-env."
+  "Pre-commit, linting, format: pre-commit hooks come from nix-devenv.flakeModules.dev-hygiene in Nix repos. zizmor policy from dryvist/.github (trusted publishers: actions/*, DeterminateSystems/*, googleapis/* may use ref-pins; everything else requires hash-pins)."
+]

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -64,6 +64,28 @@
       # playwright@claude-skills (skills-only, no MCP) stays enabled.
       plugins.enabled."playwright@claude-plugins-official" = lib.mkForce false;
 
+      # Auto-mode classifier context. Tells Claude Code's auto-mode
+      # classifier (https://code.claude.com/docs/en/auto-mode-config)
+      # which infrastructure to treat as trusted/internal. Without it,
+      # the classifier defaults to trusting only the working repo and
+      # blocks routine cross-repo / cross-org / cloud / homelab ops.
+      # Lands at top-level `autoMode` in settings.json via nix-ai's
+      # programs.claude.settings.autoMode option.
+      settings.autoMode.environment = [
+        "$defaults"
+        "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://docs.jacobpevans.com (source github.com/JacobPEvans/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
+        "Source control: GitHub orgs github.com/JacobPEvans/* and github.com/dryvist/*. All public repos under both are trusted to clone, push, branch, and PR-mutate against. Force-push to feature branches is routine; force-push to main is off-limits."
+        "Workspace layout: ~/git/<repo>/main is the main-branch worktree. Feature work happens in ~/git/<repo>/<type>/<name>/ via git worktrees. Standard across every repo."
+        "Cloud: AWS via aws-vault profiles (terraform-aws, terraform-aws-bedrock); Proxmox cluster on the home LAN (terraform-proxmox plus ansible-proxmox-*). No multi-tenant production."
+        "Secrets stores: Doppler (ai-ci-automation/prd project carries AI/MCP keys); macOS Keychain (ai-secrets keychain holds ANTHROPIC_API_KEY etc.; elevate-access keychain holds elevated GH tokens via the RESTRICTED/PRIVATE/ADMIN tier system); Mozilla SOPS handles at-rest encryption; Bitwarden vault plus Bitwarden Secrets Manager. No long-lived AWS keys — OIDC handles CI."
+        "AI runtimes: local MLX server on this Mac (mlx-server devenv shell); Claude / Codex / Gemini / Copilot CLIs all routed through local dev shells; PAL MCP proxy handles multi-model orchestration; HuggingFace CLI handles model management."
+        "Observability stack: OpenTelemetry instrumentation → Cribl Stream → Splunk Enterprise (homelab). splunk-dev devenv shell on local Splunk work."
+        "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the JacobPEvans/.github v3 catalog. Jobs targeting RunsOn labels are routine."
+        "Container deployment: LXC on Proxmox is the default in production homelab workloads. Docker only on vendor-locked images that require it (high-throughput network traffic must never flow through Docker's virtualized networking)."
+        "Nix-first: nix-darwin (macOS), nix-home (cross-platform user env), nix-ai (AI tooling), nix-devenv (reusable dev shells plus flakeModules.dev-hygiene), nix-claude-code (Claude Code declarative module). Flakes-only — never use nix-env."
+        "Pre-commit, linting, format: pre-commit hooks come from nix-devenv.flakeModules.dev-hygiene in Nix repos. zizmor policy from dryvist/.github (trusted publishers: actions/*, DeterminateSystems/*, googleapis/* may use ref-pins; everything else requires hash-pins)."
+      ];
+
       # Disable MCP servers that duplicate built-in tools, are demo/test, or are project-specific.
       # Servers remain defined (for type validation) but disabled = true excludes them from ~/.claude.json.
       # Project-specific servers (cribl, terraform, aws) are re-enabled via per-project .mcp.json.

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -64,27 +64,11 @@
       # playwright@claude-skills (skills-only, no MCP) stays enabled.
       plugins.enabled."playwright@claude-plugins-official" = lib.mkForce false;
 
-      # Auto-mode classifier context. Tells Claude Code's auto-mode
-      # classifier (https://code.claude.com/docs/en/auto-mode-config)
-      # which infrastructure to treat as trusted/internal. Without it,
-      # the classifier defaults to trusting only the working repo and
-      # blocks routine cross-repo / cross-org / cloud / homelab ops.
-      # Lands at top-level `autoMode` in settings.json via nix-ai's
-      # programs.claude.settings.autoMode option.
-      settings.autoMode.environment = [
-        "$defaults"
-        "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://docs.jacobpevans.com (source github.com/JacobPEvans/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
-        "Source control: GitHub orgs github.com/JacobPEvans/* and github.com/dryvist/*. All public repos under both are trusted to clone, push, branch, and PR-mutate against. Force-push to feature branches is routine; force-push to main is off-limits."
-        "Workspace layout: ~/git/<repo>/main is the main-branch worktree. Feature work happens in ~/git/<repo>/<type>/<name>/ via git worktrees. Standard across every repo."
-        "Cloud: AWS via aws-vault profiles (terraform-aws, terraform-aws-bedrock); Proxmox cluster on the home LAN (terraform-proxmox plus ansible-proxmox-*). No multi-tenant production."
-        "Secrets stores: Doppler (ai-ci-automation/prd project carries AI/MCP keys); macOS Keychain (ai-secrets keychain holds ANTHROPIC_API_KEY etc.; elevate-access keychain holds elevated GH tokens via the RESTRICTED/PRIVATE/ADMIN tier system); Mozilla SOPS handles at-rest encryption; Bitwarden vault plus Bitwarden Secrets Manager. No long-lived AWS keys — OIDC handles CI."
-        "AI runtimes: local MLX server on this Mac (mlx-server devenv shell); Claude / Codex / Gemini / Copilot CLIs all routed through local dev shells; PAL MCP proxy handles multi-model orchestration; HuggingFace CLI handles model management."
-        "Observability stack: OpenTelemetry instrumentation → Cribl Stream → Splunk Enterprise (homelab). splunk-dev devenv shell on local Splunk work."
-        "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the JacobPEvans/.github v3 catalog. Jobs targeting RunsOn labels are routine."
-        "Container deployment: LXC on Proxmox is the default in production homelab workloads. Docker only on vendor-locked images that require it (high-throughput network traffic must never flow through Docker's virtualized networking)."
-        "Nix-first: nix-darwin (macOS), nix-home (cross-platform user env), nix-ai (AI tooling), nix-devenv (reusable dev shells plus flakeModules.dev-hygiene), nix-claude-code (Claude Code declarative module). Flakes-only — never use nix-env."
-        "Pre-commit, linting, format: pre-commit hooks come from nix-devenv.flakeModules.dev-hygiene in Nix repos. zizmor policy from dryvist/.github (trusted publishers: actions/*, DeterminateSystems/*, googleapis/* may use ref-pins; everything else requires hash-pins)."
-      ];
+      # Auto-mode classifier trust context. Lives in its own file so it
+      # stays out of the home.nix file-size budget. See
+      # https://code.claude.com/docs/en/auto-mode-config and
+      # ./automode-environment.nix.
+      settings.autoMode.environment = import ./automode-environment.nix;
 
       # Disable MCP servers that duplicate built-in tools, are demo/test, or are project-specific.
       # Servers remain defined (for type validation) but disabled = true excludes them from ~/.claude.json.

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -65,10 +65,14 @@
       plugins.enabled."playwright@claude-plugins-official" = lib.mkForce false;
 
       # Auto-mode classifier trust context. Lives in its own file so it
-      # stays out of the home.nix file-size budget. See
+      # stays out of the home.nix file-size budget. The file is a
+      # function taking { userConfig, lib } so the GitHub username
+      # threads through from lib/user-config.nix. See
       # https://code.claude.com/docs/en/auto-mode-config and
       # ./automode-environment.nix.
-      settings.autoMode.environment = import ./automode-environment.nix;
+      settings.autoMode.environment = import ./automode-environment.nix {
+        inherit userConfig lib;
+      };
 
       # Disable MCP servers that duplicate built-in tools, are demo/test, or are project-specific.
       # Servers remain defined (for type validation) but disabled = true excludes them from ~/.claude.json.


### PR DESCRIPTION
## Summary

Populates `programs.claude.settings.autoMode.environment` in `hosts/macbook-m4/home.nix` with prose entries describing every trusted surface from <https://docs.jacobpevans.com>. With this in place, Claude Code's auto-mode classifier stops blocking routine cross-repo, cross-org, cloud, and homelab operations.

## Why this is needed

`permissions.defaultMode = "auto"` enables the classifier. Without `autoMode.environment`, the classifier defaults to trusting only the working directory plus the active repo's configured remotes — so pushing to a sibling JacobPEvans/ or dryvist/ repo, writing to S3 via aws-vault, hitting the Proxmox cluster, etc., all get treated as exfiltration candidates and blocked.

## Content

Prose entries cover:
- GitHub orgs (JacobPEvans + dryvist)
- AWS via aws-vault, Proxmox cluster on home LAN
- Secrets: Doppler, macOS Keychain (ai-secrets, elevate-access), Mozilla SOPS, Bitwarden + BWS
- AI runtimes: local MLX server, Claude/Codex/Gemini/Copilot CLIs via dev shells, PAL MCP multi-model proxy
- Observability: OTEL → Cribl Stream → Splunk Enterprise
- Self-hosted RunsOn runners per the JacobPEvans/.github v3 catalog
- Container deployment policy (LXC default, Docker for vendor-locked images)
- Nix-first ecosystem (nix-darwin, nix-home, nix-ai, nix-devenv, nix-claude-code; flakes-only)
- zizmor policy from dryvist/.github (trusted-publisher ref-pins)

## Cross-repo dependency

Requires [JacobPEvans/nix-ai#feat/automode-options](https://github.com/JacobPEvans/nix-ai/pull/new/feat/automode-options) which adds the `programs.claude.settings.autoMode` typed option. This PR's `flake.nix` pins `nix-ai` to that branch until the option lands on default. After nix-ai PR merges, follow-up commit flips `nix-ai.url` back to `github:JacobPEvans/nix-ai` + `nix flake update nix-ai`.

## Test plan

- [x] `nix flake check` clean (`darwinConfigurations.jevans-mbp` and `darwinConfigurations.default` eval)
- [x] `nix fmt` no diff
- [ ] `sudo darwin-rebuild switch --flake .#jevans-mbp` after PR G merges
- [ ] `jq '.autoMode.environment' ~/.claude/settings.json` returns the populated list
- [ ] `claude auto-mode config` shows the entries
- [ ] `claude auto-mode critique` AI review

🤖 Generated with [Claude Code](https://claude.com/claude-code)