### PR TITLE
chore(deps): bump nix-ai for PR #858 (claude-latest -> bunx)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780195830,
-        "narHash": "sha256-pM5NUlTaXJvfckO+pjL1zMu6j+c4z6XN0u9YzKK0JxA=",
+        "lastModified": 1780198890,
+        "narHash": "sha256-AuE70BYBpdIc8oE3Q3bsPAqsNijsZ0bY9IK8UDerSN0=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c3dcb726417e67ae84106d4bff53f465ec099772",
+        "rev": "63949ed3722d862c0ac0b276de8409d28919cadf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps the `nix-ai` flake input from `c3dcb72` → `63949ed` to pick up [`dryvist/nix-ai#858`](https://github.com/dryvist/nix-ai/pull/858).

That PR rewires the `claude-latest` shell alias:

```diff
- alias claude-latest="$HOME/.local/bin/claude"
+ alias claude-latest="bunx @anthropic-ai/claude-code@latest"
```

Before: `claude-latest` was a no-op alias for `$HOME/.local/bin/claude` — the same binary bare `claude` resolves to via PATH.
After: `claude-latest` fetches the npm `latest` dist-tag via `bunx` on each invocation. No parallel install to maintain, no LaunchAgent, no symlink to keep healthy.

## Why

Home user's `claude` (PATH-resolved) tracks whatever the local install ships — typically the brew cask's stable or nix-ai's pinned package. `claude-latest` is meant to be the manual "I want today's bleeding edge" escape hatch. `bunx` makes that a single-invocation fetch instead of a separate install lifecycle.

## Refs

- dryvist/nix-ai#858

## Test plan

- [ ] `darwin-rebuild switch --flake .#macbook-m4` succeeds
- [ ] `alias claude-latest` → `bunx @anthropic-ai/claude-code@latest`
- [ ] `claude-latest --version` returns the npm `latest` dist-tag version (may differ from `claude --version`, that's expected)
- [ ] `claude --version` unchanged (PATH-resolved binary unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)