### PR TITLE
chore(deps): bump nix-ai (drop qwen soft-check script)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780254721,
-        "narHash": "sha256-hR7liY3U4njdtQUmPEBcB9uIuzJErzhG5wRggT6+eo0=",
+        "lastModified": 1780268807,
+        "narHash": "sha256-rMXG9+3pWSW0RNDGD+bLB2/Z7QhF0snWpAAuWSyJlmg=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "2e12eec62463dfb23bfc6fb05862d5278c175957",
+        "rev": "f35bdca64c713ae8ca33cf03dfc60a223961f7bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls dryvist/nix-ai#863 — deletes the qwen-code activation check script that emitted a false `qwen is not on PATH` warning on every darwin-rebuild (the check used $PATH, excluded by home-manager's activation env). Pairs with #1167 (claude cask) for a warning-clean rebuild.