### PR TITLE
fix(homebrew): drop powershell@preview cask, migrate to nix-devenv

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -196,14 +196,12 @@ in
         name = "microsoft-teams";
         greedy = true;
       }
-      # PowerShell 7 preview — cross-platform successor to Windows PowerShell 5.1.
-      # Includes a built-in Windows PowerShell 5.1 compatibility layer so legacy
-      # scripts run without modification. (PS 5.1 itself is Windows-only.)
-      # Note: Homebrew only ships powershell@preview; there is no stable cask.
-      {
-        name = "powershell@preview";
-        greedy = true;
-      }
+      # PowerShell migrated to the nix-devenv `windows` dev shell (stable pwsh
+      # from nixpkgs): `nix develop github:dryvist/nix-devenv?dir=shells/windows`.
+      # Moved off the always-on cask per nix-package-placement (project-scoped
+      # toolchain → nix-devenv). cleanup="none", so the previously-installed
+      # cask is left in place; run `brew uninstall --cask powershell@preview`
+      # to remove it.
 
       # --- Browsers ---
       # Firefox is in nixpkgs (firefox-bin) but installs to /nix/store/<hash>


### PR DESCRIPTION
## Summary

Removes the `powershell@preview` homebrew cask. PowerShell is migrated to the project-scoped nix-devenv `windows` shell (stable `pwsh` 7.6.2 from nixpkgs), per the `nix-package-placement` matrix — a project-specific toolchain belongs in nix-devenv, not an always-on global install.

## Behavior change

- `pwsh` is no longer globally on PATH. Get it on demand:
  \`\`\`bash
  nix develop github:dryvist/nix-devenv?dir=shells/windows
  \`\`\`
- `onActivation.cleanup = "none"`, so the already-installed cask is **not** auto-uninstalled by this change. Remove it manually if desired:
  \`\`\`bash
  brew uninstall --cask powershell@preview
  \`\`\`
- Version note: nixpkgs ships stable 7.6.2; the cask was 7.7.0-preview. Intentional move to stable.

## Test plan

- [x] `nix flake check --no-build` passes (darwinConfigurations evaluate)
- [x] `nix fmt` — 0 files changed
- [ ] After merge + `darwin-rebuild switch`: `brew bundle` no longer lists powershell@preview

Refs: dryvist/nix-devenv#44

🤖 Generated with [Claude Code](https://claude.com/claude-code)