### PR TITLE
refactor(apple-silicon-tunables): keep only generic excludes in the default

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -5,7 +5,7 @@
 #
 # This file imports darwin modules and configures host-specific settings.
 
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 let
   # User-specific configuration (hostname, identity, etc.)
@@ -252,6 +252,13 @@ in
     # 2026-06-10 snapshot: swap 94 % with a single healthy 53 GB worker).
     # Still fits the largest model in use (~75 GB resident).
     wiredLimitMb = 0; # OS default (~96 GB on 128 GB); leave headroom for the rest of the system
+    # Set explicitly rather than relying on the module default: a list option
+    # drops its default once any config value is set, so the generic excludes
+    # must be a config def here for a private host layer to append to via merge.
+    timeMachineExcludes = [
+      "${userConfig.user.homeDir}/.cache/uv"
+      config.system.appleSiliconTunables.huggingfaceVolume
+    ];
   };
 
   # --- Energy & Sleep Configuration ---

--- a/modules/darwin/apple-silicon-tunables.nix
+++ b/modules/darwin/apple-silicon-tunables.nix
@@ -1,7 +1,7 @@
 # Apple Silicon System Tunables
 #
 # Boot-time and runtime knobs for Apple Silicon (M-series) hosts that run
-# heavy local AI inference workloads (vllm-mlx, screenpipe, etc.).
+# heavy local AI inference + capture workloads (vllm-mlx, etc.).
 # All knobs target native macOS surfaces (sysctl, pmset, mdutil, tmutil,
 # user defaults) — there is no first-class nix-darwin option for any of them.
 
@@ -46,15 +46,11 @@ in
       type = lib.types.listOf lib.types.str;
       default = [
         "${userConfig.user.homeDir}/.cache/uv"
-        "${userConfig.user.homeDir}/.cache/nix-screenpipe"
-        "${userConfig.user.homeDir}/.screenpipe/data"
         cfg.huggingfaceVolume
       ];
       defaultText = lib.literalExpression ''
         [
           "''${userConfig.user.homeDir}/.cache/uv"
-          "''${userConfig.user.homeDir}/.cache/nix-screenpipe"
-          "''${userConfig.user.homeDir}/.screenpipe/data"
           config.system.appleSiliconTunables.huggingfaceVolume
         ]
       '';


### PR DESCRIPTION
## What

- Drop two private, host-specific app cache/data paths from the `timeMachineExcludes` **module default** (and its `defaultText`), leaving only broadly applicable excludes: the `uv` cache and the HuggingFace volume.
- Set `timeMachineExcludes` **explicitly** in the `macbook-m4` host config. A `listOf` option discards its default the moment any config value is set, so the generic excludes must be a config definition here for a private host layer to *append* its own paths via list-merge instead of replacing them.
- Add `config` to the host module arguments (needed to reference `huggingfaceVolume`).

## Why

The shared module default should only carry excludes that are generic to the host class, not paths specific to one machine's private tooling. Moving them out keeps the public module clean and lets per-host/private layers own their own exclude paths.

## Validation

- `nix fmt`, `statix`, `deadnix`: clean
- `nix eval .#darwinConfigurations.default.config.system.appleSiliconTunables.timeMachineExcludes` → `["/Users/jevans/.cache/uv","/Volumes/HuggingFace"]` (generic excludes preserved via the host config def)
- Full `nix flake check` + macOS `darwin-rebuild` enforced by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnaGvmLeT6AYsFF7S5Lv2H