### PR TITLE
feat(mlx): wire services.aiStack.defaultLocalModelId from automation keychain

### DIFF
--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -57,6 +57,14 @@ jobs:
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Build Home Manager
+        env:
+          # Sourced from the dryvist org variable `AI_MODEL_LOCAL_LLM`.
+          # Read by `services.aiStack.defaultLocalModelId` in
+          # `hosts/macbook-m4/services-ai-stack.nix` via `builtins.getEnv`.
+          # The `--impure` flag downstream picks up the var; without it the
+          # option throws (intentional — fail loud on misconfig at deploy
+          # time, but CI gets the value from the org var here).
+          AI_MODEL_LOCAL_LLM: ${{ vars.AI_MODEL_LOCAL_LLM }}
         run: ./scripts/workflows/build-hm.sh result-hm
 
       - name: Verify Nix Symlinks

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -1,0 +1,96 @@
+# Reusable: Nix Validate (local copy)
+#
+# Local copy of JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+# with one addition: the `Check flake` step exports `AI_MODEL_LOCAL_LLM`
+# from the dryvist org variable so `builtins.getEnv` calls in the
+# host config (`hosts/macbook-m4/services-ai-stack.nix`) resolve at
+# evaluation time.
+#
+# The shared workflow accepts only `runner_label` + `all_systems` inputs;
+# `env:` cannot be injected from the caller into a reusable workflow's
+# steps. This local copy is the workaround. Re-sync from the shared
+# workflow when it gains generic env-input support.
+
+name: _nix-validate
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        type: string
+        required: false
+        default: ubuntu-latest
+      all_systems:
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  group: nix-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: inputs.all_systems && startsWith(inputs.runner_label, 'ubuntu-')
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 50
+            connect-timeout = 5
+            stalled-download-timeout = 10
+            narinfo-cache-positive-ttl = 86400
+            fallback = true
+            log-lines = 1000
+
+      - name: Restore Nix Store Cache
+        uses: actions/cache/restore@v5
+        id: nix-cache
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-linux-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-keys: |
+            nix-linux-${{ runner.os }}-
+
+      - name: Check flake
+        env:
+          # Org-variable injection so `builtins.getEnv "AI_MODEL_LOCAL_LLM"`
+          # resolves at evaluation time inside the imported home config.
+          # See `hosts/macbook-m4/services-ai-stack.nix` for the reader.
+          AI_MODEL_LOCAL_LLM: ${{ vars.AI_MODEL_LOCAL_LLM }}
+          ALL_SYSTEMS_FLAG: ${{ inputs.all_systems && '--all-systems' || '' }}
+        run: nix flake check $ALL_SYSTEMS_FLAG --print-build-logs --show-trace --keep-going --impure
+
+      - name: Save Nix Store Cache
+        if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-linux-${{ runner.os }}-${{ hashFiles('flake.lock') }}

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -110,7 +110,12 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+    # Local copy of the shared workflow so the `Check flake` step can inject
+    # `AI_MODEL_LOCAL_LLM` from the dryvist org variable — reusable workflow
+    # calls can't propagate env to the called workflow's steps, and the
+    # shared workflow doesn't (yet) accept a generic env input. Re-sync from
+    # the shared workflow when it gains env-input support.
+    uses: ./.github/workflows/_nix-validate.yml
     with:
       # Linux `nix flake check --all-systems` needs more disk/RAM for
       # darwin-source substitution; m7+c7 family with s3-cache fits.

--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780436654,
-        "narHash": "sha256-7OICEYeZJpXX/OF516A/L4v3t39Rd3rMEL9EVnJGA+A=",
+        "lastModified": 1780538651,
+        "narHash": "sha256-raZCj49HMswSMX+lsTfKENtfuKaPWPrbHXNSZ63r3wY=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "a80386d03a2f378cd9186060b9ea8748920d1f40",
+        "rev": "ddf97fbe8ddc97f23b16c14d8d10aa80457b8d57",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780422238,
-        "narHash": "sha256-vjpmQgrE/D8XaLf4HC1R6OiojDm2svTbdodd8cX77cU=",
+        "lastModified": 1780361688,
+        "narHash": "sha256-xMNO51e2hTqPCe2N3icRd6+inLgqwGw33sw0RUWx9QU=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "b107aede8b07a435261b9dbdc2695fc7cc2f8fae",
+        "rev": "0e0bffcad964b7a4004e31271cc63e62c58cbb71",
         "type": "github"
       },
       "original": {
@@ -894,11 +894,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
         "type": "github"
       },
       "original": {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -106,6 +106,13 @@
         # HuggingFace - for huggingface MCP server and hf CLI (model downloads)
         export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
 
+        # Local MLX model id — consumed by services.aiStack.defaultLocalModelId
+        # in this same module via `builtins.getEnv` at `darwin-rebuild --impure`
+        # time. Lives in the no-password automation keychain alongside HF_TOKEN
+        # (also retrievable from Doppler `gh-workflow-tokens` / `prd` and the
+        # dryvist `AI_MODEL_LOCAL_LLM` org variable).
+        export AI_MODEL_LOCAL_LLM=''${AI_MODEL_LOCAL_LLM:-"$(_get_keychain_secret 'AI_MODEL_LOCAL_LLM' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
+
         unset -f _get_keychain_secret  # No longer needed after init
         unset _KC_USER _KC_AI_DB  # _KC_AI_ACCOUNT persists for runtime gh-token switching
 
@@ -142,6 +149,27 @@
       '';
     };
   };
+
+  # AI Stack — required option since dryvist/nix-ai#878 collapsed the role
+  # registry to a single configurable physical model id. The value is read
+  # from the `AI_MODEL_LOCAL_LLM` env var, which the shell-initContent block
+  # above exports from the no-password automation keychain (matching the
+  # HF_TOKEN pattern). `darwin-rebuild switch --impure` is required so
+  # `builtins.getEnv` resolves; running darwin-rebuild from an interactive
+  # zsh inherits the env var that the initContent has already set.
+  #
+  # If the keychain entry is missing or the env var is otherwise unset, the
+  # build fails fast with a message naming the keychain item.
+  services.aiStack.defaultLocalModelId =
+    let
+      raw = builtins.getEnv "AI_MODEL_LOCAL_LLM";
+    in
+    if raw == "" then
+      throw "AI_MODEL_LOCAL_LLM env var is unset. Verify the automation-keychain item `AI_MODEL_LOCAL_LLM` exists and that `darwin-rebuild switch --impure` is invoked from a shell where the initContent above has already exported it."
+    else if (builtins.match ".*/.*" raw) != null then
+      raw
+    else
+      "mlx-community/${raw}";
 
   home = {
     # ========================================================================

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -14,6 +14,13 @@
 }:
 
 {
+  imports = [
+    # services.aiStack.defaultLocalModelId — supplied from AI_MODEL_LOCAL_LLM
+    # (no-password automation keychain). Extracted to keep this file under
+    # the per-file size cap.
+    ./services-ai-stack.nix
+  ];
+
   # ==========================================================================
   # macOS Application Management (copyApps for TCC stability)
   # ==========================================================================
@@ -149,27 +156,6 @@
       '';
     };
   };
-
-  # AI Stack — required option since dryvist/nix-ai#878 collapsed the role
-  # registry to a single configurable physical model id. The value is read
-  # from the `AI_MODEL_LOCAL_LLM` env var, which the shell-initContent block
-  # above exports from the no-password automation keychain (matching the
-  # HF_TOKEN pattern). `darwin-rebuild switch --impure` is required so
-  # `builtins.getEnv` resolves; running darwin-rebuild from an interactive
-  # zsh inherits the env var that the initContent has already set.
-  #
-  # The keychain value must be the **full** physical model id (e.g. the
-  # full `mlx-community/...` form) — this consumer reads it verbatim, no
-  # prefix synthesis. If the env var is unset, the build fails fast with
-  # a message naming the keychain item.
-  services.aiStack.defaultLocalModelId =
-    let
-      raw = builtins.getEnv "AI_MODEL_LOCAL_LLM";
-    in
-    if raw == "" then
-      throw "AI_MODEL_LOCAL_LLM env var is unset. Verify the automation-keychain item `AI_MODEL_LOCAL_LLM` exists (full physical model id, not just the suffix) and that `darwin-rebuild switch --impure` is invoked from a shell where the initContent above has already exported it."
-    else
-      raw;
 
   home = {
     # ========================================================================

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -158,18 +158,18 @@
   # `builtins.getEnv` resolves; running darwin-rebuild from an interactive
   # zsh inherits the env var that the initContent has already set.
   #
-  # If the keychain entry is missing or the env var is otherwise unset, the
-  # build fails fast with a message naming the keychain item.
+  # The keychain value must be the **full** physical model id (e.g. the
+  # full `mlx-community/...` form) — this consumer reads it verbatim, no
+  # prefix synthesis. If the env var is unset, the build fails fast with
+  # a message naming the keychain item.
   services.aiStack.defaultLocalModelId =
     let
       raw = builtins.getEnv "AI_MODEL_LOCAL_LLM";
     in
     if raw == "" then
-      throw "AI_MODEL_LOCAL_LLM env var is unset. Verify the automation-keychain item `AI_MODEL_LOCAL_LLM` exists and that `darwin-rebuild switch --impure` is invoked from a shell where the initContent above has already exported it."
-    else if (builtins.match ".*/.*" raw) != null then
-      raw
+      throw "AI_MODEL_LOCAL_LLM env var is unset. Verify the automation-keychain item `AI_MODEL_LOCAL_LLM` exists (full physical model id, not just the suffix) and that `darwin-rebuild switch --impure` is invoked from a shell where the initContent above has already exported it."
     else
-      "mlx-community/${raw}";
+      raw;
 
   home = {
     # ========================================================================

--- a/hosts/macbook-m4/services-ai-stack.nix
+++ b/hosts/macbook-m4/services-ai-stack.nix
@@ -1,0 +1,24 @@
+# AI Stack — local model id supplier
+#
+# Required option since dryvist/nix-ai#878 collapsed the role registry to a
+# single configurable physical model id. Reads from the `AI_MODEL_LOCAL_LLM`
+# env var, which the home.nix shell-initContent block exports from the
+# no-password automation keychain. `darwin-rebuild switch --impure` is
+# required so `builtins.getEnv` resolves.
+#
+# The keychain value must be the full physical model id (no prefix
+# synthesis on this side). Build fails fast with a message naming the
+# keychain item if the env is unset.
+
+{ ... }:
+
+{
+  services.aiStack.defaultLocalModelId =
+    let
+      raw = builtins.getEnv "AI_MODEL_LOCAL_LLM";
+    in
+    if raw == "" then
+      throw "AI_MODEL_LOCAL_LLM env var is unset. Verify the automation-keychain item `AI_MODEL_LOCAL_LLM` exists (full physical model id) and that `darwin-rebuild switch --impure` is invoked from a shell where the home.nix initContent has already exported it."
+    else
+      raw;
+}

--- a/hosts/macbook-m4/services-ai-stack.nix
+++ b/hosts/macbook-m4/services-ai-stack.nix
@@ -10,7 +10,7 @@
 # synthesis on this side). Build fails fast with a message naming the
 # keychain item if the env is unset.
 
-{ ... }:
+_:
 
 {
   services.aiStack.defaultLocalModelId =

--- a/scripts/workflows/build-hm.sh
+++ b/scripts/workflows/build-hm.sh
@@ -9,8 +9,13 @@ OUTPUT_LINK="${1:-result-hm}"
 BUILD_OUTPUT=$(mktemp)
 trap 'rm -f "$BUILD_OUTPUT"' EXIT
 
-# Build and capture output (--print-build-logs shows derivation output inline)
-nix build .#lib.ci.hmActivationPackage --print-build-logs -o "$OUTPUT_LINK" 2>&1 | tee "$BUILD_OUTPUT"
+# Build and capture output (--print-build-logs shows derivation output inline).
+# --impure required because services.aiStack.defaultLocalModelId is sourced
+# at evaluation time from `builtins.getEnv "AI_MODEL_LOCAL_LLM"` (the value
+# lives in Doppler / org variable / no-password automation keychain — never
+# committed). The build will fail loudly with a clear error if the env var
+# is unset, so this stays explicit rather than wrapping nix with a guard.
+nix build .#lib.ci.hmActivationPackage --impure --print-build-logs -o "$OUTPUT_LINK" 2>&1 | tee "$BUILD_OUTPUT"
 build_exit_code=${PIPESTATUS[0]}
 
 if [ "$build_exit_code" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Consumes the parameterization landed in
[dryvist/nix-ai#878](https://github.com/dryvist/nix-ai/pull/878) —
the capability-class role registry no longer ships a default value, so
this configuration has to supply one. The value comes from the
**no-password automation keychain** item `AI_MODEL_LOCAL_LLM`, exported
to the shell environment from `initContent`, then read by
`builtins.getEnv` at evaluation time (requires `--impure`).

## What changes

- **`flake.lock`** — bump `nix-ai` `a80386d` → `ddf97fb` (includes PR
  \#878 + #882 which together provide the new option + CI green).
- **`hosts/macbook-m4/home.nix`**:
  - Adds `services.aiStack.defaultLocalModelId` with a helper that
    throws cleanly when the env var is unset (names the keychain item
    in the error).
  - Mirrors the existing HF_TOKEN pattern: one more keychain export
    line in the shell-init `initContent` block, beside the existing
    GitHub PAT / Context7 / HF_TOKEN exports.

## Where the model id lives (not committed anywhere)

- macOS no-password automation keychain item `AI_MODEL_LOCAL_LLM`
- Doppler \`gh-workflow-tokens\` project, configs \`prd\` and \`dryvist\`
- GitHub org variable \`dryvist.AI_MODEL_LOCAL_LLM\`

All three carry the same value; the keychain is the activation-time
source on this host.

## Operator notes

- \`darwin-rebuild switch --impure\` is required from now on so
  \`builtins.getEnv\` resolves at evaluation.
- The env var is exported by the same module's initContent, so any
  interactive zsh shell already has it available — running
  darwin-rebuild from a normal terminal inherits it.
- If the keychain item is missing, the build error names the item so
  the operator knows exactly what to populate.

## Test plan

- [x] \`nix flake check --no-build --impure\` passes locally with the
      env var sourced from the keychain
- [ ] After merge + \`darwin-rebuild switch --impure\`:
      \`curl localhost:11434/v1/models | jq '.data | length'\` returns 1
- [ ] After rebuild: 404 on any non-default model id
- [ ] After rebuild: \`vm.swapusage\` trends down over the next
      30–60 min as fewer models stay resident

## No auto-merge

Sits open for review.

Refs: dryvist/nix-ai#878 (the parameterization),
dryvist/docs-starlight#22 (architecture writeup),
dryvist/nix-mac-performance#21 (operational tracker)