### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -3,5 +3,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -29,5 +29,5 @@ jobs:
 
   recommend:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "CI Gate"
     secrets: inherit

--- a/.github/workflows/ci-file-length.yml
+++ b/.github/workflows/ci-file-length.yml
@@ -22,4 +22,4 @@ permissions:
 jobs:
   check:
     name: Check File Sizes
-    uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -28,7 +28,7 @@ jobs:
     #   github.event.workflow_run.conclusion == 'failure' &&
     #   github.event.workflow_run.head_branch != 'main'
     # --- END DISABLED ---
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "Nix flakes configuration for macOS and Linux systems"
       ci_structure: "ci-gate.yml (orchestrator calling _nix-validate, _nix-build, _markdown-lint, _file-size, _claude-settings)"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -110,7 +110,7 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
     with:
       # Linux `nix flake check --all-systems` needs more disk/RAM for
       # darwin-source substitution; m7+c7 family with s3-cache fits.
@@ -121,7 +121,7 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
@@ -135,7 +135,7 @@ jobs:
     name: File Size
     needs: changes
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 

--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -23,4 +23,4 @@ permissions:
 jobs:
   lint:
     name: Lint Markdown
-    uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -19,4 +19,4 @@ permissions:
 jobs:
   validate:
     name: Validate
-    uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -28,5 +28,5 @@ jobs:
 
   simplify:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,4 +7,4 @@ permissions:
 
 jobs:
   copilot-setup-steps:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_copilot-setup-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_copilot-setup-steps.yml@main

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -18,5 +18,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -68,7 +68,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -79,7 +79,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "NixOS/nix-darwin system configuration using flakes"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -29,5 +29,5 @@ jobs:
 
   analyze:
     if: github.event_name != 'schedule'
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,7 +1,7 @@
 # Periodic + per-PR OSV vulnerability scan.
 #
-# Inherits the centralized reusable workflow from JacobPEvans/.github.
-# Config: JacobPEvans/.github/osv-scanner.toml (org default) or local
+# Inherits the centralized reusable workflow from JacobPEvans-personal/.github.
+# Config: JacobPEvans-personal/.github/osv-scanner.toml (org default) or local
 # osv-scanner.toml in this repo (takes precedence).
 #
 # Make this a required check via branch protection on `main` after merge.
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   scan:
-    # SHA pin → JacobPEvans/.github main as of 2026-05-20.
+    # SHA pin → JacobPEvans-personal/.github main as of 2026-05-20.
     # Bump intentionally when the upstream workflow changes.
-    uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
+    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
     with:
       runner_label: ubuntu-latest

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -24,7 +24,7 @@ rules:
       - ci-fix.yml
 
   # ACCEPTED: secrets: inherit is required for reusable workflow callers.
-  # These thin callers delegate to JacobPEvans/ai-workflows reusable workflows
+  # These thin callers delegate to dryvist/ai-workflows reusable workflows
   # which need CLAUDE_CODE_OAUTH_TOKEN and other repo secrets at runtime.
   # The reusable workflows are owned by the same org and are trusted.
   secrets-inherit:


### PR DESCRIPTION
CI on `dryvist/nix-darwin` is fully red. Run [26614839367](https://github.com/dryvist/nix-darwin/actions/runs/26614839367) failed at parse time:

```
error parsing called workflow ".github/workflows/copilot-setup-steps.yml"
 -> "JacobPEvans/ai-workflows/.github/workflows/_copilot-setup-steps.yml@main"
 : workflow was not found.
```

## Root cause

The shared-CI repos moved during the org migration, and **GitHub Actions does not follow repository move/rename redirects for reusable-workflow `uses:` clauses** (by design). Every thin-caller `uses:` ref pointing at the old owner failed at parse time (`jobCount: 0`) — Copilot Setup Steps, CI Gate, OSV Scan, AI Merge Gate, and the scheduled agents.

`uses:` also forbids expressions, so the owner cannot be a variable — it must be a literal pinned to each repos real current home.

## Fix

| Referenced as | Real current home | Refs |
| --- | --- | --- |
| `JacobPEvans/ai-workflows/...` | `dryvist/ai-workflows` | 14 |
| `JacobPEvans/.github/...` | `JacobPEvans-personal/.github` | 9 (incl. SHA-pinned `osv-scan`) |

Plus the `dryvist/ai-workflows` comment in `.github/zizmor.yml`. 21 files, owner-string swaps only.

## Intentionally NOT changed

`{{#import JacobPEvans/.github/...}}` references in `repo-health-audit.md` / `.lock.yml` are left as-is: gh-aw imports resolve at **compile time** via the API redirect (not the no-redirect `uses:` path), so they are governed by the workspace "dont rewrite on redirect" rule. (Repo Health Audits current failure is an unrelated runtime template error.)

## Scope

This is the nix-darwin slice of an org-wide rollout — ~12 other `dryvist/*` repos carry the same broken refs. A follow-up documents the canonical owner mapping in `ai-assistant-instructions` and sweeps the remaining repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)