### PR TITLE
fix(homebrew): add powershell@preview cask

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -196,6 +196,13 @@ in
         name = "microsoft-teams";
         greedy = true;
       }
+      # PowerShell 7 — cross-platform successor to Windows PowerShell 5.1.
+      # Includes a built-in Windows PowerShell 5.1 compatibility layer so legacy
+      # scripts run without modification. (PS 5.1 itself is Windows-only.)
+      {
+        name = "powershell";
+        greedy = true;
+      }
 
       # --- Browsers ---
       # Firefox is in nixpkgs (firefox-bin) but installs to /nix/store/<hash>

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -196,11 +196,12 @@ in
         name = "microsoft-teams";
         greedy = true;
       }
-      # PowerShell 7 — cross-platform successor to Windows PowerShell 5.1.
+      # PowerShell 7 preview — cross-platform successor to Windows PowerShell 5.1.
       # Includes a built-in Windows PowerShell 5.1 compatibility layer so legacy
       # scripts run without modification. (PS 5.1 itself is Windows-only.)
+      # Note: Homebrew only ships powershell@preview; there is no stable cask.
       {
-        name = "powershell";
+        name = "powershell@preview";
         greedy = true;
       }
 


### PR DESCRIPTION
## Summary

- Adds the `powershell@preview` Homebrew cask (PowerShell 7) under the Microsoft section
- PowerShell 7 includes a built-in Windows PowerShell 5.1 compatibility layer for running legacy scripts on macOS
- `greedy = true` ensures updates land via brew autoupdate rather than the app's built-in updater
- Note: Homebrew only ships `powershell@preview`; there is no stable `powershell` cask

## Changes

- `modules/darwin/homebrew.nix`: added `powershell@preview` cask with `greedy = true`

## Test Plan

- [x] `darwin-rebuild switch` evaluates cleanly (CI: Nix Build + Validate pass)
- [ ] `brew install --cask powershell@preview` (one-time manual install — PKG casks require interactive sudo on first install)
- [ ] `pwsh --version` confirms PowerShell 7.x is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)