### PR TITLE
chore(deps): bump nix-ai for nix-claude-code merge-script-exec fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,13 +319,21 @@
       }
     },
     "dryvist-github": {
-      "flake": false,
+      "inputs": {
+        "git-hooks": "git-hooks",
+        "nixpkgs": [
+          "nix-ai",
+          "nix-claude-code",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
       "locked": {
-        "lastModified": 1780060417,
-        "narHash": "sha256-pPb5ZJzFK3v/wfqR5KO2TptoVedakes9mKDExwdmZ4k=",
+        "lastModified": 1780244578,
+        "narHash": "sha256-wsNxWB6MfwFXBgHXxvByqWwDB2OgN4fBUaJ0YgbEGXU=",
         "owner": "dryvist",
         "repo": ".github",
-        "rev": "218b9a5d1b408c3be06ac732f978208027ed510f",
+        "rev": "de34cfea46962c8abee3878005ed120731c4c45a",
         "type": "github"
       },
       "original": {
@@ -486,6 +494,7 @@
         "nixpkgs": [
           "nix-ai",
           "nix-claude-code",
+          "dryvist-github",
           "nixpkgs"
         ]
       },
@@ -534,6 +543,7 @@
         "nixpkgs": [
           "nix-ai",
           "nix-claude-code",
+          "dryvist-github",
           "git-hooks",
           "nixpkgs"
         ]
@@ -740,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780198890,
-        "narHash": "sha256-AuE70BYBpdIc8oE3Q3bsPAqsNijsZ0bY9IK8UDerSN0=",
+        "lastModified": 1780252344,
+        "narHash": "sha256-kSk4b2uDLMs7EI/Ro3bhiR1B9jBD4tKmfjUnj6DK3+Q=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "63949ed3722d862c0ac0b276de8409d28919cadf",
+        "rev": "ad6ff52361f6b1a8d6b3c9aed79876c161261c49",
         "type": "github"
       },
       "original": {
@@ -778,7 +788,6 @@
         "dryvist-github": "dryvist-github",
         "fabric-src": "fabric-src_2",
         "flake-parts": "flake-parts_2",
-        "git-hooks": "git-hooks",
         "home-manager": [
           "nix-ai",
           "home-manager"
@@ -794,17 +803,16 @@
         "obsidian-skills": "obsidian-skills",
         "openai-codex": "openai-codex",
         "superpowers-marketplace": "superpowers-marketplace",
-        "treefmt-nix": "treefmt-nix_2",
         "vct-cribl-pack-validator-skills": "vct-cribl-pack-validator-skills",
         "visual-explainer-marketplace": "visual-explainer-marketplace",
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780195187,
-        "narHash": "sha256-IsYx/jkCLyaWkJXZYYogjumtyg0lusFAmAs+suhzGq0=",
+        "lastModified": 1780252245,
+        "narHash": "sha256-o4MJY2zde9IJbiTVN5kV00sSdqGvdKbnMbO1v5O7e68=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "9fe7a2e86265a96d69f97e6514a5a3e012743b9c",
+        "rev": "628dd6fac218e65ce32b1adca7eb6605c1510e1a",
         "type": "github"
       },
       "original": {
@@ -1103,15 +1111,16 @@
         "nixpkgs": [
           "nix-ai",
           "nix-claude-code",
+          "dryvist-github",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bumps `nix-ai` from `63949ed` to `ad6ff52`, pulling in dryvist/nix-ai#861 which in turn bumps `nix-claude-code` to `628dd6f` (dryvist/nix-claude-code#37).
- Fix: `merge-json-settings.sh` is now invoked through a `pkgs.writeShellApplication` wrapper that carries the executable bit. Direct exec from the activation script no longer fails with EACCES.

## Why

Every `darwin-rebuild switch` since PR #1160 has been silently aborting at `claudeSettingsMerge` because the source script under `nix-claude-code/modules/scripts/merge-json-settings.sh` was committed with mode 0644 and `${"$"}{./scripts/...}` path interpolation preserved that mode in the Nix store. With `set -eu -o pipefail` in the home-manager activation script, the EACCES exit propagated and stopped `linkGeneration` and all subsequent activations.

Live impact pre-fix (verified):
- `jq '.autoMode' ~/.claude/settings.json` → `null` (PR #28's render never gets written)
- `~/.claude/plugins/marketplaces/` → empty (`linkGeneration` never runs)
- `~/.claude/plugins/known_marketplaces.json` → stale

## Test plan

- [ ] CI green (Nix Build / Nix Validate / file-size / etc.)
- [ ] Local: `sudo darwin-rebuild switch --flake .` reaches `Activating linkGeneration`
- [ ] Post-rebuild: `jq '.autoMode.environment | length' ~/.claude/settings.json` ≥ 12
- [ ] Post-rebuild: `ls ~/.claude/plugins/marketplaces/ | wc -l` = 22

Refs:
- dryvist/nix-claude-code#37
- dryvist/nix-ai#861

🤖 Generated with [Claude Code](https://claude.com/claude-code)