### PR TITLE
docs(nix-darwin): use ${GIT_HOME_PUBLIC} in docs + slash commands

### DIFF
--- a/.claude/commands/flake-rebuild.md
+++ b/.claude/commands/flake-rebuild.md
@@ -24,9 +24,9 @@ If the user passes additional arguments (e.g. "also update X" or "fix Y"), handl
 
 This repo uses a bare git repo with worktrees:
 
-- `~/git/nix-darwin/` - bare repo (do not cd here directly)
-- `~/git/nix-darwin/main/` - main branch worktree
-- `~/git/nix-darwin/<branch-name>/` - feature worktrees
+- `${GIT_HOME_PUBLIC}/nix-darwin/` - bare repo (do not cd here directly)
+- `${GIT_HOME_PUBLIC}/nix-darwin/main/` - main branch worktree
+- `${GIT_HOME_PUBLIC}/nix-darwin/<branch-name>/` - feature worktrees
 
 ## Steps
 
@@ -35,7 +35,7 @@ This repo uses a bare git repo with worktrees:
 **IMPORTANT**: Update the main worktree before starting:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd "${GIT_HOME_PUBLIC}/nix-darwin/main"
 git fetch origin
 git pull origin main
 git status
@@ -50,7 +50,7 @@ Branch/worktree name format: `chore/flake-update-YYYY-MM-DD` (replace with today
 Check if worktree already exists, otherwise create it:
 
 ```bash
-cd ~/git/nix-darwin
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 # Check if worktree exists
 if [ -d "chore/flake-update-YYYY-MM-DD" ]; then
   cd chore/flake-update-YYYY-MM-DD
@@ -184,7 +184,7 @@ gh pr merge --auto --squash --delete-branch
 Switch back to the main worktree while waiting for auto-merge:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd "${GIT_HOME_PUBLIC}/nix-darwin/main"
 ```
 
 ### 10. Report Summary
@@ -199,5 +199,5 @@ Tell the user:
 
 **DO NOT wait for checks** - auto-merge handles this automatically.
 
-**Note**: The worktree at `~/git/nix-darwin/chore/flake-update-YYYY-MM-DD/` should be
+**Note**: The worktree at `${GIT_HOME_PUBLIC}/nix-darwin/chore/flake-update-YYYY-MM-DD/` should be
 removed manually after the PR is merged (`/wrap-up` or `/clean_gone`).

--- a/.claude/commands/quick-add-package.md
+++ b/.claude/commands/quick-add-package.md
@@ -44,16 +44,16 @@ Per project rules: nixpkgs first, Homebrew only when package is unavailable in n
 
 Create a dedicated worktree for the change (NEVER work on main).
 
-**From the bare repo root** (`~/git/nix-darwin`):
+**From the bare repo root** (`${GIT_HOME_PUBLIC}/nix-darwin`):
 
 ```bash
-cd ~/git/nix-darwin
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 git fetch origin
 git worktree add feat/add-<pkg-name> -b feat/add-<pkg-name> origin/main
 cd feat/add-<pkg-name>
 ```
 
-The worktree is created at `~/git/nix-darwin/feat/add-<pkg-name>/`.
+The worktree is created at `${GIT_HOME_PUBLIC}/nix-darwin/feat/add-<pkg-name>/`.
 
 ### 4. Determine Installation Location
 
@@ -131,7 +131,7 @@ Once the PR is merged, clean up your local environment:
 
 ```bash
 # Navigate to the bare repo root
-cd ~/git/nix-darwin
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 
 # Remove the worktree
 git worktree remove feat/add-<pkg-name>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ pass before merge. You may run it locally to verify before pushing, but it is no
 ## Worktree Workflow
 
 ```bash
-cd ~/git/nix-darwin
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 git fetch origin
 git worktree add <branch> -b <branch> origin/main
 cd <branch>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI Gate][ci-gate-img]][ci-gate-link] [![Nix Build][nix-build-img]][nix-build-link] [![Markdown Lint][md-lint-img]][md-lint-link]
 
-## What Is This?
+## What Is This
 
 A flakes-only nix-darwin configuration for M4 Max MacBook Pro. Manages macOS
 system-level settings: system packages, Dock, Finder, keyboard, security,
@@ -34,14 +34,14 @@ imported as flake inputs.
 
 ```bash
 # 1. Clone as a bare repo (worktree convention used throughout ~/git/)
-git clone --bare https://github.com/JacobPEvans/nix-darwin.git ~/git/nix-darwin
-cd ~/git/nix-darwin
+git clone --bare https://github.com/JacobPEvans/nix-darwin.git "${GIT_HOME_PUBLIC}/nix-darwin"
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 
 # 2. Create the main worktree
 git worktree add main main
 
 # 3. Build and activate for the first time
-cd ~/git/nix-darwin/main
+cd "${GIT_HOME_PUBLIC}/nix-darwin/main"
 sudo darwin-rebuild switch --flake .
 ```
 

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -42,7 +42,7 @@ sudo darwin-rebuild switch --flake ~/.config/nix
 Or manually install hooks (if not using full rebuild):
 
 ```bash
-cd ~/git/nix-darwin
+cd "${GIT_HOME_PUBLIC}/nix-darwin"
 pre-commit install
 ```
 

--- a/docs/boot-failure/permanent-fix.md
+++ b/docs/boot-failure/permanent-fix.md
@@ -182,7 +182,7 @@ is missing, along with a `nix-recover` helper function.
 After making these changes:
 
 ```bash
-cd ~/git/nix-darwin/<worktree>
+cd "${GIT_HOME_PUBLIC}/nix-darwin/<worktree>"
 git add modules/
 git commit -m "fix: multi-layered boot failure recovery"
 sudo darwin-rebuild switch --flake .

--- a/docs/investigations/current-system-symlink-issue.md
+++ b/docs/investigations/current-system-symlink-issue.md
@@ -222,7 +222,7 @@ work even if lsregister fails.
 To verify the fix works:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd "${GIT_HOME_PUBLIC}/nix-darwin/main"
 sudo darwin-rebuild switch --flake .
 ```
 


### PR DESCRIPTION
## Summary

Sweep hardcoded `~/git/nix-darwin/...` references in user-facing docs and AI slash commands to use the `${GIT_HOME_PUBLIC}` workspace variable introduced in nix-home v1.23.0. New users and AI agents reading these docs get the public/private workspace distinction modeled correctly from the first interaction.

Also fixes a pre-existing README validator failure (`## What Is This?` → `## What Is This` — the validator config expected the no-question-mark form).

## Files

- `README.md` — install instructions + section header fix
- `AGENTS.md` — worktree workflow block
- `.claude/commands/flake-rebuild.md` — repo-structure refs, cd commands
- `.claude/commands/quick-add-package.md` — bare repo refs, worktree cd commands
- `docs/PRECOMMIT.md` — pre-commit install snippet
- `docs/boot-failure/permanent-fix.md` — `cd ~/git/nix-darwin/<worktree>` example
- `docs/investigations/current-system-symlink-issue.md` — repro snippet

## Test plan

- [x] `nix flake check` passes (aarch64-darwin)
- [x] `sudo darwin-rebuild switch --flake .` passes (per nix-darwin workflow rule)
- [x] No remaining `~/git/nix-darwin` or `/Users/jevans/git/nix-darwin` refs in docs (verified via grep)
- [x] README validator now passes (no missing sections)

## Related

- nix-home v1.23.0 introducing `GIT_HOME` / `GIT_HOME_PUBLIC` sessionVariables
- nix-home #265 (refactor: drop monitoring-deploy; pin orbstack-kubernetes)
- Workspace migration moving public JacobPEvans repos to `${GIT_HOME_PUBLIC}/` on 2026-05-25

Assisted-by: Claude <noreply@anthropic.com>