### PR TITLE
fix(ci): repoint shared workflows to dryvist hub

### DIFF
--- a/.github/workflows/ci-file-length.yml
+++ b/.github/workflows/ci-file-length.yml
@@ -22,4 +22,4 @@ permissions:
 jobs:
   check:
     name: Check File Sizes
-    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
+    uses: dryvist/.github/.github/workflows/_file-size.yml@main

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -110,7 +110,7 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+    uses: dryvist/.github/.github/workflows/_nix-validate.yml@main
     with:
       # Linux `nix flake check --all-systems` needs more disk/RAM for
       # darwin-source substitution; m7+c7 family with s3-cache fits.
@@ -121,7 +121,7 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
+    uses: dryvist/.github/.github/workflows/_markdown-lint.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
@@ -135,7 +135,7 @@ jobs:
     name: File Size
     needs: changes
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
+    uses: dryvist/.github/.github/workflows/_file-size.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 

--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -23,4 +23,4 @@ permissions:
 jobs:
   lint:
     name: Lint Markdown
-    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
+    uses: dryvist/.github/.github/workflows/_markdown-lint.yml@main

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -19,4 +19,4 @@ permissions:
 jobs:
   validate:
     name: Validate
-    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+    uses: dryvist/.github/.github/workflows/_nix-validate.yml@main

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,7 +1,7 @@
 # Periodic + per-PR OSV vulnerability scan.
 #
-# Inherits the centralized reusable workflow from JacobPEvans-personal/.github.
-# Config: JacobPEvans-personal/.github/osv-scanner.toml (org default) or local
+# Inherits the centralized reusable workflow from dryvist/.github.
+# Config: dryvist/.github/osv-scanner.toml (org default) or local
 # osv-scanner.toml in this repo (takes precedence).
 #
 # Make this a required check via branch protection on `main` after merge.
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   scan:
-    # SHA pin → JacobPEvans-personal/.github main as of 2026-05-20.
+    # SHA pin → dryvist/.github main as of 2026-06-12.
     # Bump intentionally when the upstream workflow changes.
-    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
+    uses: dryvist/.github/.github/workflows/_osv-scan.yml@57c5cc6ac8f080137f551c745a2e2a0c6dcde62a
     with:
       runner_label: ubuntu-latest


### PR DESCRIPTION
## Why

`uses:` references to reusable workflows do **not** follow GitHub account-rename redirects, and policy says dryvist repos must never depend on `JacobPEvans-personal/*`. This repoints every reusable-workflow reference whose target already exists in `dryvist/.github`.

## Changes

| File | Target | Ref handling |
| --- | --- | --- |
| `ci-gate.yml` | `_nix-validate.yml`, `_markdown-lint.yml`, `_file-size.yml` | `@main` preserved |
| `ci-validate.yml` | `_nix-validate.yml` | `@main` preserved |
| `ci-markdownlint.yml` | `_markdown-lint.yml` | `@main` preserved |
| `ci-file-length.yml` | `_file-size.yml` | `@main` preserved |
| `osv-scan.yml` | `_osv-scan.yml` | re-pinned to `dryvist/.github@57c5cc6` (current main) — the old SHA pin (`a76cf8f`) is a `JacobPEvans-personal/.github` commit and cannot resolve in the new repo |

All five dryvist hub targets were verified to exist and to accept the same optional `runner_label` input the call sites pass (verified against `dryvist/.github` main).

## Design decision: keep the standalone workflows

`ci-validate.yml`, `ci-markdownlint.yml`, and `ci-file-length.yml` were evaluated for deletion as possible duplicates of jobs `ci-gate.yml` aggregates. They are **not redundant**: all three trigger on `push` to `main` (post-merge visibility), while `ci-gate.yml` triggers on `pull_request` only. Deleting them would remove all push-to-main CI for nix-validate / markdown-lint / file-size. Kept, owner-swap only.

(`ci-gate.yml` itself is a local Merge Gatekeeper implementation with RunsOn runner routing and deps-only detection — replacing it with the hub `_ci-gate.yml` would be a behavioral change out of scope here.)

## Left unchanged

- `gh-aw-pin-refresh.yml` still references `JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main` — that reusable workflow does **not** exist in `dryvist/.github` yet. Repoint once the hub gains it.
- `repo-health-audit.md` / `*.lock.yml` `{{#import}}` references and prose mentions (`deps-update-flake.yml` comments) — out of scope per gh-aw/prose exclusion.
- `.markdownlint-cli2.yaml` — local config diverges from hub canon only by repo-specific additive `ignores` (explicitly allowed by the canon) and already carries a header naming the canonical source and the delta. Kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)