### PR TITLE
fix(python): consume PyYAML-enabled home env

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -122,7 +122,7 @@ On-demand via `nix run nixpkgs#d2` and `nix run nixpkgs#mermaid-cli` — not ins
 | pyright | Static type checker for Python (global: IDEs require it in PATH) |
 | python314 | Python 3.14 (primary runtime) |
 | uv | Fast Python package manager (also runs EOL versions) |
-| python3.withPackages | Unified env: cryptography, pygithub + document-skills deps |
+| python3.withPackages | Unified env: cryptography, pygithub, pyyaml + document-skills deps |
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         "orbstack-kubernetes": "orbstack-kubernetes"
       },
       "locked": {
-        "lastModified": 1781296853,
-        "narHash": "sha256-VzqxpGH6r+9WJ3T3x3cZ/UMjaKO/sUeNt2WSkb/bOVk=",
+        "lastModified": 1781836642,
+        "narHash": "sha256-MY2SFjB5YnB/pf45lazLogjxeQwLpg7V1OO/Adyyl3I=",
         "owner": "dryvist",
         "repo": "nix-home",
-        "rev": "63b5a73fea5bcf87aca2f123e15ee0b26f297f9b",
+        "rev": "a6bdcae8b36d389700d0b4f95786c562c877660a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update `nix-home` to the PyYAML-enabled commit from dryvist/nix-home#300.
- Document PyYAML in the shared Python environment inventory.

## Changes
- Refresh the `nix-home` lock entry to commit `a6bdcae8b36d389700d0b4f95786c562c877660a`.
- Update `MANIFEST.md` so `python3.withPackages` lists `pyyaml` alongside the existing automation/document-skill dependencies.

## Test Plan
- `nix fmt`
- `nix flake check`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); pkgs = import flake.inputs.nixpkgs { system = "aarch64-darwin"; overlays = [ flake.inputs.nix-home.overlays.default ]; config.allowUnfree = true; }; in pkgs.python314Packages.pyyaml.version'` -> `6.0.3`
- `nix build .#lib.ci.hmActivationPackage --no-link`
- `nix path-info -r $(nix build --print-out-paths .#lib.ci.hmActivationPackage --no-link) | rg 'python3\\.14-pyyaml|python3-3\\.14\\.4-env'` -> includes `python3.14-pyyaml-6.0.3`

Refs: dryvist/nix-home#300