### PR TITLE
feat(cribl-edge): standalone GitOps mode + inline LLM-stack sources

### DIFF
--- a/docs/CRIBL-GITOPS.md
+++ b/docs/CRIBL-GITOPS.md
@@ -1,0 +1,51 @@
+# Cribl Edge GitOps (standalone mode)
+
+How this repo manages the macOS Cribl Edge node's configuration as code, and
+why the node is standalone rather than fleet-managed.
+
+## Policy
+
+- **Cribl Cloud fleets are reserved for Linux machines** (VMs, containers,
+  servers). macOS hosts run Cribl Edge in **standalone** mode with
+  configuration owned by this repo (`programs.cribl-edge.mode = "standalone"`).
+- Configuration is declarative: `programs.cribl-edge.standalone.configFiles`
+  renders files from the Nix store into `<dataDir>/local/cribl/` on every
+  `darwin-rebuild switch`.
+
+## Why standalone + files (the Cribl-supported shape)
+
+Cribl's documented configuration surface is a file tree under
+`$CRIBL_HOME/local/cribl/` — `inputs.yml`, `outputs.yml`,
+`pipelines/<name>/conf.yml`, `pipelines/route.yml` — and Cribl explicitly
+supports bootstrapping nodes from these files
+([Config Files](https://docs.cribl.io/edge/configuration-files/),
+[inputs.yml](https://docs.cribl.io/edge/inputsyml/)). Cribl's GitOps feature
+([GitOps](https://docs.cribl.io/stream/gitops/)) is Leader-centric — it
+version-controls a distributed deployment's Leader config — which does not
+apply to a single standalone Edge node. For a single node, version-controlled
+config files deployed by a config-management system (this repo) are the
+supported equivalent. With `CRIBL_VOLUME_DIR` set, the mutable copy of that
+tree lives under the data volume (`/opt/cribl-data/local/cribl/`).
+
+Cribl reloads local configuration changes without a daemon restart, so
+activation only needs to install the files.
+
+## Managed-mode remnants
+
+On the first standalone start, any fleet-enrollment state (`.enrolled`,
+`local/_system/instance.yml`, `local/edge/instance.yml`) is moved into
+`<dataDir>/retired-managed-state/` — retained, never deleted — so a prior
+fleet identity remains recoverable.
+
+## Packs
+
+Packs still deploy declaratively via `programs.cribl-edge.packs`
+(GitHub-released `.crbl` archives pinned by hash). Standalone config and packs
+compose: instance config under `local/cribl/`, packs under
+`default/<pack-name>/`.
+
+## Where the data goes
+
+Inline sources on this host ship over Cribl TCP (S2S) to the HAProxy-fronted
+Cribl Stream workers (port: `service_ports.cribl_s2s` in terraform-proxmox
+constants), which forward to Splunk. Index/sourcetype are stamped at the Edge.

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -5,7 +5,7 @@
 #
 # This file imports darwin modules and configures host-specific settings.
 
-{ pkgs, config, ... }:
+{ pkgs, ... }:
 
 let
   # User-specific configuration (hostname, identity, etc.)
@@ -74,14 +74,73 @@ in
     };
 
     # --- Cribl Edge ---
-    # Log collection agent managed by Cribl Cloud.
-    # Nix invokes Cribl Cloud's install-edge.sh on every rebuild and manages the LaunchDaemon.
-    # Cribl Cloud manages all runtime configuration after enrollment.
-    # Sensitive values (org ID, workspace ID, token) fetched from Doppler at activation time.
+    # Log collection agent, standalone + GitOps-managed (this file owns the
+    # node's config; Cribl Cloud fleets are reserved for Linux machines).
+    # Inline sources/pipelines below cover the local LLM stack; events ship
+    # over Cribl TCP to the HAProxy-fronted Stream workers (port value from
+    # terraform-proxmox constants service_ports.cribl_s2s) which forward to
+    # the Splunk `llm` index. See docs/CRIBL-GITOPS.md.
     cribl-edge = {
       enable = true;
-      cloud = {
-        secretsFile = config.sops.templates."cribl-edge.env".path;
+      mode = "standalone";
+      standalone.configFiles = {
+        "inputs.yml" = ''
+          inputs:
+            in_llm_logs:
+              type: file
+              disabled: false
+              mode: manual
+              filenames:
+                - ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/vllm-mlx.log
+                - ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/vllm-mlx.error.log
+              sendToRoutes: false
+              connections:
+                - pipeline: llm_logs
+                  output: cribl_stream
+            in_system_metrics:
+              type: system_metrics
+              disabled: false
+              sendToRoutes: false
+              connections:
+                - pipeline: llm_metrics
+                  output: cribl_stream
+        '';
+        "outputs.yml" = ''
+          outputs:
+            cribl_stream:
+              type: cribl_tcp
+              # Bare hostname — resolves via the LAN search domain; fronted by
+              # HAProxy, load-balanced across the Cribl Stream workers.
+              host: haproxy
+              port: 10300
+              pqEnabled: true
+        '';
+        # Model-server logs: the manager (Go) and its workers (Python) share
+        # the same two files; sourcetype is derived per line.
+        "pipelines/llm_logs/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "_raw.match(/^(INFO|DEBUG|WARNING|ERROR|CRITICAL):/) ? 'vllm:mlx' : 'llamaswap'"
+        '';
+        "pipelines/llm_metrics/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "'mlx:metrics'"
+        '';
       };
       packs = {
         cc-edge-the-mac-pack-io = pkgs.fetchzip {

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -5,17 +5,25 @@
 # packages/cribl-edge.nix and is immutable in the Nix store. Mutable state
 # (config, queues, logs) lives under cfg.dataDir (default /opt/cribl-data).
 #
-# Fleet enrollment happens at first start via `cribl mode-managed-edge`:
-# if instance.yml doesn't exist in dataDir, the startScript enrolls with
-# Cribl Cloud using CRIBL_ORG_ID / CRIBL_WORKSPACE_ID / CRIBL_TOKEN from the
-# sops-rendered secrets file. Subsequent starts skip enrollment and run
-# `cribl server` directly. After enrollment Cribl Cloud manages all runtime
-# configuration for the edge node.
+# Two management modes (mode option):
+#
+#   managed    — Fleet enrollment at first start via `cribl mode-managed-edge`
+#                using credentials from the sops-rendered secrets file; Cribl
+#                Cloud owns runtime configuration after enrollment.
+#                FLEET POLICY: Cribl Cloud fleets are reserved for Linux
+#                machines (VMs/containers/servers). Do not enroll macOS hosts.
+#
+#   standalone — GitOps: this module owns the node's configuration. Declarative
+#                config files (standalone.configFiles) are rendered from the
+#                Nix store into <dataDir>/local/cribl/ on every activation —
+#                the config-as-code layout documented by Cribl (inputs.yml,
+#                outputs.yml, pipelines/<name>/conf.yml). Any stale fleet
+#                enrollment state is retired at startup. See docs/CRIBL-GITOPS.md.
 #
 # Secrets are provided via sops-nix (modules/darwin/sops.nix), which decrypts
 # age-encrypted credentials to a root-only (0400) KEY=value file at activation
 # time. The startScript parses this file line-by-line — no `source`, no shell
-# eval — and only exports recognized CRIBL_* keys.
+# eval — and only exports recognized CRIBL_* keys. (Managed mode only.)
 #
 # Service runs as root (temporary — revert serviceUser/serviceGroup to cribl:cribl when ready).
 
@@ -40,12 +48,25 @@ let
     runtimeInputs = [ pkgs.coreutils ];
     text = ''
       exec ${./scripts/cribl-edge-start.sh} \
-        "${cfg.cloud.secretsFile}" \
+        "${if cfg.cloud.secretsFile != null then cfg.cloud.secretsFile else "/dev/null"}" \
         "${cfg.dataDir}" \
         "${cfg.package}/opt/cribl" \
-        "${cfg.cloud.group}"
+        "${cfg.cloud.group}" \
+        "${cfg.mode}"
     '';
   };
+
+  # Render each declarative standalone config file into the Nix store; the
+  # activation script installs them under <dataDir>/local/cribl/.
+  standaloneConfigInstall = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (relPath: text: ''
+      /usr/bin/install -d -o ${cfg.serviceUser} -g ${cfg.serviceGroup} \
+        "$(/usr/bin/dirname "${cfg.dataDir}/local/cribl/${relPath}")"
+      /usr/bin/install -m 0644 -o ${cfg.serviceUser} -g ${cfg.serviceGroup} \
+        ${pkgs.writeText (builtins.replaceStrings [ "/" ] [ "-" ] relPath) text} \
+        "${cfg.dataDir}/local/cribl/${relPath}"
+    '') cfg.standalone.configFiles
+  );
 in
 {
   options.programs.cribl-edge = {
@@ -75,13 +96,48 @@ in
       description = "Group to run the Cribl Edge service as.";
     };
 
+    mode = lib.mkOption {
+      type = lib.types.enum [
+        "managed"
+        "standalone"
+      ];
+      default = "managed";
+      description = ''
+        managed = Cribl Cloud fleet owns runtime config (Linux-only fleet
+        policy — do not enroll macOS hosts). standalone = this module owns
+        config via standalone.configFiles (GitOps).
+      '';
+    };
+
+    standalone = {
+      configFiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.lines;
+        default = { };
+        description = ''
+          Declarative Cribl config files for standalone mode, keyed by path
+          relative to <dataDir>/local/cribl/ (the config-as-code location
+          documented by Cribl). Installed on every activation. Cribl reloads
+          local config changes without a daemon restart.
+        '';
+        example = lib.literalExpression ''
+          {
+            "inputs.yml" = "inputs: ...";
+            "outputs.yml" = "outputs: ...";
+            "pipelines/llm_logs/conf.yml" = "output: default ...";
+          }
+        '';
+      };
+    };
+
     cloud = {
       secretsFile = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nullOr lib.types.str;
+        default = null;
         description = ''
           Path to a root-readable KEY=value file containing CRIBL_ORG_ID,
           CRIBL_WORKSPACE_ID, and CRIBL_TOKEN. Use the sops-nix rendered
           template: config.sops.templates."cribl-edge.env".path
+          Required when mode = "managed"; unused in standalone mode.
         '';
         example = "/run/secrets/rendered/cribl-edge.env";
       };
@@ -89,7 +145,7 @@ in
       group = lib.mkOption {
         type = lib.types.str;
         default = "default_fleet";
-        description = "Fleet group name.";
+        description = "Fleet group name (managed mode only).";
       };
     };
 
@@ -105,10 +161,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.mode != "managed" || cfg.cloud.secretsFile != null;
+        message = "programs.cribl-edge: cloud.secretsFile is required when mode = \"managed\".";
+      }
+    ];
+
     # Always ensure dataDir + logs subdir exist with correct ownership so the
-    # launchd job can write, whether or not any packs are declared.
+    # launchd job can write, whether or not any packs are declared. In
+    # standalone mode, also install the declarative config files.
     system.activationScripts.postActivation.text = ''
       ${./scripts/cribl-edge-activate.sh} "${cfg.dataDir}" "${cfg.serviceUser}:${cfg.serviceGroup}"
+      ${lib.optionalString (cfg.mode == "standalone") standaloneConfigInstall}
       ${lib.optionalString (cfg.packs != { }) (
         lib.concatStringsSep "\n" (
           lib.mapAttrsToList (name: src: ''

--- a/modules/darwin/apps/scripts/cribl-edge-start.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-start.sh
@@ -2,12 +2,14 @@
 # Cribl Edge startup script.
 #
 # Arguments (set by the Nix wrapper in cribl-edge.nix):
-#   $1 = path to sops-rendered KEY=value secrets file (root-only 0400)
+#   $1 = path to sops-rendered KEY=value secrets file (root-only 0400;
+#        /dev/null in standalone mode)
 #   $2 = CRIBL_VOLUME_DIR (mutable state / data dir)
 #   $3 = CRIBL_HOME (read-only path into the Nix store package)
 #   $4 = Cribl fleet group name (default; overridden by the URL's `?group=` if present)
+#   $5 = mode: "managed" (default) or "standalone"
 #
-# Responsibilities:
+# Responsibilities (managed mode):
 #   1. Safely load credentials from the secrets file without shell eval.
 #      Two formats are honored, in order of preference:
 #        a) CRIBL_DIST_MASTER_URL=tls://TOKEN@HOST:PORT?group=GROUP
@@ -19,6 +21,12 @@
 #      marker so subsequent starts skip enrollment. Enrollment failures are
 #      fatal — launchd retries via ThrottleInterval.
 #   4. exec `cribl server`.
+#
+# Responsibilities (standalone mode):
+#   1. Retire any leftover fleet-enrollment state (moved aside, never
+#      deleted) so the node runs purely from its local config — which the
+#      nix-darwin activation renders into local/cribl/ (GitOps).
+#   2. exec `cribl server`.
 
 set -euo pipefail
 
@@ -28,8 +36,27 @@ SECRETS_FILE="${1:?secrets file path required}"
 CRIBL_VOLUME_DIR="${2:?volume dir required}"
 CRIBL_HOME="${3:?cribl home required}"
 CRIBL_GROUP="${4:?cribl fleet group required}"
+CRIBL_MODE="${5:-managed}"
 
 export CRIBL_VOLUME_DIR CRIBL_HOME
+
+if [ "$CRIBL_MODE" = "standalone" ]; then
+  mkdir -p "$CRIBL_VOLUME_DIR" "$CRIBL_VOLUME_DIR/logs"
+  # Retire managed-mode enrollment state. Moved (not deleted) so the prior
+  # fleet identity is recoverable; the marker dir is created once.
+  _retired="$CRIBL_VOLUME_DIR/retired-managed-state"
+  for _f in "$CRIBL_VOLUME_DIR/.enrolled" \
+            "$CRIBL_VOLUME_DIR/local/_system/instance.yml" \
+            "$CRIBL_VOLUME_DIR/local/edge/instance.yml"; do
+    if [ -e "$_f" ]; then
+      mkdir -p "$_retired"
+      mv "$_f" "$_retired/$(basename "$_f").$(date +%Y%m%d%H%M%S)"
+      echo "$(ts) [INFO] Standalone mode: retired managed-state file $_f"
+    fi
+  done
+  echo "$(ts) [INFO] Starting Cribl Edge standalone (config: local/cribl, GitOps-managed)."
+  exec "$CRIBL_HOME/bin/cribl" server
+fi
 
 if [ ! -r "$SECRETS_FILE" ]; then
   echo "$(ts) [ERROR] Cribl secrets file not readable: $SECRETS_FILE" >&2


### PR DESCRIPTION
## What

- New `programs.cribl-edge.mode` (`managed` | `standalone`, default managed). Standalone: no fleet enrollment; prior enrollment state is retired into `<dataDir>/retired-managed-state/` (moved, never deleted); `standalone.configFiles` renders declarative config into `<dataDir>/local/cribl/` on every activation — the config-as-code layout documented by Cribl ([Config Files](https://docs.cribl.io/edge/configuration-files/)).
- `cloud.secretsFile` is now nullable, asserted non-null only in managed mode.
- **macbook-m4 → standalone** with inline sources: file monitor on the model-server manager/worker logs, the built-in `system_metrics` input rerouted from devnull, both shipping over `cribl_tcp` to `haproxy:10300` (persistent queue on) with `index=llm` stamped at the Edge and sourcetype derived per line.
- `docs/CRIBL-GITOPS.md`: layout, the **Linux-only Cribl Cloud fleet policy**, and doc citations.

## How

Cribl's GitOps feature is Leader-centric and doesn't apply to a single standalone Edge node; the supported equivalent is version-controlled config files under `local/cribl/`, which this module now owns. Cribl reloads local config without a daemon restart. Packs continue to deploy via the existing `packs` mechanism and compose with standalone config.

## Apply

`darwin-rebuild switch` (after the server-side path lands: terraform-proxmox#424 → ansible-proxmox-apps#393 → ansible-splunk#246).

## Verify

`<dataDir>/log/cribl.log` shows the file + metrics inputs reading and the tcp output connected; Splunk: `index=llm | stats count by sourcetype`.

Refs: dryvist/ansible-proxmox-apps#393, dryvist/terraform-proxmox#424, dryvist/ansible-splunk#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)