### PR TITLE
fix(ci): repoint release-please caller to org-native reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
+    uses: dryvist/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
nix-darwin was the last repo still calling JacobPEvans-personal/.github's reusable with the old app (3509510, not installed), so its release-please 404'd and v1.39.0 didn't cut. Repoints to dryvist/.github with the org release App secret. The hub already cuts the release; this stops the per-repo caller failing on every push.