### PR TITLE
fix(homebrew): declare claude-code@latest cask to match install

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -137,9 +137,11 @@ in
         greedy = true;
       } # Claude desktop app (not in nixpkgs for Darwin)
       {
-        name = "claude-code";
+        name = "claude-code@latest";
         greedy = true;
-      } # Claude Code CLI
+      } # Claude Code CLI — the @latest cask tracks the newest release (the
+      # plain `claude-code` cask lags; declaring @latest matches what's
+      # actually installed and stops the rebuild's brew-bundle binary conflict)
 
       # --- OpenAI ---
       # OpenAI Codex CLI (AI coding agent) - migrated from homebrew/core to cask


### PR DESCRIPTION
The declared `claude-code` cask (2.1.149) was never installed — `claude-code@latest` (2.1.158, newest-tracking) is what's actually present and working. Every rebuild's brew bundle tried to install the declared `claude-code` and failed with a binary conflict on `/opt/homebrew/bin/claude`. Declaring `@latest` (which auto-tracks newest, matching intent) makes the config match reality and stops the recurring rebuild error. `onActivation.cleanup = none`, so nothing gets uninstalled.

Resolves the brew-bundle error surfaced during the post-deps-update rebuild.