### PR TITLE
chore: use Antigravity Homebrew CLI

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -166,7 +166,7 @@ Source: `modules/darwin/homebrew.nix`
 | --- | --- |
 | ccusage | Claude Code usage analyzer |
 | block-goose-cli | Block's Goose AI agent |
-| gemini-cli | Google Gemini CLI (moved from nixpkgs) |
+| antigravity-cli | Google Gemini CLI (moved from nixpkgs) |
 | whisperkit-cli | Swift native on-device speech recognition (Apple Silicon) |
 
 ### Casks

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -166,7 +166,6 @@ Source: `modules/darwin/homebrew.nix`
 | --- | --- |
 | ccusage | Claude Code usage analyzer |
 | block-goose-cli | Block's Goose AI agent |
-| antigravity-cli | Google Gemini CLI (moved from nixpkgs) |
 | whisperkit-cli | Swift native on-device speech recognition (Apple Silicon) |
 
 ### Casks
@@ -183,7 +182,9 @@ via LaunchAgent) always installs the latest version rather than deferring to bui
 | claude | yes | Anthropic Claude desktop app (not in nixpkgs for Darwin) |
 | claude-code | yes | Anthropic Claude Code CLI |
 | codex | yes | OpenAI Codex CLI (moved from nixpkgs; migrated from homebrew/core to cask) |
-| antigravity | yes | Google AI-powered IDE (Gemini 3) |
+| antigravity | yes | Google AI-powered agent orchestrator (Gemini 3) |
+| antigravity-cli | yes | Google terminal interface for agents (agy command) |
+| antigravity-ide | yes | Google AI-powered IDE environment |
 | lm-studio | yes | Local LLM inference UI + OpenAI-compatible API server |
 | postman | yes | API development environment (moved from nixpkgs — version lag caused schema mismatch) |
 | orbstack | yes | Container/Linux VM runtime — cask for TCC permission stability |

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -51,7 +51,8 @@ in
       # AI Assistants
       "/Applications/Claude.app" # Anthropic Claude desktop app (homebrew cask)
       "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
-      "/Applications/Antigravity.app" # Google's AI-powered IDE (homebrew cask)
+      "/Applications/Antigravity.app" # Google's AI-powered agent orchestrator (homebrew cask)
+      "/Applications/Antigravity IDE.app" # Google's AI-powered IDE environment (homebrew cask)
 
       # Browsers
       "/Applications/Safari.app"

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -69,15 +69,17 @@ in
     };
     taps = [
       "homebrew/autoupdate" # Background auto-update via launchd (brew autoupdate)
+      "google/antigravity" # Google Antigravity agents (agy command)
+      "anthropics/tap" # Anthropic platform tools (ant command)
     ];
     brews = [
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs
 
-      # Gemini CLI (Google Gemini AI assistant)
+      # Antigravity CLI (Google Gemini AI assistant)
       # - Moved from nixpkgs due to severe version lag (v0.23 vs v0.29 upstream)
       # - Homebrew version is required for Gemini 3.1 Pro support
-      "gemini-cli"
+      "antigravity-cli"
 
       # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
 
@@ -111,7 +113,7 @@ in
       # unreliable (require the app to be open, can be dismissed, etc.), so greedy
       # ensures updates land deterministically via brew autoupdate.
       # NOTE: ChatGPT and Cursor are in nixpkgs - see home.packages.
-      # NOTE: Antigravity and gemini-cli are in homebrew (above).
+      # NOTE: Antigravity and antigravity-cli are in homebrew (above).
 
       # --- Productivity / Communication ---
       {

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -76,11 +76,6 @@ in
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs
 
-      # Antigravity CLI (Google Gemini AI assistant)
-      # - Moved from nixpkgs due to severe version lag (v0.23 vs v0.29 upstream)
-      # - Homebrew version is required for Gemini 3.1 Pro support
-      "antigravity-cli"
-
       # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
 
       # Block Goose AI agent (https://github.com/block/goose)
@@ -172,7 +167,15 @@ in
       {
         name = "antigravity";
         greedy = true;
-      } # Google's AI-powered IDE (Gemini 3) - moved from nixpkgs for Gemini 3.1 Pro support
+      } # Google's AI-powered agent orchestrator (Gemini 3)
+      {
+        name = "antigravity-cli";
+        greedy = true;
+      } # Google's terminal interface for agents (agy command)
+      {
+        name = "antigravity-ide";
+        greedy = true;
+      } # Google's AI-powered IDE environment
 
       # --- API Development ---
       {

--- a/scripts/validate-nix-before-all.sh
+++ b/scripts/validate-nix-before-all.sh
@@ -14,6 +14,7 @@ fi
 # Format: "package-name:reason"
 EXCLUSIONS=(
   "antigravity:Intentionally using homebrew due to nixpkgs version lag (requires Gemini 3.1 Pro support)"
+  "antigravity-ide:Intentionally using homebrew for early access to Google agent IDE"
   "claude:Not available for aarch64-darwin (only x86_64-linux)"
   "claude-code:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "antigravity-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"

--- a/scripts/validate-nix-before-all.sh
+++ b/scripts/validate-nix-before-all.sh
@@ -16,7 +16,7 @@ EXCLUSIONS=(
   "antigravity:Intentionally using homebrew due to nixpkgs version lag (requires Gemini 3.1 Pro support)"
   "claude:Not available for aarch64-darwin (only x86_64-linux)"
   "claude-code:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
-  "gemini-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
+  "antigravity-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "bitwarden:nixpkgs build pins EOL electron_39 (insecure); cask uses Bitwarden's maintained build"
   "orbstack:Cask preferred over nixpkgs for TCC permission stability (nixpkgs symlink changes on rebuild, forcing TCC re-grant)"
   "postman:Nixpkgs version lags significantly behind upstream, causing Squirrel/ShipIt schema mismatch errors"
@@ -33,14 +33,14 @@ fi
 brews=$(awk '
   /brews = \[/ {in_brews=1; next}
   /\];/ && in_brews {in_brews=0; next}
-  in_brews {print}
+  in_brews && ! /^[[:space:]]*#/ {print}
 ' "$HOMEBREW_FILE" | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' || true)
 
 # Extract cask packages (casks = [...])
 casks=$(awk '
   /casks = \[/ {in_casks=1; next}
   /\];/ && in_casks {in_casks=0; next}
-  in_casks {print}
+  in_casks && ! /^[[:space:]]*#/ {print}
 ' "$HOMEBREW_FILE" | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' || true)
 
 if [[ -z "$brews" ]] && [[ -z "$casks" ]]; then
@@ -79,7 +79,7 @@ while IFS= read -r package; do
   [[ -z "$package" ]] && continue
 
   # Validate package name contains only safe characters
-  if ! [[ "$package" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  if ! [[ "$package" =~ ^[a-zA-Z0-9._@-]+$ ]]; then
     echo "✗ INVALID: '$package' (brew) contains unsafe characters"
     violations+="  - $package (brew) - invalid characters\n"
     ((failed++))
@@ -109,7 +109,7 @@ while IFS= read -r package; do
   [[ -z "$package" ]] && continue
 
   # Validate package name contains only safe characters
-  if ! [[ "$package" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  if ! [[ "$package" =~ ^[a-zA-Z0-9._@-]+$ ]]; then
     echo "✗ INVALID: '$package' (cask) contains unsafe characters"
     violations+="  - $package (cask) - invalid characters\n"
     ((failed++))


### PR DESCRIPTION
## Type

- Maintenance

## Description

Switch the Homebrew-managed Gemini CLI formula to Antigravity CLI and keep related package inventory and validation exclusions in sync.

### What Changed

- Add the Google Antigravity and Anthropic taps used by the Homebrew formulas.
- Replace `gemini-cli` with `antigravity-cli` in Homebrew configuration and `MANIFEST.md`.
- Update the Homebrew validator to ignore comment-only lines and allow formula names containing `@`.

## Related Issue

None.

## Testing and Validation

- [ ] `nix flake check` passes
- [ ] All markdown files pass linting (`markdownlint-cli2 "**/*.md"`)
- [x] Manual testing performed
- [x] No breaking changes introduced

Manual validation performed:

- `nix fmt`
- `statix check`
- `deadnix`
- `./scripts/validate-nix-before-all.sh`
- `git diff --check`

## Checklist

- [x] My commit message follows conventional commits format
- [x] I have performed a self-review

## Additional Information

Created from the existing local modified files as requested.