### PR TITLE
chore(deps): bump nix-home → release 1.25.0 (tofu identities live)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "orbstack-kubernetes": "orbstack-kubernetes"
       },
       "locked": {
-        "lastModified": 1780442955,
-        "narHash": "sha256-/PlltopBNKl2ysPqwfkXREVvHyxZK2yulTCgchRsLM8=",
+        "lastModified": 1780508492,
+        "narHash": "sha256-DATTSMba/QpyOQVJ7DO+tWGt00JCXFtHwFgWso15fnA=",
         "owner": "dryvist",
         "repo": "nix-home",
-        "rev": "1afb7777b433911f4aede750d2183b10b24c34b5",
+        "rev": "1d96a3f6604258fee72fe385f817fc169504af47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bumps `nix-home` pin from `1afb777` (pre-#282) → `1d96a3f` (release 1.25.0)
- Brings in the `tofu` and `tofu-admin` base identity profiles (#282) and OpenTofu-first docs (#281)
- `tf-unifi` now correctly sources from the `tofu` base identity; `[profile tofu]` and `[profile tofu-admin]` are active in `~/.aws/config`

## Test plan

- [x] `darwin-rebuild build` succeeded locally
- [x] `darwin-rebuild switch` applied successfully  
- [x] `~/.aws/config` regenerated at 20:22 (post-switch)
- [x] `grep -A5 "[profile tf-unifi]" ~/.aws/config` → `source_profile = tofu` ✓
- [x] `grep "^\[profile tofu" ~/.aws/config` → `[profile tofu]` and `[profile tofu-admin]` present ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)