### PR TITLE
feat(tunables): lower iogpu wired limit to 104000 for 24GB pageable headroom

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -130,7 +130,16 @@ in
   # --- Apple Silicon Tunables ---
   # Wired-memory ceiling, App Nap, Spotlight + TM excludes for AI caches.
   # See modules/darwin/apple-silicon-tunables.nix for option semantics.
-  system.appleSiliconTunables.enable = true;
+  system.appleSiliconTunables = {
+    enable = true;
+    # 104000 (not the module's 118000 default): guarantee 24 GB of unwirable
+    # headroom. At 118000 only ~10 GB was guaranteed pageable and the desktop
+    # working set alone exceeds 25 GB, so any large resident MLX model pushed
+    # the host into compressor + swap saturation (nix-mac-performance RC14;
+    # 2026-06-10 snapshot: swap 94 % with a single healthy 53 GB worker).
+    # Still fits the largest model in use (~75 GB resident).
+    wiredLimitMb = 104000;
+  };
 
   # --- Energy & Sleep Configuration ---
   system.energy = {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -28,8 +28,9 @@
   # Share system-level Homebrew taps with nix-ai's trust.json.
   # homebrew.taps entries can be strings or submodule attrsets (nix-darwin
   # normalizes to attrsets with a `name`); the nix-ai option takes strings.
-  programs.ai-homebrew.trustedTaps = map (t: if builtins.isString t then t else t.name) osConfig.homebrew.taps;
-
+  programs.ai-homebrew.trustedTaps = map (
+    t: if builtins.isString t then t else t.name
+  ) osConfig.homebrew.taps;
 
   # ==========================================================================
   # macOS Application Management (copyApps for TCC stability)
@@ -84,13 +85,15 @@
     # Brings the existing vllm-mlx LaunchAgent under Nix management — without
     # this, the registry at services.aiStack.models is materialized to nothing
     # and llama-swap.json drifts from whatever was last activated by hand.
-    mlx.enable = true;
-    # Multi-turn agent clients re-prefill 5-40K-token contexts; the 8192 MB
-    # default left no room for paged-cache prefix reuse (constant ~700-token
-    # hits) and cold prefill ran ~270 tok/s. Measured 2026-06-10 with these
-    # values: identical-prefix re-request dropped 21.8K -> 63 prefill tokens.
-    mlx.cacheMemoryMb = 16384;
-    mlx.prefillBatchSize = 2048;
+    mlx = {
+      enable = true;
+      # Multi-turn agent clients re-prefill 5-40K-token contexts; the 8192 MB
+      # default left no room for paged-cache prefix reuse (constant ~700-token
+      # hits) and cold prefill ran ~270 tok/s. Measured 2026-06-10 with these
+      # values: identical-prefix re-request dropped 21.8K -> 63 prefill tokens.
+      cacheMemoryMb = 16384;
+      prefillBatchSize = 2048;
+    };
 
     # macOS-specific zsh overrides
     # Base zsh config provided by nix-home (sharedModule).


### PR DESCRIPTION
## What

Host-level override for jevans-mbp: `system.appleSiliconTunables.wiredLimitMb = 104000` (module default remains 118000). Also groups the host's `mlx.*` and `system.appleSiliconTunables.*` attribute sets to clear statix W20 and restore a clean `Nix Validate` on this branch.

## How

`iogpu.wired_limit_mb` caps how much memory the IOGPU subsystem may wire (pin un-pageable). 104000 MB guarantees ~24 GB of pageable headroom for the OS and applications while still accommodating the largest model in use. The `set-iogpu-wired-limit` launchd daemon re-asserts the value at boot; activation applies it immediately.

## Apply

`darwin-rebuild switch` after merge.

Refs: dryvist/nix-mac-performance#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)