### PR TITLE
chore(renovate): remove internal-flakes rule duplicated by org preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -51,8 +51,8 @@
   // Package grouping and scheduling strategy
   //
   // matchPackageNames uses GitHub repo paths (owner/repo), not flake input names.
-  // Internal-flakes rule sits LAST so it overrides minimumReleaseAge for
-  // dryvist/* and JacobPEvans-personal/* — these merge immediately, never wait.
+  // Own-org auto-merge (dryvist/**, JacobPEvans/**, JacobPEvans-personal/**) is
+  // owned by the org preset (local>dryvist/.github) — not redeclared here.
   "packageRules": [
     // GROUP 1: External critical infrastructure (Daily 7am, 2-day delay for nixpkgs cache lag)
     {
@@ -81,22 +81,7 @@
       "schedule": ["after 7am every day"]
     },
 
-    // GROUP 3: Internal flakes — merge instantly. Never wait for releases on
-    // first-party repos. This rule overrides any prior group's minimumReleaseAge.
-    {
-      "description": "Internal JacobPEvans/dryvist flake inputs - merge immediately, no release-age delay",
-      "matchDatasources": ["git-refs"],
-      "matchPackageNames": [
-        "dryvist/**",
-        "JacobPEvans/**",
-        "JacobPEvans-personal/**"
-      ],
-      "groupName": "internal-flakes",
-      "minimumReleaseAge": "0 days",
-      "automerge": true
-    },
-
-    // GROUP 4: GitHub Actions - Weekly Monday 7am
+    // GROUP 3: GitHub Actions - Weekly Monday 7am
     {
       "description": "GitHub Actions updates - weekly at 7am Monday",
       "matchManagers": ["github-actions"],
@@ -104,7 +89,7 @@
       "schedule": ["after 7am on Monday"]
     },
 
-    // GROUP 5: Cribl Edge - Weekly Monday 7am
+    // GROUP 4: Cribl Edge - Weekly Monday 7am
     {
       "description": "Cribl Edge version - weekly at 7am Monday",
       "matchDatasources": ["custom.cribl-edge"],


### PR DESCRIPTION
## What

Removes the local `internal-flakes` packageRule from `renovate.json5`. The org
preset `local>dryvist/.github` (`renovate-presets.json`) already owns an own-org
auto-merge rule (`automerge: true`, `minimumReleaseAge: 0` for `dryvist/**` +
`JacobPEvans/**`), so this repo was carrying a second home for the same policy.

## Why (DRY)

One home for every piece of knowledge. The own-org auto-merge owner list belongs
in the org preset, not duplicated per repo where the two copies drift.

## Coverage note

The preset covered `dryvist/**` and `JacobPEvans/**` but was missing the renamed
`JacobPEvans-personal/**` account. That owner is added to the preset in a
companion `dryvist/.github` PR so the single source of truth is complete. This
repo has **no** `JacobPEvans-personal/*` inputs today, so there is no functional
coverage change here.

Also: refreshed the header comment and re-numbered the remaining GROUP labels.

Verified with `renovate-config-validator`: **Config validated successfully**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)