### PR TITLE
chore(streamline-login): prune stale login agents

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -213,6 +213,9 @@ in
       removePlists = [
         "com.google.keystone.agent.plist" # Legacy Google Keystone (empty, replaced by GoogleUpdater)
         "com.google.keystone.xpcservice.plist" # Legacy Google Keystone (empty)
+        "com.jacobpevans.orbstack-runner.plist" # Hand-installed `make` runner, superseded by programs.orbstack
+        "com.github.domt4.homebrew-autoupdate.plist" # `brew autoupdate`, contradicts homebrew autoUpdate=false
+        "com.nix-darwin.orbstack-background.plist" # Stale: programs.orbstack.background.enable=false (nix-darwin leaves old plists behind)
       ];
 
       # User-domain services to disable (updaters, redundant apps, broken daemons)


### PR DESCRIPTION
## What

Adds three stale/superseded user LaunchAgents to `programs.streamline-login.removePlists` so they are booted out and removed on every `darwin-rebuild`:

| Plist | Why |
| --- | --- |
| `com.jacobpevans.orbstack-runner` | Hand-installed `make runner-foreground` agent; superseded by the nix-managed `programs.orbstack` integration. |
| `com.github.domt4.homebrew-autoupdate` | Installed by `brew autoupdate`; contradicts `homebrew … autoUpdate = false` in `modules/darwin/homebrew.nix`. |
| `com.nix-darwin.orbstack-background` | Stale leftover: `programs.orbstack.background.enable = false`, but nix-darwin does not garbage-collect plists it no longer declares. |

## Why

Part of a full macOS login-items audit. These three were auto-starting at login with no declarative owner (or contradicting the declared config). The two hand-installed ones were also removed at runtime on the affected host; this PR makes all three removals reproducible and enforced on every rebuild.

## Validation

- `nix fmt`, `statix`, `deadnix`: clean
- `nix eval .#darwinConfigurations.default.config.system.activationScripts.postActivation.text`: confirms all three removal blocks are wired into the activation script
- Full `nix flake check` + macOS `darwin-rebuild switch` enforced by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnaGvmLeT6AYsFF7S5Lv2H