### PR TITLE
fix(homebrew): drop Shortwave for Apple Mail; bitwarden-desktop → cask

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -132,7 +132,6 @@ Source: `modules/darwin/common.nix`
 
 | Package | Description |
 | --- | --- |
-| bitwarden-desktop | Password manager desktop app |
 | raycast | Productivity launcher (replaces Spotlight) |
 | swiftbar | Menu bar customization |
 
@@ -178,7 +177,7 @@ via LaunchAgent) always installs the latest version rather than deferring to bui
 | Package | greedy | Description |
 | --- | --- | --- |
 | obsidian | yes | Knowledge base / note-taking |
-| shortwave | yes | AI-powered email client |
+| bitwarden | yes | Password manager desktop app (moved from nixpkgs — EOL electron_39) |
 | wispr-flow | yes | AI-powered voice dictation |
 | voiceink | yes | Voice-to-text app (local whisper) |
 | claude | yes | Anthropic Claude desktop app (not in nixpkgs for Darwin) |

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -77,7 +77,8 @@ in
     # ========================================================================
     # GUI applications (system-level, in /Applications/Nix Apps/)
     # ========================================================================
-    bitwarden-desktop # Password manager desktop app
+    # bitwarden-desktop moved to a Homebrew cask (`bitwarden`) — the nixpkgs
+    # build pins EOL/insecure electron_39. See modules/darwin/homebrew.nix.
     raycast # Productivity launcher (replaces Spotlight)
     swiftbar # Menu bar customization
   ];

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -40,7 +40,7 @@ in
       "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
 
       # Communication
-      "/Applications/Shortwave.app" # AI-powered email client (homebrew cask)
+      "/System/Applications/Mail.app" # Apple Mail (system app)
       "/Applications/Microsoft Outlook.app"
       "/Applications/Microsoft Teams.app"
       "/Applications/Slack.app"

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -118,10 +118,18 @@ in
         name = "obsidian";
         greedy = true;
       } # Knowledge base / note-taking
+      # Bitwarden desktop password manager. Cask, NOT nixpkgs: the nixpkgs
+      # `bitwarden-desktop` build pins `electron_39`, which is now EOL and
+      # flagged insecure, so `darwin-rebuild` refuses to evaluate it. Bitwarden
+      # upstream still pins electron_39 even on its latest release, so bumping
+      # nixpkgs does not help. This cask is Bitwarden's own signed build
+      # (independent of nixpkgs' from-source electron), so it sidesteps the EOL
+      # flag and stays current via greedy auto-update. Moved here from
+      # modules/darwin/common.nix systemPackages.
       {
-        name = "shortwave";
+        name = "bitwarden";
         greedy = true;
-      } # AI-powered email client
+      } # Password manager desktop app (ex-nixpkgs; EOL electron_39)
       {
         name = "wispr-flow";
         greedy = true;

--- a/scripts/validate-nix-before-all.sh
+++ b/scripts/validate-nix-before-all.sh
@@ -17,7 +17,7 @@ EXCLUSIONS=(
   "claude:Not available for aarch64-darwin (only x86_64-linux)"
   "claude-code:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "gemini-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
-  "shortwave:Different apps - nixpkgs=radio client, homebrew=email client"
+  "bitwarden:nixpkgs build pins EOL electron_39 (insecure); cask uses Bitwarden's maintained build"
   "orbstack:Cask preferred over nixpkgs for TCC permission stability (nixpkgs symlink changes on rebuild, forcing TCC re-grant)"
   "postman:Nixpkgs version lags significantly behind upstream, causing Squirrel/ShipIt schema mismatch errors"
 )


### PR DESCRIPTION
## What

Two homebrew app-sourcing changes:

1. **Remove Shortwave**, replace with **Apple Mail** in the dock. Drops the `shortwave` cask + its `persistent-apps` entry; adds `/System/Applications/Mail.app` in the freed Communication-section slot.
2. **Move `bitwarden-desktop` from nixpkgs → the `bitwarden` cask.**

## Why bitwarden moves to a cask

After the recent nixpkgs lock bumps, `darwin-rebuild switch` started **failing to evaluate**:

```
error: Package 'electron-39.8.10' ... is marked as insecure (EOL), refusing to evaluate.
  darwin-system → system-path → bitwarden-desktop-2026.2.1 → electron-39.8.10
```

`bitwarden-desktop` is the **only** consumer of the EOL Electron in the closure. Bumping nixpkgs does not help — even `nixos-unstable` HEAD (bitwarden-desktop 2026.5.0) still pins `electron_39`. Per repo policy we do **not** whitelist insecure packages (`permittedInsecurePackages`). The cask is Bitwarden's own signed build (independent of nixpkgs' from-source electron), matching the existing pattern for problematic GUI apps (orbstack, firefox, postman, antigravity). This **restores buildability off `main`**.

`bitwarden-cli` / `bws` (nix-home) are unaffected.

## Files
- `modules/darwin/dock/persistent-apps.nix` — Shortwave → Mail
- `modules/darwin/homebrew.nix` — drop shortwave cask, add `bitwarden` cask (commented with the EOL-electron rationale)
- `modules/darwin/common.nix` — drop `bitwarden-desktop` from systemPackages (breadcrumb comment → homebrew.nix)
- `scripts/validate-nix-before-all.sh` — swap shortwave exclusion → bitwarden exclusion (documented reason)
- `MANIFEST.md` — move bitwarden row to Casks; drop shortwave row

## Verification
- `nix flake check` passes (rebased on current main).
- `darwin-rebuild switch` succeeds off **current `origin/main`** (electron-39.8.10 gone from `/run/current-system`).
- Live: `bitwarden` cask installed (`/Applications/Bitwarden.app`), Shortwave removed (cask + app), dock shows Apple Mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)