### PR TITLE
chore(deps): update flake.lock (dotgithub to latest main)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,11 +337,11 @@
     "dotgithub": {
       "flake": false,
       "locked": {
-        "lastModified": 1781793329,
-        "narHash": "sha256-ygO1jMurwtZREDLEGDm6luC3l4gk8xALNw7OU0fl5a4=",
+        "lastModified": 1781799539,
+        "narHash": "sha256-9Vtun24uJaBZb9O9jWd/vRipTL9T7D4JPcPYkcRGiGA=",
         "owner": "dryvist",
         "repo": ".github",
-        "rev": "7950aaa29300a509789cc00dd2363c36de5bc4f0",
+        "rev": "624f92c871f146e486746b3916b0fc62d8262023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

`nix flake update dotgithub` — pulls `dryvist/.github` HEAD into the lock after
the own-org renovate-preset merge (#44).

## Why

Keeps the lock truly latest. `dotgithub` feeds only the org-default `.gitignore`
seed; that content is unchanged, so this is a currency-only pointer bump. Every
other input was already current from the #1258 lock-file maintenance run earlier
today.

System closure builds clean (`nix build .#darwinConfigurations.jevans-mbp.system`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)