### PR TITLE
refactor: use ${GIT_HOME_PUBLIC}/${GIT_HOME} for git-workspace paths

### DIFF
--- a/.claude/commands/flake-rebuild.md
+++ b/.claude/commands/flake-rebuild.md
@@ -24,9 +24,9 @@ If the user passes additional arguments (e.g. "also update X" or "fix Y"), handl
 
 This repo uses a bare git repo with worktrees:
 
-- `~/git/nix-darwin/` - bare repo (do not cd here directly)
-- `~/git/nix-darwin/main/` - main branch worktree
-- `~/git/nix-darwin/<branch-name>/` - feature worktrees
+- `${GIT_HOME_PUBLIC}/nix-darwin/` - bare repo (do not cd here directly)
+- `${GIT_HOME_PUBLIC}/nix-darwin/main/` - main branch worktree
+- `${GIT_HOME_PUBLIC}/nix-darwin/<branch-name>/` - feature worktrees
 
 ## Steps
 
@@ -35,7 +35,7 @@ This repo uses a bare git repo with worktrees:
 **IMPORTANT**: Update the main worktree before starting:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd ${GIT_HOME_PUBLIC}/nix-darwin/main
 git fetch origin
 git pull origin main
 git status
@@ -50,7 +50,7 @@ Branch/worktree name format: `chore/flake-update-YYYY-MM-DD` (replace with today
 Check if worktree already exists, otherwise create it:
 
 ```bash
-cd ~/git/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 # Check if worktree exists
 if [ -d "chore/flake-update-YYYY-MM-DD" ]; then
   cd chore/flake-update-YYYY-MM-DD
@@ -184,7 +184,7 @@ gh pr merge --auto --squash --delete-branch
 Switch back to the main worktree while waiting for auto-merge:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd ${GIT_HOME_PUBLIC}/nix-darwin/main
 ```
 
 ### 10. Report Summary
@@ -199,5 +199,5 @@ Tell the user:
 
 **DO NOT wait for checks** - auto-merge handles this automatically.
 
-**Note**: The worktree at `~/git/nix-darwin/chore/flake-update-YYYY-MM-DD/` should be
+**Note**: The worktree at `${GIT_HOME_PUBLIC}/nix-darwin/chore/flake-update-YYYY-MM-DD/` should be
 removed manually after the PR is merged (`/wrap-up` or `/clean_gone`).

--- a/.claude/commands/quick-add-package.md
+++ b/.claude/commands/quick-add-package.md
@@ -44,16 +44,16 @@ Per project rules: nixpkgs first, Homebrew only when package is unavailable in n
 
 Create a dedicated worktree for the change (NEVER work on main).
 
-**From the bare repo root** (`~/git/nix-darwin`):
+**From the bare repo root** (`${GIT_HOME_PUBLIC}/nix-darwin`):
 
 ```bash
-cd ~/git/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 git fetch origin
 git worktree add feat/add-<pkg-name> -b feat/add-<pkg-name> origin/main
 cd feat/add-<pkg-name>
 ```
 
-The worktree is created at `~/git/nix-darwin/feat/add-<pkg-name>/`.
+The worktree is created at `${GIT_HOME_PUBLIC}/nix-darwin/feat/add-<pkg-name>/`.
 
 ### 4. Determine Installation Location
 
@@ -131,7 +131,7 @@ Once the PR is merged, clean up your local environment:
 
 ```bash
 # Navigate to the bare repo root
-cd ~/git/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 
 # Remove the worktree
 git worktree remove feat/add-<pkg-name>

--- a/.claude/plans/darwin-rebuild-fixes.md
+++ b/.claude/plans/darwin-rebuild-fixes.md
@@ -187,7 +187,7 @@ Add grep check to pre-commit or CI:
 1. **Pre-implementation**:
 
    ```bash
-   cd ~/git/nix-darwin/main
+   cd ${GIT_HOME_PUBLIC}/nix-darwin/main
    git status  # Confirm clean state
    nix flake check  # Baseline
    ```

--- a/.claude/plans/replicated-napping-pixel.md
+++ b/.claude/plans/replicated-napping-pixel.md
@@ -141,9 +141,9 @@ modules/home-manager/ai-cli/
 
 ```bash
 # Test jsondiff is globally available in Python 3.12 dev shell
-nix develop ~/git/nix-darwin/main/shells/python312 \
+nix develop ${GIT_HOME_PUBLIC}/nix-darwin/main/shells/python312 \
   --command python -c "import jsondiff; print('jsondiff OK')"
 
 # Full flake check
-nix flake check ~/git/nix-darwin/main
+nix flake check ${GIT_HOME_PUBLIC}/nix-darwin/main
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ pass before merge. You may run it locally to verify before pushing, but it is no
 ## Worktree Workflow
 
 ```bash
-cd ~/git/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 git fetch origin
 git worktree add <branch> -b <branch> origin/main
 cd <branch>

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ imported as flake inputs.
 ### First-Time Setup
 
 ```bash
-# 1. Clone as a bare repo (worktree convention used throughout ~/git/)
-git clone --bare https://github.com/JacobPEvans/nix-darwin.git ~/git/nix-darwin
-cd ~/git/nix-darwin
+# 1. Clone as a bare repo (worktree convention used throughout ${GIT_HOME})
+git clone --bare https://github.com/JacobPEvans/nix-darwin.git ${GIT_HOME_PUBLIC}/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 
 # 2. Create the main worktree
 git worktree add main main
 
 # 3. Build and activate for the first time
-cd ~/git/nix-darwin/main
+cd ${GIT_HOME_PUBLIC}/nix-darwin/main
 sudo darwin-rebuild switch --flake .
 ```
 

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -42,7 +42,7 @@ sudo darwin-rebuild switch --flake ~/.config/nix
 Or manually install hooks (if not using full rebuild):
 
 ```bash
-cd ~/git/nix-darwin
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 pre-commit install
 ```
 

--- a/docs/boot-failure/permanent-fix.md
+++ b/docs/boot-failure/permanent-fix.md
@@ -182,7 +182,7 @@ is missing, along with a `nix-recover` helper function.
 After making these changes:
 
 ```bash
-cd ~/git/nix-darwin/<worktree>
+cd ${GIT_HOME_PUBLIC}/nix-darwin/<worktree>
 git add modules/
 git commit -m "fix: multi-layered boot failure recovery"
 sudo darwin-rebuild switch --flake .

--- a/docs/investigations/current-system-symlink-issue.md
+++ b/docs/investigations/current-system-symlink-issue.md
@@ -222,7 +222,7 @@ work even if lsregister fails.
 To verify the fix works:
 
 ```bash
-cd ~/git/nix-darwin/main
+cd ${GIT_HOME_PUBLIC}/nix-darwin/main
 sudo darwin-rebuild switch --flake .
 ```
 

--- a/hosts/macbook-m4/macos-setup.zsh
+++ b/hosts/macbook-m4/macos-setup.zsh
@@ -16,4 +16,4 @@ unset _brew_dir _brew_stamp
 # Clean up .DS_Store files in common directories.
 # Single find across all dirs; -exec rm {} + batches args for fewer rm invocations.
 # Runs in the background to avoid blocking shell startup.
-{ find ~/.config/ ~/git/ ~/obsidian/ -name ".DS_Store" -depth -exec rm {} + 2>/dev/null; } &!
+{ find ~/.config/ "${GIT_HOME}/" ~/obsidian/ -name ".DS_Store" -depth -exec rm {} + 2>/dev/null; } &!

--- a/modules/darwin/finder.nix
+++ b/modules/darwin/finder.nix
@@ -38,7 +38,7 @@ _: {
 
     # Show full POSIX path in window title
     # Default: false
-    # Example: "/Users/<username>/git/project" instead of "project"
+    # Example: "${GIT_HOME}/project" instead of "project"
     _FXShowPosixPathInTitle = true;
 
     # Default view style for new windows


### PR DESCRIPTION
Replace hardcoded ~/git/nix-darwin with ${GIT_HOME_PUBLIC}/nix-darwin and standalone ~/git/ with ${GIT_HOME} across docs, the macOS setup zsh fragment, and a finder.nix comment. Also corrects the stale path (repo lives at ~/git/public/nix-darwin). Scope limited to git-workspace path references; non-git home paths left as ~.