### PR TITLE
feat(homebrew): integrate with nix-ai trustedTaps option for aws/tap

### DIFF
--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -10,6 +10,7 @@
   pkgs,
   lib,
   userConfig,
+  osConfig,
   ...
 }:
 
@@ -23,6 +24,10 @@
     # registry stays at the single defaultLocalModelId entry.
     ./mlx-no-autodiscover.nix
   ];
+
+  # Share system-level Homebrew taps with nix-ai's trust.json
+  programs.ai-homebrew.trustedTaps = osConfig.homebrew.taps;
+
 
   # ==========================================================================
   # macOS Application Management (copyApps for TCC stability)

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -75,6 +75,7 @@ in
     };
     taps = [
       "homebrew/autoupdate" # Background auto-update via launchd (brew autoupdate)
+      "aws/tap" # AWS SAM CLI and other AWS tools
     ]
     ++ agentHomebrewTaps; # AI-tool taps declared in nix-ai/lib/homebrew.nix
     brews = [


### PR DESCRIPTION
Leverages the new `programs.ai-homebrew.trustedTaps` option in `nix-ai` to inject system-level taps (like `aws/tap`) into `~/.homebrew/trust.json` so Homebrew trusts them.