### PR TITLE
docs: drop bare-repo worktree layout from setup and commands

### DIFF
--- a/.claude/commands/flake-rebuild.md
+++ b/.claude/commands/flake-rebuild.md
@@ -22,20 +22,15 @@ If the user passes additional arguments (e.g. "also update X" or "fix Y"), handl
 
 ## Repository Structure
 
-This repo uses a bare git repo with worktrees:
-
-- `${GIT_HOME_PUBLIC}/nix-darwin/` - bare repo (do not cd here directly)
-- `${GIT_HOME_PUBLIC}/nix-darwin/main/` - main branch worktree
-- `${GIT_HOME_PUBLIC}/nix-darwin/<branch-name>/` - feature worktrees
+Work in a worktree on its own branch — never on main.
 
 ## Steps
 
-### 1. Sync Main Worktree First
+### 1. Sync Main First
 
-**IMPORTANT**: Update the main worktree before starting:
+**IMPORTANT**: Update main before starting:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin/main
 git fetch origin
 git pull origin main
 git status
@@ -43,23 +38,9 @@ git status
 
 If there are uncommitted changes, **STOP** and report to the user.
 
-### 2. Create or Switch to Feature Worktree
+### 2. Work in a Feature Worktree
 
-Branch/worktree name format: `chore/flake-update-YYYY-MM-DD` (replace with today's date)
-
-Check if worktree already exists, otherwise create it:
-
-```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin
-# Check if worktree exists
-if [ -d "chore/flake-update-YYYY-MM-DD" ]; then
-  cd chore/flake-update-YYYY-MM-DD
-  git pull origin main  # Update with latest main
-else
-  git worktree add chore/flake-update-YYYY-MM-DD -b chore/flake-update-YYYY-MM-DD origin/main
-  cd chore/flake-update-YYYY-MM-DD
-fi
-```
+Work in a worktree named for the update (e.g. `chore/flake-update-YYYY-MM-DD`, replacing with today's date).
 
 ### Security Note
 
@@ -179,13 +160,9 @@ Enable auto-merge (this will merge automatically when checks pass):
 gh pr merge --auto --squash --delete-branch
 ```
 
-### 9. Return to Main Worktree
+### 9. Return to Main
 
-Switch back to the main worktree while waiting for auto-merge:
-
-```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin/main
-```
+Switch back to main while waiting for auto-merge.
 
 ### 10. Report Summary
 
@@ -195,9 +172,8 @@ Tell the user:
 2. The PR URL
 3. Any warnings or errors found (from Step 6 output)
 4. That auto-merge is enabled and will merge when checks pass
-5. They can run `git pull` in the main worktree after the PR merges
+5. They can pull main after the PR merges
 
 **DO NOT wait for checks** - auto-merge handles this automatically.
 
-**Note**: The worktree at `${GIT_HOME_PUBLIC}/nix-darwin/chore/flake-update-YYYY-MM-DD/` should be
-removed manually after the PR is merged (`/wrap-up` or `/clean_gone`).
+**Note**: Remove the worktree and merged branch after the PR is merged (`/wrap-up` or `/clean_gone`).

--- a/.claude/commands/quick-add-package.md
+++ b/.claude/commands/quick-add-package.md
@@ -42,18 +42,7 @@ Per project rules: nixpkgs first, Homebrew only when package is unavailable in n
 
 ### 3. Create Worktree
 
-Create a dedicated worktree for the change (NEVER work on main).
-
-**From the bare repo root** (`${GIT_HOME_PUBLIC}/nix-darwin`):
-
-```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin
-git fetch origin
-git worktree add feat/add-<pkg-name> -b feat/add-<pkg-name> origin/main
-cd feat/add-<pkg-name>
-```
-
-The worktree is created at `${GIT_HOME_PUBLIC}/nix-darwin/feat/add-<pkg-name>/`.
+Create a worktree for the change (NEVER work on main), naming the branch `feat/add-<pkg-name>`.
 
 ### 4. Determine Installation Location
 
@@ -127,20 +116,7 @@ home-manager switch --flake .  # Linux
 
 ### 12. Cleanup (After Merge)
 
-Once the PR is merged, clean up your local environment:
-
-```bash
-# Navigate to the bare repo root
-cd ${GIT_HOME_PUBLIC}/nix-darwin
-
-# Remove the worktree
-git worktree remove feat/add-<pkg-name>
-
-# Delete the local feature branch
-git branch -d feat/add-<pkg-name>
-```
-
-**Note**: After the PR merges, run `/wrap-up` or `/clean_gone` to remove the worktree and the now-merged local branch.
+After the PR merges, run `/wrap-up` or `/clean_gone` to remove the worktree and the now-merged local branch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,11 @@ imported as flake inputs.
 ### First-Time Setup
 
 ```bash
-# 1. Clone as a bare repo (worktree convention used throughout ${GIT_HOME})
-git clone --bare https://github.com/JacobPEvans/nix-darwin.git ${GIT_HOME_PUBLIC}/nix-darwin
+# 1. Clone the repo
+git clone https://github.com/JacobPEvans/nix-darwin.git ${GIT_HOME_PUBLIC}/nix-darwin
 cd ${GIT_HOME_PUBLIC}/nix-darwin
 
-# 2. Create the main worktree
-git worktree add main main
-
-# 3. Build and activate for the first time
-cd ${GIT_HOME_PUBLIC}/nix-darwin/main
+# 2. Build and activate for the first time
 sudo darwin-rebuild switch --flake .
 ```
 

--- a/docs/boot-failure/permanent-fix.md
+++ b/docs/boot-failure/permanent-fix.md
@@ -182,7 +182,7 @@ is missing, along with a `nix-recover` helper function.
 After making these changes:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin/<worktree>
+cd ${GIT_HOME_PUBLIC}/nix-darwin
 git add modules/
 git commit -m "fix: multi-layered boot failure recovery"
 sudo darwin-rebuild switch --flake .


### PR DESCRIPTION
## What
- `README.md`: first-time setup `git clone --bare` + `git worktree add main` → plain `git clone`.
- `.claude/commands/flake-rebuild.md`, `quick-add-package.md`: stripped explicit `git worktree add <type>/<name>` / bare-repo-root path instructions; kept the "work in a worktree, never on main" guardrail and branch-naming conventions.
- `docs/boot-failure/permanent-fix.md`: `cd .../nix-darwin/<worktree>` → `cd .../nix-darwin`.

Net: 15 insertions, 67 deletions. Where a worktree lives is the tool's choice now.

## Why
Part of #671 — migrating to normal clones with native AI-tool worktrees.

Refs: dryvist/ai-assistant-instructions#671

🤖 Generated with [Claude Code](https://claude.com/claude-code)