### PR TITLE
chore(deps): bump nix-ai for settings.json render dedup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780252344,
-        "narHash": "sha256-kSk4b2uDLMs7EI/Ro3bhiR1B9jBD4tKmfjUnj6DK3+Q=",
+        "lastModified": 1780254721,
+        "narHash": "sha256-hR7liY3U4njdtQUmPEBcB9uIuzJErzhG5wRggT6+eo0=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ad6ff52361f6b1a8d6b3c9aed79876c161261c49",
+        "rev": "2e12eec62463dfb23bfc6fb05862d5278c175957",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780252245,
-        "narHash": "sha256-o4MJY2zde9IJbiTVN5kV00sSdqGvdKbnMbO1v5O7e68=",
+        "lastModified": 1780254652,
+        "narHash": "sha256-+OThghl1ecV7fVD2NiHEGfopITtQxTl4aXYLCMEHaQc=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "628dd6fac218e65ce32b1adca7eb6605c1510e1a",
+        "rev": "947526673a8fb52ce400bb824f073f532f4fd2f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `nix-ai` from `ad6ff52` to `2e12eec`, pulling in dryvist/nix-ai#862 → dryvist/nix-claude-code#39 which removes the conflicting `home.file.".claude/settings.json"` install in nix-claude-code. Activation merge is now the sole writer.

## Why

After the previous cascade (PRs #1162 / #1163), `darwin-rebuild switch` completes cleanly but Claude Code refuses to load `~/.claude/settings.json`:

> `permissions.defaultMode: Invalid value. Expected one of: acceptEdits, auto, bypassPermissions, default, dontAsk, plan`
> Files with errors are skipped entirely, not just the invalid settings.

`enabledPlugins` is also missing entirely → marketplace plugins like `karpathy-skills` can't auto-enable. Root cause: two writers race on every activation. `home.file` installs a smaller, broken render via `linkGeneration` which runs *after* `claudeSettingsMerge` and overwrites the merge's correct output with a symlink to the broken source.

This bump eliminates the race; the merge script (made executable in dryvist/nix-claude-code#37) handles the no-existing-file case so first-time installs still work.

Refs:
- dryvist/nix-claude-code#37 (made the merge script executable)
- dryvist/nix-claude-code#39 (removed the conflicting `home.file` install)
- dryvist/nix-ai#862 (bumped the lock)

## Test plan

- [ ] CI green (Nix Build / Nix Validate / pre-commit / file-size / Merge Gate)
- [ ] Local: `sudo darwin-rebuild switch --flake .` completes
- [ ] Post-rebuild: `jq '.permissions.defaultMode' ~/.claude/settings.json` → `"auto"`
- [ ] Post-rebuild: `jq '.enabledPlugins | keys | length' ~/.claude/settings.json` ≥ 90
- [ ] Restart Claude Code → no settings error dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)