### PR TITLE
chore(macbook-m4): remove unused gh-claude-* token relaunch wrappers

### DIFF
--- a/hosts/macbook-m4/claude-launchers.zsh
+++ b/hosts/macbook-m4/claude-launchers.zsh
@@ -1,35 +1,23 @@
-# Custom-auth launchers for `claude` (Claude Code).
-# Sibling of gh-token-switching.zsh; sourced from home.nix initContent.
+# Custom-auth launcher for `claude` (Claude Code).
+# Sourced from home.nix initContent.
 #
 # Provides:
 #   av-claude <profile> [claude-args...]   aws-vault exec <profile> -- claude ...
-#   gh-claude-restricted [claude-args...]  claude with GITHUB_TOKEN from the RESTRICTED tier
-#   gh-claude-private    [claude-args...]  claude with GITHUB_TOKEN from the PRIVATE tier
-#   gh-claude-dryvist    [claude-args...]  claude with GITHUB_TOKEN from the DRYVIST tier
-#   gh-claude-admin      [claude-args...]  claude with GITHUB_TOKEN from the ADMIN tier
-#   gh-claude-org-admin  [claude-args...]  claude with GITHUB_TOKEN from the ORG_ADMIN tier
 #
-# Each gh-claude-* wrapper runs its underlying gh-* function (defined in
-# gh-token-switching.zsh) inside a subshell, so the GITHUB_TOKEN and
-# GH_ENV_MODE exports those functions produce do NOT leak into the parent
-# shell after claude exits. This preserves the shell's default least-privilege
-# tier. The tier names (RESTRICTED / PRIVATE / ADMIN) correspond to the macOS
-# Keychain service names GH_PAT_RESTRICTED / GH_PAT_PRIVATE / GH_PAT_ADMIN
-# from which the underlying gh-* functions read the token.
+# (The gh-claude-* GitHub-token relaunch wrappers were removed — they were
+# unused. To run claude under a non-default GitHub token tier, switch the
+# parent shell with the gh-* functions in gh-token-switching.zsh first, then
+# launch claude.)
 #
-# Every launcher prints a short status banner to stderr before invoking
-# claude. The banner is primarily aimed at nested AI sessions: when a Claude
-# Code agent invokes one of these functions via its bash tool, the banner
-# lands in the tool output so the agent can see (a) that it is now running
-# under a custom authentication context, (b) what kind of context it is,
-# and (c) that the context disappears when the claude process exits. The
-# banner contains no secrets or token material — only the source type and
-# the context label passed into the launcher.
+# av-claude prints a short status banner to stderr before invoking claude. The
+# banner is aimed at nested AI sessions: when a Claude Code agent invokes it via
+# its bash tool, the banner lands in the tool output so the agent can see (a)
+# that it is now running under a custom authentication context, (b) what kind,
+# and (c) that the context disappears when the claude process exits. The banner
+# contains no secrets — only the source type and the context label.
 
-# Shared status banner emitted before claude is execed.
-# Reusable across all launchers — takes an auth-source label and a
-# context name. Prints to stderr so it doesn't collide with claude's
-# stdout. No secret material is ever printed.
+# Status banner emitted before claude is execed. Prints to stderr so it doesn't
+# collide with claude's stdout. No secret material is ever printed.
 _claude_launchers_banner() {
   local source_type="$1"
   local context="$2"
@@ -60,44 +48,4 @@ av-claude() {
   shift
   _claude_launchers_banner "aws-vault profile" "$profile"
   aws-vault exec "$profile" -- claude "$@"
-}
-
-gh-claude-restricted() {
-  (
-    gh-restricted >/dev/null \
-      && _claude_launchers_banner "github-token tier" "restricted" \
-      && exec claude "$@"
-  )
-}
-
-gh-claude-private() {
-  (
-    gh-private >/dev/null \
-      && _claude_launchers_banner "github-token tier" "private" \
-      && exec claude "$@"
-  )
-}
-
-gh-claude-dryvist() {
-  (
-    gh-dryvist >/dev/null \
-      && _claude_launchers_banner "github-token tier" "dryvist" \
-      && exec claude "$@"
-  )
-}
-
-gh-claude-admin() {
-  (
-    gh-admin >/dev/null \
-      && _claude_launchers_banner "github-token tier" "admin" \
-      && exec claude "$@"
-  )
-}
-
-gh-claude-org-admin() {
-  (
-    gh-org-admin >/dev/null \
-      && _claude_launchers_banner "github-token tier" "org-admin" \
-      && exec claude "$@"
-  )
 }

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -157,10 +157,11 @@
         unset GITHUB_TOKEN
         gh-dryvist
 
-        # --- Custom-auth launchers for `claude` ---
-        # Defines av-claude <profile>, gh-claude-restricted, gh-claude-private,
-        # gh-claude-dryvist, gh-claude-admin, gh-claude-org-admin. Depends on
-        # the gh-* functions sourced above.
+        # --- Custom-auth launcher for `claude` ---
+        # Defines av-claude <profile> (aws-vault exec <profile> -- claude). The
+        # gh-claude-* GitHub-token relaunch wrappers were removed as unused; to
+        # run claude under a non-default tier, switch the parent shell with the
+        # gh-* functions sourced above first.
         source ${./claude-launchers.zsh}
 
         # --- macOS setup ---


### PR DESCRIPTION
## What

Removes the five `gh-claude-*` GitHub-token relaunch wrappers
(`gh-claude-restricted` / `private` / `dryvist` / `admin` / `org-admin`)
from `hosts/macbook-m4/claude-launchers.zsh`.

## Why

They wrapped the `gh-*` token switchers to relaunch `claude` under a different
token tier in a subshell. Unused in practice, and they added ceremony — plus a
doc surface that kept telling AI agents to "relaunch with `gh-claude-private`".

## Kept (deliberately)

- **`av-claude`** (`aws-vault exec <profile> -- claude`) — a different mechanism,
  still used for credential-injected claude sessions.
- **`gh-token-switching.zsh`** tier system (`gh-dryvist` default, etc.) — it
  supplies the shell's `GITHUB_TOKEN` and gates private-repo HTTPS pushes. Untouched.

To run claude under a non-default tier now: switch the parent shell with the
`gh-*` functions first, then launch claude.

## Validation

`zsh -n` clean on the trimmed `claude-launchers.zsh`. `home.nix` change is a
comment + the same `source` line (only the launcher file's contents shrank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)