### PR TITLE
fix(identity): keep fullName "JacobPEvans" for cross-repo consistency

### DIFF
--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -30,7 +30,7 @@ in
     inherit homeDir;
 
     # Full name for git commits and other identity purposes
-    fullName = "JacobPEvans-personal";
+    fullName = "JacobPEvans";
 
     # Primary email (GitHub noreply for privacy)
     # Account renamed JacobPEvans -> JacobPEvans-personal; the noreply email and


### PR DESCRIPTION
## Summary
Revert the git author display name in `lib/user-config.nix` to `"JacobPEvans"`, matching nix-home's default. After #1155 the two repos disagreed (nix-darwin `-personal` vs nix-home `JacobPEvans`); this realigns them.

`fullName` is **display-only** and does not affect signature verification — only the noreply email and `gpg.signingKey` do, and both are left unchanged.

Refs: #1155

## Test plan
- [x] `nix flake check` passes
- [x] This PR's own commit is signed by the new key (`1335F5D082489BBA`) and Verified