### PR TITLE
feat(tokens): formalize DRYVIST/ORG_ADMIN tiers, dryvist default, post-rename signing fix

### DIFF
--- a/hosts/macbook-m4/claude-launchers.zsh
+++ b/hosts/macbook-m4/claude-launchers.zsh
@@ -5,7 +5,9 @@
 #   av-claude <profile> [claude-args...]   aws-vault exec <profile> -- claude ...
 #   gh-claude-restricted [claude-args...]  claude with GITHUB_TOKEN from the RESTRICTED tier
 #   gh-claude-private    [claude-args...]  claude with GITHUB_TOKEN from the PRIVATE tier
+#   gh-claude-dryvist    [claude-args...]  claude with GITHUB_TOKEN from the DRYVIST tier
 #   gh-claude-admin      [claude-args...]  claude with GITHUB_TOKEN from the ADMIN tier
+#   gh-claude-org-admin  [claude-args...]  claude with GITHUB_TOKEN from the ORG_ADMIN tier
 #
 # Each gh-claude-* wrapper runs its underlying gh-* function (defined in
 # gh-token-switching.zsh) inside a subshell, so the GITHUB_TOKEN and
@@ -76,10 +78,26 @@ gh-claude-private() {
   )
 }
 
+gh-claude-dryvist() {
+  (
+    gh-dryvist >/dev/null \
+      && _claude_launchers_banner "github-token tier" "dryvist" \
+      && exec claude "$@"
+  )
+}
+
 gh-claude-admin() {
   (
     gh-admin >/dev/null \
       && _claude_launchers_banner "github-token tier" "admin" \
+      && exec claude "$@"
+  )
+}
+
+gh-claude-org-admin() {
+  (
+    gh-org-admin >/dev/null \
+      && _claude_launchers_banner "github-token tier" "org-admin" \
       && exec claude "$@"
   )
 }

--- a/hosts/macbook-m4/gh-token-switching.zsh
+++ b/hosts/macbook-m4/gh-token-switching.zsh
@@ -1,14 +1,17 @@
 # GitHub token context switching — principle of least privilege
 # Tokens are tiered PATs stored in macOS Keychain.
 # Restricted: automation.keychain-db (unrestricted, AI can access freely)
-# Private/Admin: elevate-access.keychain-db (password-protected, requires user unlock)
-# Usage: gh-restricted | gh-private | gh-admin | gh-token-status
+# Elevated (private/dryvist/admin/org-admin): elevate-access.keychain-db
+#   (password-protected, requires user unlock)
+# Usage: gh-restricted | gh-private | gh-dryvist | gh-admin | gh-org-admin | gh-token-status
 #
 # REQUIRES (set by caller in home.nix initContent):
 #   _KC_AI_ACCOUNT        keychain account name (e.g. ai-cli-coder)
 #   _GH_SVC_RESTRICTED, _GH_DB_RESTRICTED
 #   _GH_SVC_PRIVATE,    _GH_DB_PRIVATE
+#   _GH_SVC_DRYVIST,    _GH_DB_DRYVIST
 #   _GH_SVC_ADMIN,      _GH_DB_ADMIN
+#   _GH_SVC_ORG_ADMIN,  _GH_DB_ORG_ADMIN
 
 _gh_switch_token() {
   local svc="$1" db="$2" mode="$3" desc="$4"
@@ -49,11 +52,19 @@ gh-restricted() {
 }
 
 gh-private() {
-  _gh_switch_token "$_GH_SVC_PRIVATE" "$_GH_DB_PRIVATE" "PRIVATE" "+ private repos"
+  _gh_switch_token "$_GH_SVC_PRIVATE" "$_GH_DB_PRIVATE" "PRIVATE" "+ JacobPEvans-personal private repos"
+}
+
+gh-dryvist() {
+  _gh_switch_token "$_GH_SVC_DRYVIST" "$_GH_DB_DRYVIST" "DRYVIST" "+ dryvist org repos (public + private)"
 }
 
 gh-admin() {
-  _gh_switch_token "$_GH_SVC_ADMIN" "$_GH_DB_ADMIN" "ADMIN" "full access"
+  _gh_switch_token "$_GH_SVC_ADMIN" "$_GH_DB_ADMIN" "ADMIN" "JacobPEvans-personal admin"
+}
+
+gh-org-admin() {
+  _gh_switch_token "$_GH_SVC_ORG_ADMIN" "$_GH_DB_ORG_ADMIN" "ORG_ADMIN" "dryvist org admin"
 }
 
 gh-token-status() {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -155,9 +155,13 @@
 
         source ${./gh-token-switching.zsh}
 
-        # Default to lowest privilege on every new shell
+        # Default to the dryvist tier on every new shell. dryvist's token lives
+        # in the auto-readable automation keychain, so this loads with no password
+        # prompt. This is NOT least-privilege — every shell + AI session defaults
+        # to dryvist write access — a deliberate popups-vs-privilege tradeoff
+        # (2026-05-28). Use gh-private / gh-admin / gh-org-admin to elevate further.
         unset GITHUB_TOKEN
-        gh-restricted
+        gh-dryvist
 
         # --- Custom-auth launchers for `claude` ---
         # Defines av-claude <profile>, gh-claude-restricted, gh-claude-private,

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -146,8 +146,12 @@
         _GH_DB_RESTRICTED='${userConfig.github.tokens.restricted.keychain}'
         _GH_SVC_PRIVATE='${userConfig.github.tokens.private.service}'
         _GH_DB_PRIVATE='${userConfig.github.tokens.private.keychain}'
+        _GH_SVC_DRYVIST='${userConfig.github.tokens.dryvist.service}'
+        _GH_DB_DRYVIST='${userConfig.github.tokens.dryvist.keychain}'
         _GH_SVC_ADMIN='${userConfig.github.tokens.admin.service}'
         _GH_DB_ADMIN='${userConfig.github.tokens.admin.keychain}'
+        _GH_SVC_ORG_ADMIN='${userConfig.github.tokens.orgAdmin.service}'
+        _GH_DB_ORG_ADMIN='${userConfig.github.tokens.orgAdmin.keychain}'
 
         source ${./gh-token-switching.zsh}
 
@@ -157,7 +161,8 @@
 
         # --- Custom-auth launchers for `claude` ---
         # Defines av-claude <profile>, gh-claude-restricted, gh-claude-private,
-        # gh-claude-admin. Depends on the gh-* functions sourced above.
+        # gh-claude-dryvist, gh-claude-admin, gh-claude-org-admin. Depends on
+        # the gh-* functions sourced above.
         source ${./claude-launchers.zsh}
 
         # --- macOS setup ---

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -30,10 +30,13 @@ in
     inherit homeDir;
 
     # Full name for git commits and other identity purposes
-    fullName = "JacobPEvans";
+    fullName = "JacobPEvans-personal";
 
-    # Primary email (GitHub noreply for privacy)
-    email = "20714140+JacobPEvans@users.noreply.github.com";
+    # Primary email (GitHub noreply for privacy).
+    # Uses the post-rename username form: the old `…+JacobPEvans@` noreply is no
+    # longer a verified email on the renamed account, which breaks GitHub
+    # signature verification (and signed-commit rulesets). Account id 20714140.
+    email = "20714140+JacobPEvans-personal@users.noreply.github.com";
   };
 
   # ==========================================================================
@@ -50,8 +53,10 @@ in
   # NOTE: These are PUBLIC key identifiers, NOT private keys.
   # Safe to commit - GitHub displays these on every signed commit.
   gpg = {
-    # Primary signing key ID (public identifier)
-    signingKey = "31652F22BF6AC286";
+    # Primary signing key ID (public identifier).
+    # Rotated after the JacobPEvans -> JacobPEvans-personal rename; the old key
+    # 31652F22BF6AC286 produces "Unverified" signatures on the renamed account.
+    signingKey = "1335F5D082489BBA";
   };
 
   # ==========================================================================
@@ -111,7 +116,12 @@ in
     tokens = {
       # Tiered GitHub PATs — each tier specifies its keychain service + DB.
       # Restricted uses the unrestricted automation keychain (AI can access freely).
-      # Private/Admin use a password-protected keychain (requires user unlock).
+      # All elevated tiers use a password-protected keychain (requires user unlock).
+      #   restricted → public repos (default)
+      #   private    → JacobPEvans-personal public + private repos
+      #   dryvist    → dryvist org repos (public + private)
+      #   admin      → JacobPEvans-personal admin (rulesets, branch protection)
+      #   orgAdmin   → dryvist org admin (org-level rulesets)
       restricted = {
         service = "GH_PAT_RESTRICTED";
         keychain = "automation.keychain-db";
@@ -120,8 +130,16 @@ in
         service = "GH_PAT_PRIVATE";
         keychain = "elevate-access.keychain-db";
       };
+      dryvist = {
+        service = "GH_PAT_DRYVIST";
+        keychain = "elevate-access.keychain-db";
+      };
       admin = {
         service = "GH_PAT_ADMIN";
+        keychain = "elevate-access.keychain-db";
+      };
+      orgAdmin = {
+        service = "GH_PAT_ORG_ADMIN";
         keychain = "elevate-access.keychain-db";
       };
     };

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -115,23 +115,30 @@ in
   github = {
     tokens = {
       # Tiered GitHub PATs — each tier specifies its keychain service + DB.
-      # Restricted uses the unrestricted automation keychain (AI can access freely).
-      # All elevated tiers use a password-protected keychain (requires user unlock).
-      #   restricted → public repos (default)
+      # Auto-readable automation keychain (no password prompt; AI can access freely):
+      #   restricted → public repos
+      #   dryvist    → dryvist org repos (public + private) — the DEFAULT tier
+      # Password-protected keychain (requires interactive user unlock):
       #   private    → JacobPEvans-personal public + private repos
-      #   dryvist    → dryvist org repos (public + private)
       #   admin      → JacobPEvans-personal admin (rulesets, branch protection)
       #   orgAdmin   → dryvist org admin (org-level rulesets)
+      #
+      # NOTE: dryvist lives in the auto-readable keychain by deliberate choice —
+      # it is the default tier (see home.nix), so it must load without a password
+      # prompt on every shell. This means the dryvist token (write access to all
+      # dryvist repos) is freely readable by the user session and AI agents. This
+      # trades the former least-privilege RESTRICTED default for zero keychain
+      # popups, per an explicit decision on 2026-05-28.
       restricted = {
         service = "GH_PAT_RESTRICTED";
         keychain = "automation.keychain-db";
       };
-      private = {
-        service = "GH_PAT_PRIVATE";
-        keychain = "elevate-access.keychain-db";
-      };
       dryvist = {
         service = "GH_PAT_DRYVIST";
+        keychain = "automation.keychain-db";
+      };
+      private = {
+        service = "GH_PAT_PRIVATE";
         keychain = "elevate-access.keychain-db";
       };
       admin = {


### PR DESCRIPTION
## Summary
- Add `dryvist` + `orgAdmin` GitHub token tiers (first-class shell + claude-launcher wrappers), matching the existing `restricted`/`private`/`admin` pattern.
- Make `dryvist` the default tier and move its PAT to the auto-readable `automation.keychain-db` — eliminates the constant `elevate-access` keychain popups when working in dryvist repos.
- Repair the commit-signing identity invalidated by the `JacobPEvans` → `JacobPEvans-personal` rename (old key/email produced "Unverified" signatures rejected by signed-commit rulesets).

## Changes
- `lib/user-config.nix`: `dryvist` (`GH_PAT_DRYVIST`, automation keychain) + `orgAdmin` (`GH_PAT_ORG_ADMIN`); signing identity → key `1335F5D082489BBA` / `JacobPEvans-personal` / `20714140+JacobPEvans-personal@users.noreply.github.com`.
- `hosts/macbook-m4/home.nix`: wire the two new tiers; default `gh-restricted` → `gh-dryvist`.
- `gh-token-switching.zsh`: add `gh-dryvist` + `gh-org-admin`.
- `claude-launchers.zsh`: add `gh-claude-dryvist` + `gh-claude-org-admin`.

## Tradeoff (deliberate)
Defaulting to `dryvist` from the auto-readable keychain means every shell + AI session defaults to dryvist write access — NOT least-privilege. Chosen to eliminate password popups (2026-05-28). `private`/`admin`/`org-admin` remain password-gated.

## Test plan
- [x] `nix fmt` / `statix` / `deadnix` / `nix-instantiate --parse` clean
- [x] commits signed + verified (key `1335F5D082489BBA`, sig G)
- [ ] CI gate (`nix flake check` + `darwin-rebuild` on macOS runner)
- [ ] Post-merge: `darwin-rebuild switch`; `GH_PAT_DRYVIST` present in `automation.keychain-db`; confirm new shells show `GH_ENV_MODE=DRYVIST` with no popup; `gh-claude-org-admin` launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)