### PR TITLE
chore(deps): update all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1782338286,
-        "narHash": "sha256-FoOfXbGL4UdNFM+IXN698E+t5iK/XxoxpzT7oKlZMQ0=",
+        "lastModified": 1782423951,
+        "narHash": "sha256-OOnUnRf3D9hGBsitrU5ZGl9buFfy32ikciCDLs9ByFE=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "0bd954331e2dbf76024ac53b0fd997314f653e51",
+        "rev": "f0919a1a7277bf0a1d39374a49dfa0065247f72e",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
     "dotgithub": {
       "flake": false,
       "locked": {
-        "lastModified": 1782316194,
-        "narHash": "sha256-sWm8oDsaUZu24nzougTPLAy8jhGitwYXFXrclFwNEas=",
+        "lastModified": 1782428774,
+        "narHash": "sha256-q9eye6zClR7SYxZwkAQWaiJwIZHZ9+EwZ91YJpWQUmI=",
         "owner": "dryvist",
         "repo": ".github",
-        "rev": "84189516daf460ac399a3ed7195aa64b4b398317",
+        "rev": "c3a0d61731142bcc66386324ed9de972930a9bd5",
         "type": "github"
       },
       "original": {
@@ -1050,22 +1050,6 @@
         "type": "github"
       }
     },
-    "pal-mcp-server": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1765818451,
-        "narHash": "sha256-N10TLndisNT48NVT8OZs7hZFf4D6j8ekPU7RfqwkqY0=",
-        "owner": "BeehiveInnovations",
-        "repo": "pal-mcp-server",
-        "rev": "7afc7c1cc96e23992c8f105f960132c657883bb1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "BeehiveInnovations",
-        "repo": "pal-mcp-server",
-        "type": "github"
-      }
-    },
     "ponytail": {
       "flake": false,
       "locked": {
@@ -1095,7 +1079,6 @@
         "nix-ai": "nix-ai",
         "nix-home": "nix-home",
         "nixpkgs": "nixpkgs_3",
-        "pal-mcp-server": "pal-mcp-server",
         "sops-nix": "sops-nix",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -55,10 +55,6 @@
       url = "github:anthropics/claude-code";
       flake = false;
     };
-    pal-mcp-server = {
-      url = "github:BeehiveInnovations/pal-mcp-server";
-      flake = false;
-    };
     # dryvist org-wide config hub. Source of the org-default .gitignore
     # (configs/gitignore) that seeds the global git excludes file. Tracks
     # main; `nix flake update dotgithub` pulls the latest. The git module
@@ -80,7 +76,6 @@
         home-manager.follows = "home-manager";
         ai-assistant-instructions.follows = "ai-assistant-instructions";
         claude-code-plugins.follows = "claude-code-plugins";
-        pal-mcp-server.follows = "pal-mcp-server";
       };
     };
 


### PR DESCRIPTION
# chore(deps): update all flake inputs

## What

Full end-to-end flake update + rebuild. Net `flake.lock` changes (most inputs were
already current on `main` via Renovate):

- Bump `claude-code-plugins` (`0bd9543` → `f0919a1`)
- Bump `dotgithub` (`8418951` → `c3a0d61`)
- **Remove the `pal-mcp-server` input** and its `nix-ai` `follows` override —
  upstream `nix-ai` dropped its `pal-mcp-server` input, leaving the override
  dangling (`warning: input 'nix-ai' has an override for a non-existent input
  'pal-mcp-server'`). Nothing else in the repo referenced it.

## Verification (local, aarch64-darwin)

- `nix fmt` — 0 changed
- `statix check` — exit 0
- `deadnix` — exit 0
- `nix flake check` — exit 0 (only the inherent `lib` unchecked / `x86_64-linux`
  omitted notices)
- `sudo darwin-rebuild switch --flake .#jevans-mbp` — **EXIT 0**, applied live
  (generation 727), idempotent on re-run.

## Out of scope (pre-existing, not introduced here)

These activation-time warnings appear with the inputs already on `main` and are
upstream/environmental, not fixable in nix-darwin:

- `verify-cache-integrity.sh: Permission denied` — nix-ai ships this Claude
  plugin-cache activation script without an execute bit.
- `~/.claude/settings.json $.attribution.sessionUrl: Additional properties are not
  allowed` — nix-ai/nix-claude-code emits a key the public schemastore schema
  rejects.
- `brew bundle failed` (OneDrive) — mas/cask install needs an admin password; no
  TTY during activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
