### PR TITLE
chore(flake.lock): pull mlx-watchdog into nix-ai

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780268807,
-        "narHash": "sha256-rMXG9+3pWSW0RNDGD+bLB2/Z7QhF0snWpAAuWSyJlmg=",
+        "lastModified": 1780434189,
+        "narHash": "sha256-M3Ud73TnO6xuZMcYXoDBMpLdQ85ToclYNzzHflw/h38=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "f35bdca64c713ae8ca33cf03dfc60a223961f7bb",
+        "rev": "d43c1cef39f5ae6d1b298d24858a303cec10242e",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780254652,
-        "narHash": "sha256-+OThghl1ecV7fVD2NiHEGfopITtQxTl4aXYLCMEHaQc=",
+        "lastModified": 1780422238,
+        "narHash": "sha256-vjpmQgrE/D8XaLf4HC1R6OiojDm2svTbdodd8cX77cU=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "947526673a8fb52ce400bb824f073f532f4fd2f4",
+        "rev": "b107aede8b07a435261b9dbdc2695fc7cc2f8fae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Updates the \`nix-ai\` flake input from \`f35bdca\` (2026-05-31) to
\`d43c1ce\` (2026-06-02). The only material change in that diff is
**dryvist/nix-ai#873** — the new \`mlx-watchdog\` LaunchAgent that
self-heals the local vllm-mlx stack under memory pressure.

## What activates after this PR merges + \`darwin-rebuild switch\`

A second LaunchAgent (label \`dev.vllm-mlx.server.watchdog\`) wakes
every 5 minutes via \`StartInterval=300\`. On each tick it checks:

| Check | Default threshold |
|---|---|
| Stuck-past-TTL worker | \`etime > 2 × ttl\` per model |
| Swap pressure | \`vm.swapusage\` used > 75 % of pool |
| Single-worker RSS | \> 50 % of physical RAM |

If any check fires, it runs \`launchctl kickstart -k dev.vllm-mlx.server\`.
The existing \`KeepAlive\` + \`ThrottleInterval=120s\` then respawns
the manager cleanly.

## Why this PR matters

The upstream \`mostlygeek/llama-swap\` \`sync.WaitGroup\` race at
\`proxy/process.go:280-289\` has fired 5+ times on this host in five
weeks. Each firing leaves a worker resident past TTL, eventually
saturating compressor + swap (the RC14 mechanism). This watchdog
makes the host self-recover within 5 min — no human intervention
required.

Live smoke test against the stuck state on 2026-06-02:

\`\`\`text
2026-06-02T16:58:55 TRIGGER SWAP_PRESSURE swap_used=19245.12MB swap_total=20480.00MB pct=93%
2026-06-02T16:58:55 ACTION launchctl kickstart -k gui/501/dev.vllm-mlx.server
2026-06-02T16:58:56 DONE
\`\`\`

Worker resident dropped 71 GB → 18 GB on the fresh load.

## Test plan

- [x] \`nix flake check --no-build\` passes on the lock change
- [x] mlx-watchdog smoke test fired correctly on the live host
- [ ] After merge: \`darwin-rebuild switch\`
- [ ] After switch: \`launchctl print gui/$(id -u)/dev.vllm-mlx.server.watchdog\` shows \`state = waiting\`
- [ ] After switch: \`~/Library/Logs/vllm-mlx/watchdog.log\` accumulates entries every 5 min
- [ ] After 24 h: no panic in \`vllm-mlx.error.log\` goes unrecovered

Refs: dryvist/nix-ai#873, dryvist/docs-starlight#22, dryvist/nix-mac-performance#21