### PR TITLE
chore(deps): bump nix-ai/ai-assistant-instructions/cc-plugins pins (consolidation activation)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ai-assistant-instructions": {
       "flake": false,
       "locked": {
-        "lastModified": 1780800951,
-        "narHash": "sha256-fsY4/y0iW1+Ez46tLgzQoPmvap5w8ycVBtKV5wnduCs=",
+        "lastModified": 1781129501,
+        "narHash": "sha256-C8VZdU4hjN47QPXZrxGZ16H8ODY/cXqr1XK+WjNVxUw=",
         "owner": "dryvist",
         "repo": "ai-assistant-instructions",
-        "rev": "3128b52c377c1e00a19bde4339255f72991f793e",
+        "rev": "ab1db663dbd394965b98b6ad7e4358b41d7db6ba",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1780800960,
-        "narHash": "sha256-KwWjayS4Dm3FWyXuXNaBvwilosKdrq4LWc716hRFDsU=",
+        "lastModified": 1781125547,
+        "narHash": "sha256-622YuZh3rESR4F08WC2SMAD9HLkwsiWYhvHUELxNT8o=",
         "owner": "dryvist",
         "repo": "claude-code-plugins",
-        "rev": "a55a2364c22bb64a7ef8288e6d6f8ac1d548189c",
+        "rev": "6b5af8fe1fc215abcc6c9f7be675e647b09e4daf",
         "type": "github"
       },
       "original": {
@@ -618,11 +618,11 @@
     "jacobpevans-cc-plugins_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1779660353,
-        "narHash": "sha256-Wst459BiRSLXaE2PtSpQk1wYMev0uhDlOTmW5ks7ZEo=",
+        "lastModified": 1781125547,
+        "narHash": "sha256-622YuZh3rESR4F08WC2SMAD9HLkwsiWYhvHUELxNT8o=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "36a6a281d5d4d1120c857e212eca6d061ca1c6bc",
+        "rev": "6b5af8fe1fc215abcc6c9f7be675e647b09e4daf",
         "type": "github"
       },
       "original": {
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781043386,
-        "narHash": "sha256-nH/dV/P1i1Mdslm0GdBKr38d9JQw1SbF23Tkvtc7X0A=",
+        "lastModified": 1781180873,
+        "narHash": "sha256-8OlwnSMEg4KPV3PYR28IB1Q3bCKcMhjO7jua7g36E2Y=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "099347628a8d64961ac31b7e59087a1e535c1389",
+        "rev": "910b5513de35eea22735baf28417981ff676c84a",
         "type": "github"
       },
       "original": {
@@ -808,11 +808,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780545323,
-        "narHash": "sha256-zRvQmT61mQyu161WGm4xY75NZQVFsWlEh1CnwschLP0=",
+        "lastModified": 1781125779,
+        "narHash": "sha256-NHoaSDeJWUzG8m2dQCqoBDr3HQG6dRXNZ+l3r/EwZCA=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "087dddee2e5cd8be2ffa0fec5e09d5176db1dd7f",
+        "rev": "0e3404c1199f71f119d00e76478be1912305bf5a",
         "type": "github"
       },
       "original": {
@@ -894,11 +894,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780747962,
-        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Activates the instruction-consolidation work on this host:
- ai-assistant-instructions v1.16.0 — drops the 3 rules migrated to
  marketplace skills (pre-commit, nix-tool-policy, shared-workflow-org-refs)
- nix-ai 910b551 — permissions data read from nix-claude-code (Phase 3b)
- claude-code-plugins v4.2.0-era pin for plugin auto-discovery

Pre-switch verification (darwin-rebuild build, old vs new generation):
- ~/.claude/rules: exactly the 3 migrated rules removed
- Claude settings permissions: set-identical (all arrays + keys)
- codex-config.toml, copilot-config.json, antigravity-settings.json:
  byte-identical
- qwen-settings.json: differs only by the local-model swap already
  committed on main (5a8a28a), unrelated to this bump

Refs: dryvist/ai-assistant-instructions#680

Assisted-by: Claude:claude-fable-5
