### PR TITLE
fix(ai-stack): source defaultLocalModelId from committed user-config

### DIFF
--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -57,14 +57,6 @@ jobs:
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Build Home Manager
-        env:
-          # Sourced from the dryvist org variable `AI_MODEL_LOCAL_LLM`.
-          # Read by `services.aiStack.defaultLocalModelId` in
-          # `hosts/macbook-m4/services-ai-stack.nix` via `builtins.getEnv`.
-          # The `--impure` flag downstream picks up the var; without it the
-          # option throws (intentional — fail loud on misconfig at deploy
-          # time, but CI gets the value from the org var here).
-          AI_MODEL_LOCAL_LLM: ${{ vars.AI_MODEL_LOCAL_LLM }}
         run: ./scripts/workflows/build-hm.sh result-hm
 
       - name: Verify Nix Symlinks

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -1,15 +1,10 @@
 # Reusable: Nix Validate (local copy)
 #
-# Local copy of JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
-# with one addition: the `Check flake` step exports `AI_MODEL_LOCAL_LLM`
-# from the dryvist org variable so `builtins.getEnv` calls in the
-# host config (`hosts/macbook-m4/services-ai-stack.nix`) resolve at
-# evaluation time.
-#
-# The shared workflow accepts only `runner_label` + `all_systems` inputs;
-# `env:` cannot be injected from the caller into a reusable workflow's
-# steps. This local copy is the workaround. Re-sync from the shared
-# workflow when it gains generic env-input support.
+# Local copy of JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main.
+# This copy originally diverged only to inject `AI_MODEL_LOCAL_LLM` for an
+# eval-time `builtins.getEnv`; that sourcing was removed (the value is now
+# committed in `lib/user-config.nix`), so the copy no longer needs to diverge.
+# FOLLOW-UP: re-sync to / replace this local copy with the shared workflow.
 
 name: _nix-validate
 
@@ -79,12 +74,8 @@ jobs:
 
       - name: Check flake
         env:
-          # Org-variable injection so `builtins.getEnv "AI_MODEL_LOCAL_LLM"`
-          # resolves at evaluation time inside the imported home config.
-          # See `hosts/macbook-m4/services-ai-stack.nix` for the reader.
-          AI_MODEL_LOCAL_LLM: ${{ vars.AI_MODEL_LOCAL_LLM }}
           ALL_SYSTEMS_FLAG: ${{ inputs.all_systems && '--all-systems' || '' }}
-        run: nix flake check $ALL_SYSTEMS_FLAG --print-build-logs --show-trace --keep-going --impure
+        run: nix flake check $ALL_SYSTEMS_FLAG --print-build-logs --show-trace --keep-going
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -110,11 +110,9 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true'
-    # Local copy of the shared workflow so the `Check flake` step can inject
-    # `AI_MODEL_LOCAL_LLM` from the dryvist org variable — reusable workflow
-    # calls can't propagate env to the called workflow's steps, and the
-    # shared workflow doesn't (yet) accept a generic env input. Re-sync from
-    # the shared workflow when it gains env-input support.
+    # Local copy of the shared workflow. It originally diverged only to inject
+    # `AI_MODEL_LOCAL_LLM` (now committed in lib/user-config.nix, injection
+    # removed). FOLLOW-UP: re-sync to / replace with the shared workflow.
     uses: ./.github/workflows/_nix-validate.yml
     with:
       # Linux `nix flake check --all-systems` needs more disk/RAM for

--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780538651,
-        "narHash": "sha256-raZCj49HMswSMX+lsTfKENtfuKaPWPrbHXNSZ63r3wY=",
+        "lastModified": 1780578549,
+        "narHash": "sha256-9SRM9LL5a6jeBypZnzEiUk7QgBX4nK7Qt2m/93CZo5U=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ddf97fbe8ddc97f23b16c14d8d10aa80457b8d57",
+        "rev": "bb5fe9af99a64cbdb91517859519a64e31cb5549",
         "type": "github"
       },
       "original": {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -15,9 +15,9 @@
 
 {
   imports = [
-    # services.aiStack.defaultLocalModelId — supplied from AI_MODEL_LOCAL_LLM
-    # (no-password automation keychain). Extracted to keep this file under
-    # the per-file size cap.
+    # services.aiStack.defaultLocalModelId — supplied from the committed
+    # lib/user-config.nix (non-secret model id). Extracted to keep this file
+    # under the per-file size cap.
     ./services-ai-stack.nix
     # Disables nix-ai's auto-discovery of locally-cached HF models so the
     # registry stays at the single defaultLocalModelId entry.
@@ -115,13 +115,6 @@
 
         # HuggingFace - for huggingface MCP server and hf CLI (model downloads)
         export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
-
-        # Local MLX model id — consumed by services.aiStack.defaultLocalModelId
-        # in this same module via `builtins.getEnv` at `darwin-rebuild --impure`
-        # time. Lives in the no-password automation keychain alongside HF_TOKEN
-        # (also retrievable from Doppler `gh-workflow-tokens` / `prd` and the
-        # dryvist `AI_MODEL_LOCAL_LLM` org variable).
-        export AI_MODEL_LOCAL_LLM=''${AI_MODEL_LOCAL_LLM:-"$(_get_keychain_secret 'AI_MODEL_LOCAL_LLM' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
 
         unset -f _get_keychain_secret  # No longer needed after init
         unset _KC_USER _KC_AI_DB  # _KC_AI_ACCOUNT persists for runtime gh-token switching

--- a/hosts/macbook-m4/services-ai-stack.nix
+++ b/hosts/macbook-m4/services-ai-stack.nix
@@ -1,39 +1,16 @@
 # AI Stack — local model id supplier
 #
-# Required option since dryvist/nix-ai#878 collapsed the role registry to
-# one configurable physical model id. Two-source lookup, file first then
-# env fallback.
+# Required option since dryvist/nix-ai#878 collapsed the role registry to one
+# configurable physical model id. nix-ai keeps the option generic ("never
+# hardcoded in this repo"); the consumer supplies the value.
 #
-# Primary: file at the path below. Populated from the no-password
-# automation keychain item by the home.nix activation hook. Reading from
-# a file sidesteps macOS sudo env-reset policy on this host, which strips
-# arbitrary env vars. Root reads user files, so privileged rebuilds work
-# without env passthrough.
-#
-# Fallback: AI_MODEL_LOCAL_LLM env var. Used by CI runners (workflow
-# injects the value from the dryvist org variable) and on first rebuild
-# before the activation hook has run.
-#
-# The value must be the full physical model id; this consumer reads it
-# verbatim. Build fails fast with a clear message when neither source
-# is populated.
+# The value is a non-secret public model name consumed at Nix EVAL time, so it
+# lives committed in lib/user-config.nix alongside every other eval-time
+# identifier. Keeping it in-tree means evaluation stays pure — no `--impure`,
+# no keychain/env/file sourcing. Change the model via a reviewed commit.
 
-{ config, ... }:
+{ userConfig, ... }:
 
-let
-  modelIdPath = "${config.home.homeDirectory}/.config/ai-stack/local-model-id";
-  fromFile =
-    if builtins.pathExists modelIdPath then
-      builtins.replaceStrings [ "\n" ] [ "" ] (builtins.readFile modelIdPath)
-    else
-      "";
-  fromEnv = builtins.getEnv "AI_MODEL_LOCAL_LLM";
-  raw = if fromFile != "" then fromFile else fromEnv;
-in
 {
-  services.aiStack.defaultLocalModelId =
-    if raw == "" then
-      throw "services.aiStack.defaultLocalModelId not set. Neither ${modelIdPath} nor the AI_MODEL_LOCAL_LLM env var is populated. The file is refreshed from the AI_MODEL_LOCAL_LLM automation-keychain item by the home.nix activation hook; in CI the env var is injected from the dryvist org variable."
-    else
-      raw;
+  services.aiStack.defaultLocalModelId = userConfig.ai.defaultLocalModelId;
 }

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -139,6 +139,18 @@ in
   };
 
   # ==========================================================================
+  # AI Stack Configuration
+  # ==========================================================================
+  ai = {
+    # Local MLX physical model id consumed at Nix eval time by
+    # services.aiStack.defaultLocalModelId (hosts/macbook-m4/services-ai-stack.nix).
+    # Non-secret — a public Hugging Face model name. Committed here like every
+    # other eval-time identifier so evaluation stays pure (no --impure, no
+    # keychain/env/file sourcing). Change the model via a reviewed commit.
+    defaultLocalModelId = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
+  };
+
+  # ==========================================================================
   # Nix/NixOS Configuration
   # ==========================================================================
   nix = {

--- a/scripts/workflows/build-hm.sh
+++ b/scripts/workflows/build-hm.sh
@@ -10,12 +10,9 @@ BUILD_OUTPUT=$(mktemp)
 trap 'rm -f "$BUILD_OUTPUT"' EXIT
 
 # Build and capture output (--print-build-logs shows derivation output inline).
-# --impure required because services.aiStack.defaultLocalModelId is sourced
-# at evaluation time from `builtins.getEnv "AI_MODEL_LOCAL_LLM"` (the value
-# lives in Doppler / org variable / no-password automation keychain — never
-# committed). The build will fail loudly with a clear error if the env var
-# is unset, so this stays explicit rather than wrapping nix with a guard.
-nix build .#lib.ci.hmActivationPackage --impure --print-build-logs -o "$OUTPUT_LINK" 2>&1 | tee "$BUILD_OUTPUT"
+# Pure evaluation: services.aiStack.defaultLocalModelId is now sourced from the
+# committed lib/user-config.nix, so no `--impure` (and no env/keychain) is needed.
+nix build .#lib.ci.hmActivationPackage --print-build-logs -o "$OUTPUT_LINK" 2>&1 | tee "$BUILD_OUTPUT"
 build_exit_code=${PIPESTATUS[0]}
 
 if [ "$build_exit_code" -ne 0 ]; then


### PR DESCRIPTION
## What

`AI_MODEL_LOCAL_LLM` (`mlx-community/Qwen3.6-35B-A3B-mxfp4`) is now committed in `lib/user-config.nix`, sourced via pure Nix eval. Deletes the keychain export, env/file fallback, the never-implemented activation hook, the CI org-var injection, and every `--impure` flag.

Also carries the routine `flake.lock` bump (nix-ai `ddf97fb → bb5fe9a`) that surfaced the bug.

## Why

`/flake-rebuild` ran `sudo darwin-rebuild switch --flake .` and it threw `services.aiStack.defaultLocalModelId not set`. Root cause: the value was consumed at **eval time** but sourced via `builtins.getEnv` + `builtins.pathExists`/`readFile` — both of which **pure evaluation blanks unconditionally**, even though the env var was set and the file was on disk. `darwin-rebuild switch` runs pure by default; only CI and `build-hm.sh` passed `--impure`.

`AI_MODEL_LOCAL_LLM` is a **non-secret public model name** with **no runtime env consumer** (the runtime value flows through the Nix option → `MLX_DEFAULT_MODEL`). It was the only non-secret eval-time value in these repos sourced externally. Committing it — like every other eval-time identifier already in `user-config.nix` — makes eval pure and removes all the machinery. Doppler/org-vars were considered and rejected: they're for rotating secrets and would still require `--impure`.

## Verification

- `nix flake check` passes **without `--impure`** (the eval that previously threw).
- `sudo darwin-rebuild switch --flake .` (no `--impure`) completes full activation.
- `defaultLocalModelId` resolves to `mlx-community/Qwen3.6-35B-A3B-mxfp4` (unchanged).
- `nix fmt` / `statix` / `deadnix` clean.

## Follow-up (not in this PR)

`_nix-validate.yml` was a local copy of the shared workflow created solely for the env injection — now removable. Flagged in-line for a future re-sync to the shared workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)