### PR TITLE
fix: update git identity and signing key after account rename

### DIFF
--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -30,10 +30,10 @@ in
     inherit homeDir;
 
     # Full name for git commits and other identity purposes
-    fullName = "JacobPEvans";
+    fullName = "JacobPEvans-personal";
 
     # Primary email (GitHub noreply for privacy)
-    email = "20714140+JacobPEvans@users.noreply.github.com";
+    email = "20714140+JacobPEvans-personal@users.noreply.github.com";
   };
 
   # ==========================================================================
@@ -51,7 +51,7 @@ in
   # Safe to commit - GitHub displays these on every signed commit.
   gpg = {
     # Primary signing key ID (public identifier)
-    signingKey = "31652F22BF6AC286";
+    signingKey = "1335F5D082489BBA";
   };
 
   # ==========================================================================


### PR DESCRIPTION
Update the git author name + noreply email and switch `gpg.signingKey` to the new
key (`1335F5D082489BBA`) after the personal account rename `JacobPEvans` ->
`JacobPEvans-personal`. The new key's UID matches the now-verified
`JacobPEvans-personal` noreply, so commits satisfy verified-signature rules. This
file is the effective macbook-m4 identity source.

Refs: dryvist/nix-home#269

Test: `nix flake check` passes; this PR's own commit is signed by the new key and shows Verified.