### PR TITLE
feat(homebrew): add Apple container runtime

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -165,6 +165,7 @@ Source: `modules/darwin/homebrew.nix`
 | Package | Description |
 | --- | --- |
 | ccusage | Claude Code usage analyzer |
+| container | Apple container CLI/runtime for Linux containers on Apple Silicon |
 | block-goose-cli | Block's Goose AI agent |
 | whisperkit-cli | Swift native on-device speech recognition (Apple Silicon) |
 

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -81,6 +81,9 @@ in
     brews = [
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs
+      # Apple container CLI/runtime. Homebrew tracks current upstream while
+      # nixpkgs lags by a major release.
+      "container"
 
       # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
 

--- a/scripts/validate-nix-before-all.sh
+++ b/scripts/validate-nix-before-all.sh
@@ -19,6 +19,7 @@ EXCLUSIONS=(
   "claude-code:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "antigravity-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "bitwarden:nixpkgs build pins EOL electron_39 (insecure); cask uses Bitwarden's maintained build"
+  "container:Homebrew tracks Apple container 1.0.0 while nixpkgs is still 0.12.3; use current upstream runtime"
   "orbstack:Cask preferred over nixpkgs for TCC permission stability (nixpkgs symlink changes on rebuild, forcing TCC re-grant)"
   "postman:Nixpkgs version lags significantly behind upstream, causing Squirrel/ShipIt schema mismatch errors"
 )
@@ -33,14 +34,14 @@ fi
 # Extract brew packages (brews = [...])
 brews=$(awk '
   /brews = \[/ {in_brews=1; next}
-  /\];/ && in_brews {in_brews=0; next}
+  /^[[:space:]]*\][[:space:]]*(;|$|\+\+)/ && in_brews {in_brews=0; next}
   in_brews && ! /^[[:space:]]*#/ {print}
 ' "$HOMEBREW_FILE" | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' || true)
 
 # Extract cask packages (casks = [...])
 casks=$(awk '
   /casks = \[/ {in_casks=1; next}
-  /\];/ && in_casks {in_casks=0; next}
+  /^[[:space:]]*\][[:space:]]*(;|$|\+\+)/ && in_casks {in_casks=0; next}
   in_casks && ! /^[[:space:]]*#/ {print}
 ' "$HOMEBREW_FILE" | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' || true)
 


### PR DESCRIPTION
## Summary
- add Apple's `container` Homebrew formula so nix-darwin installs the current upstream runtime
- document the formula in `MANIFEST.md`
- allow this Homebrew exception because nixpkgs currently exposes Apple `container` 0.12.3 while Homebrew tracks 1.0.0
- fix the Homebrew validator list parser so it stops at `] ++ ...` closures instead of reading later sections as brew entries

## Validation
- `brew info container`
- `nix fmt`
- `statix check`
- `deadnix`
- `bash -n scripts/validate-nix-before-all.sh`
- `shellcheck scripts/validate-nix-before-all.sh`
- `./scripts/validate-nix-before-all.sh`
- `git diff --check`
- `nix flake check`
