### PR TITLE
fix(ai): swap local LLM default to Qwen3-30B-A3B-Instruct-2507 + unbreak main build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780830423,
-        "narHash": "sha256-hO6cuuMQeoj3nTnnkA87hAnxiUUwPdZ+iTeTyXRI24s=",
+        "lastModified": 1781043386,
+        "narHash": "sha256-nH/dV/P1i1Mdslm0GdBKr38d9JQw1SbF23Tkvtc7X0A=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "cfcaa3a0553ca6c955206e01d7437702741a2506",
+        "rev": "099347628a8d64961ac31b7e59087a1e535c1389",
         "type": "github"
       },
       "original": {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -85,6 +85,12 @@
     # this, the registry at services.aiStack.models is materialized to nothing
     # and llama-swap.json drifts from whatever was last activated by hand.
     mlx.enable = true;
+    # Multi-turn agent clients re-prefill 5-40K-token contexts; the 8192 MB
+    # default left no room for paged-cache prefix reuse (constant ~700-token
+    # hits) and cold prefill ran ~270 tok/s. Measured 2026-06-10 with these
+    # values: identical-prefix re-request dropped 21.8K -> 63 prefill tokens.
+    mlx.cacheMemoryMb = 16384;
+    mlx.prefillBatchSize = 2048;
 
     # macOS-specific zsh overrides
     # Base zsh config provided by nix-home (sharedModule).

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -25,8 +25,10 @@
     ./mlx-no-autodiscover.nix
   ];
 
-  # Share system-level Homebrew taps with nix-ai's trust.json
-  programs.ai-homebrew.trustedTaps = osConfig.homebrew.taps;
+  # Share system-level Homebrew taps with nix-ai's trust.json.
+  # homebrew.taps entries can be strings or submodule attrsets (nix-darwin
+  # normalizes to attrsets with a `name`); the nix-ai option takes strings.
+  programs.ai-homebrew.trustedTaps = map (t: if builtins.isString t then t else t.name) osConfig.homebrew.taps;
 
 
   # ==========================================================================

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -147,7 +147,14 @@ in
     # Non-secret — a public Hugging Face model name. Committed here like every
     # other eval-time identifier so evaluation stays pure (no --impure, no
     # keychain/env/file sourcing). Change the model via a reviewed commit.
-    defaultLocalModelId = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
+    # 2026-06-09: switched from mlx-community/Qwen3.6-35B-A3B-mxfp4 — its hybrid
+    # linear-attention architecture (qwen3_5_moe) crashes vllm-mlx whenever two
+    # requests batch (mlx-lm conv_state shape bug; 402 crash-recovery events in
+    # one log window, 0.1-4 tok/s effective). Qwen3-30B-A3B-Instruct-2507 is a
+    # standard-attention MoE (qwen3_moe): benched 80-98 tok/s single-stream,
+    # ~85 tok/s aggregate at 4-way concurrency, zero crashes, hermes tool
+    # calling. See dryvist/nix-ai#915.
+    defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
   };
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Two fixes:

1. **Model swap** (`lib/user-config.nix`): `mlx-community/Qwen3.6-35B-A3B-mxfp4` uses the qwen3_5_moe hybrid linear-attention architecture, which crashes vllm-mlx whenever two requests batch (mlx-lm conv_state shape bug — 402 crash-recovery events in one log window, 0.1–4 tok/s effective). Replaced with `mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit` (standard-attention qwen3_moe): benched on this host at **80–98 tok/s** single-stream, ~85 tok/s aggregate at 4-way concurrency, zero crashes, clean hermes tool calling (no parser change needed). See dryvist/nix-ai#915.

2. **Build fix** (`flake.lock` + `hosts/macbook-m4/home.nix`): main was un-buildable — it consumes `programs.ai-homebrew.trustedTaps` (dryvist/nix-ai#911) but the lock pinned nix-ai one commit before that option existed. Bumping the input surfaced a type mismatch (`osConfig.homebrew.taps` yields submodule attrsets; the option takes `listOf str`) — now mapped to tap names.

## Verification

- `darwin-rebuild build --flake .` succeeds (was failing on main).
- Home-manager activation applied on the host: `~/.config/mlx/llama-swap.json` regenerated with the new model; live endpoint serves `model: "default"` at 86.8 tok/s decode (with dryvist/nix-ai#916's QoS fix).

Refs: dryvist/nix-ai#914 dryvist/nix-ai#915 dryvist/nix-ai#916

🤖 Generated with [Claude Code](https://claude.com/claude-code)