### PR TITLE
feat: seed global git excludes from dryvist/.github org-default gitignore

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,6 +334,22 @@
         "url": "https://install.determinate.systems/determinate-nixd/tag/v3.21.1/x86_64-linux"
       }
     },
+    "dotgithub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781568152,
+        "narHash": "sha256-MihaxK3kynDlIm3/+lQ6jlXb2SmjOTxSmqjwyX4a/AY=",
+        "owner": "dryvist",
+        "repo": ".github",
+        "rev": "b7cdc4b3bca92630ad3767494d6a64398732d882",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dryvist",
+        "repo": ".github",
+        "type": "github"
+      }
+    },
     "dryvist-github": {
       "inputs": {
         "git-hooks": "git-hooks",
@@ -1058,6 +1074,7 @@
         "claude-code-plugins": "claude-code-plugins",
         "darwin": "darwin",
         "determinate": "determinate",
+        "dotgithub": "dotgithub",
         "home-manager": "home-manager",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "mac-app-util": "mac-app-util",

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,14 @@
       url = "github:BeehiveInnovations/pal-mcp-server";
       flake = false;
     };
+    # dryvist org-wide config hub. Source of the org-default .gitignore
+    # (configs/gitignore) that seeds the global git excludes file. Tracks
+    # main; `nix flake update dotgithub` pulls the latest. The git module
+    # tolerates the file being absent (pre-merge) and activates once present.
+    dotgithub = {
+      url = "github:dryvist/.github";
+      flake = false;
+    };
 
     # AI CLI ecosystem (Claude, Gemini, Copilot, MCP, marketplace).
     # Only AI flake nix-darwin imports — Claude/Gemini/Codex/MCP config
@@ -107,6 +115,7 @@
       nix-home,
       determinate,
       sops-nix,
+      dotgithub,
       ...
     }:
     let
@@ -117,7 +126,7 @@
       # nix-ai modules get their inputs via _module.args (self-contained)
       # nix-home modules accept userConfig with sensible defaults
       extraSpecialArgs = {
-        inherit userConfig;
+        inherit userConfig dotgithub;
       };
 
       # Guard: fail at eval time if stateVersion drifts from nixpkgs branch.

--- a/hosts/macbook-m4/git-global-excludes.nix
+++ b/hosts/macbook-m4/git-global-excludes.nix
@@ -1,0 +1,28 @@
+# Global git excludes, sourced live from the dryvist org-default
+# (.github/configs/gitignore) — secrets, credentials, TF state, and
+# AI-assistant local state. Merges with nix-home's base `programs.git.ignores`
+# (home-manager concatenates the list across modules) and writes to the XDG
+# global excludes file, protecting EVERY repo on this machine — including
+# non-dryvist clones the per-repo .gitignore can't reach.
+#
+# `pathExists` guard: tolerates the file being absent on the pinned input
+# (e.g. before dryvist/.github#43 merges configs/gitignore to main). Absent =>
+# empty list => no-op. After merge, `nix flake update dotgithub` activates it.
+#
+# Kept in its own module (not home.nix) to stay under the per-file size cap and
+# avoid a statix multiple-`programs`-assignment lint.
+{
+  lib,
+  dotgithub,
+  ...
+}:
+let
+  f = "${dotgithub}/configs/gitignore";
+in
+{
+  programs.git.ignores = lib.optionals (builtins.pathExists f) (
+    lib.filter (l: l != "" && !(lib.hasPrefix "#" l)) (
+      map (lib.removeSuffix "\r") (lib.splitString "\n" (builtins.readFile f))
+    )
+  );
+}

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -23,6 +23,8 @@
     # Disables nix-ai's auto-discovery of locally-cached HF models so the
     # registry stays at the single defaultLocalModelId entry.
     ./mlx-no-autodiscover.nix
+    # Global git excludes seeded from the dryvist org-default (see module).
+    ./git-global-excludes.nix
   ];
 
   # Share system-level Homebrew taps with nix-ai's trust.json.


### PR DESCRIPTION
## Summary

Adds a `dotgithub` flake input (`github:dryvist/.github`, `flake = false`, matching
the existing `ai-assistant-instructions` pattern) and seeds `programs.git.ignores`
from its `configs/gitignore` (the org-default baseline). The list merges with
nix-home's base `programs.git.ignores` and writes to the XDG global excludes file —
a single global hygiene baseline covering every repo on this machine, including
non-dryvist clones a per-repo `.gitignore` can't reach.

### Self-activating — safe to merge independently

Guarded with `builtins.pathExists`: while `configs/gitignore` is absent from the
pinned `.github` input, it evaluates to `[]` (a no-op). Verified:

- Current lock: `programs.git.ignores` → nix-home defaults only.
- With the input advanced (`--override-input`): the org-default entries populate.

After the org-default lands on `.github` main, `nix flake update dotgithub`
activates the entries — no further code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
