### PR TITLE
fix(homebrew): nixfmt-required whitespace in taps list append

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -75,7 +75,8 @@ in
     };
     taps = [
       "homebrew/autoupdate" # Background auto-update via launchd (brew autoupdate)
-    ] ++ agentHomebrewTaps; # AI-tool taps declared in nix-ai/lib/homebrew.nix
+    ]
+    ++ agentHomebrewTaps; # AI-tool taps declared in nix-ai/lib/homebrew.nix
     brews = [
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs


### PR DESCRIPTION
## Summary

nixfmt requires the `++` operator to be on its own line after `]` in a list append expression. This was missed by the local `nix-instantiate --parse` syntax check (which only validates parse, not style) and caught by the Nix Validate CI job in #1210.

One-character formatting fix: `] ++ agentHomebrewTaps;` → `]\n++ agentHomebrewTaps;`

## Related Issues

Fixes formatting regression introduced in #1210.