### PR TITLE
feat(claude): re-inject homelab auto-mode context after nix-ai de-personalization

### DIFF
--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -17,6 +17,10 @@ let
   # Use this for paths in darwin modules where config.home.homeDirectory
   # is not available
   homeDir = "/Users/${username}";
+
+  # GitHub handle / public docs host, reused by the nix-ai agent profile below.
+  fullName = "JacobPEvans";
+  docsHost = "docs.jacobpevans.com";
 in
 {
   # ==========================================================================
@@ -30,13 +34,17 @@ in
     inherit homeDir;
 
     # Full name for git commits and other identity purposes
-    fullName = "JacobPEvans";
+    inherit fullName;
 
     # Primary email (GitHub noreply for privacy)
     # Account renamed JacobPEvans -> JacobPEvans-personal; the noreply email and
     # signing key below must match the renamed account or commits fail signature
     # verification (bad_email). fullName is display-only and does not affect it.
     email = "20714140+JacobPEvans-personal@users.noreply.github.com";
+
+    # Additional GitHub org (besides fullName) trusted in Claude auto-mode.
+    # Consumed by nix-ai's userConfig.user.trustedOrgs.
+    trustedOrgs = [ "dryvist" ];
   };
 
   # ==========================================================================
@@ -172,4 +180,39 @@ in
     # Reference: https://nixos.org/blog/announcements/
     homeManagerStateVersion = "25.11";
   };
+
+  # ==========================================================================
+  # AI Agent Profile (nix-ai)
+  # ==========================================================================
+  # nix-ai ships neutral defaults; this is the consumer-side re-injection of
+  # this machine's homelab context. Consumed by nix-ai's userConfig surface
+  # (modules/maintainer-profile.nix) via extraSpecialArgs in flake.nix.
+
+  # Trusted-infrastructure prose for Claude auto-mode, so routine cross-repo,
+  # cloud, and homelab actions are not flagged as exfiltration.
+  homelab = {
+    enable = true;
+    environmentRules = [
+      "Single-developer personal homelab plus day-job (Splunk/Cribl architect). Public docs map: https://${docsHost} (source github.com/${fullName}/docs) covers Infrastructure, Nix ecosystem, AI development, Observability, Security, and Tools surfaces."
+      "Workspace layout: each repo is a clone on its default branch. Create an isolated worktree for feature work via the AI tool's native mechanism (Claude's EnterWorktree, which lands worktrees under .claude/worktrees/). Never run `git worktree add` into a path inside the repo's working tree — that pollutes the main checkout; place any manual worktree as a sibling of the clone, never a child."
+      "Cloud: AWS via aws-vault profiles (terraform-aws, terraform-aws-bedrock); Proxmox cluster on the home LAN (terraform-proxmox plus ansible-proxmox-*). No multi-tenant production."
+      "Secrets stores: Doppler (ai-ci-automation/prd project carries AI/MCP keys); macOS Keychain (ai-secrets keychain holds ANTHROPIC_API_KEY etc.; elevate-access keychain holds elevated GH tokens via the RESTRICTED/PRIVATE/ADMIN tier system); Mozilla SOPS handles at-rest encryption; Bitwarden vault plus Bitwarden Secrets Manager. No long-lived AWS keys — OIDC handles CI."
+      "AI runtimes: local MLX server on this Mac (mlx-server devenv shell); Claude / Codex / Gemini / Copilot CLIs all routed through local dev shells; HuggingFace CLI handles model management."
+      "Observability stack: OpenTelemetry instrumentation → Cribl Stream → Splunk Enterprise (homelab). splunk-dev devenv shell on local Splunk work."
+      "Self-hosted runners: GitHub Actions self-hosted RunsOn runners labeled per the ${fullName}/.github v3 catalog. Jobs targeting RunsOn labels are routine."
+      "Container deployment: LXC on Proxmox is the default in production homelab workloads. Docker only on vendor-locked images that require it (high-throughput network traffic must never flow through Docker's virtualized networking)."
+      "Nix-first: nix-darwin (macOS), nix-home (cross-platform user env), nix-ai (AI tooling), nix-devenv (reusable dev shells plus flakeModules.dev-hygiene), nix-claude-code (Claude Code declarative module). Flakes-only — never use nix-env."
+      "Pre-commit, linting, format: pre-commit hooks come from nix-devenv.flakeModules.dev-hygiene in Nix repos. zizmor policy from dryvist/.github (trusted publishers: actions/*, DeterminateSystems/*, googleapis/* may use ref-pins; everything else requires hash-pins)."
+    ];
+  };
+
+  # Claude Code OpenTelemetry → local OrbStack k8s OTEL collector. nix-ai
+  # resolves the endpoint port from its registry (nodeports.otel_grpc).
+  telemetry.enable = true;
+
+  # Personal directories Claude Code may read without per-prompt approval.
+  extraTrustedPaths = [ "~/.claude/skills/retrospecting/reports/" ];
+
+  # Workspace roots whose CLAUDE.md external imports are auto-approved.
+  trustedProjectDirs = [ "~/git/public/" ];
 }


### PR DESCRIPTION
## Summary

Companion to **dryvist/nix-ai#987**, which de-personalizes nix-ai: it now ships neutral defaults and reads its maintainer profile from the `userConfig` this flake already passes via `extraSpecialArgs`. Without this change, the next nix-ai bump would silently drop this machine's Claude auto-mode homelab context, OTEL telemetry, and personal trusted paths.

## What changed (`lib/user-config.nix`)

- `user.trustedOrgs = [ "dryvist" ]` — second trusted GitHub org for auto-mode.
- `homelab.{enable,environmentRules}` — the trusted-infrastructure prose (Splunk/Cribl, AWS, Proxmox, secrets stores, runners, …), **relocated here from nix-ai** since it is this machine's context, not a reusable default.
- `telemetry.enable = true` — OTEL endpoint port resolves from nix-ai's registry (`nodeports.otel_grpc`).
- `extraTrustedPaths`, `trustedProjectDirs` — personal Claude trusted paths and workspace roots.

## Verification

Evaluated the real darwin config with the nix-ai branch:

```
nix eval .#darwinConfigurations.default.config.home-manager.users.jevans.programs.claude \
  --override-input nix-ai <nix-ai#987 worktree>
```

→ `autoMode.environment` = 12 rules (2 neutral + 10 homelab), OTEL endpoint `http://localhost:30317`, retrospecting path present, `trustedProjectDirs = [ "~/git/public/" ]`. With nix-ai's defaults (no companion), the same eval is clean.

## Merge order

**Safe to merge now** — the current pinned nix-ai ignores these extra `userConfig` fields, so this is a no-op against today's lock. It just needs to land **before** the Renovate PR that bumps the nix-ai input to include #987; otherwise a gap opens where nix-ai is neutral but this config hasn't re-injected yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)