### PR TITLE
feat(ci): receive nix-ai flake lock updates

### DIFF
--- a/.github/workflows/update-flake-input.yml
+++ b/.github/workflows/update-flake-input.yml
@@ -1,0 +1,33 @@
+# Receiver: bump a flake input on repository_dispatch
+#
+# Called by nix-ai after its own flake.lock changes on main. Delegates
+# to the shared reusable workflow in dryvist/.github.
+# Also available as workflow_dispatch for manual one-off bumps.
+#
+# Chain: nix-ai lock update → dispatch → bump nix-ai input here.
+name: Update flake input
+
+on:
+  repository_dispatch:
+    types: [update-flake-input]
+  workflow_dispatch:
+    inputs:
+      input_name:
+        description: Flake input to update (default: nix-ai)
+        type: string
+        default: nix-ai
+
+permissions: {}
+
+jobs:
+  update:
+    uses: dryvist/.github/.github/workflows/_update-flake-input.yml@main
+    with:
+      input_name: >-
+        ${{
+          github.event.client_payload.input
+          || inputs.input_name
+          || 'nix-ai'
+        }}
+    secrets:
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds `update-flake-input.yml` — the final hop in the event-driven lock-propagation chain. Receives `repository_dispatch` from nix-ai and bumps the nix-ai flake input.

## Changes

**update-flake-input.yml** (new)
- Listens for `repository_dispatch` event `update-flake-input`
- Calls shared reusable workflow `dryvist/.github/_update-flake-input.yml`
- Input name defaults to `nix-ai`
- Also available as `workflow_dispatch` for manual bumps

## Chain (full propagation)

```
nix-claude-code release
  → nix-ai receives update-flake-input dispatch
    → nix-ai flake.lock updated on main
      → nix-darwin receives dispatch (from nix-ai)
        → this workflow runs
          → nix-darwin flake.lock updated
```

## Dependencies

- dryvist/.github PR #20 (reusable workflow definition)
- nix-ai event-driven PR (dispatches the event)
- `GH_APP_CLIENT_ID` var + `GH_APP_PRIVATE_KEY` secret (org-wide)

## Test Plan

- Manual `workflow_dispatch` trigger
- Verify nix-ai input bumps correctly