### PR TITLE
fix(homebrew): stop managing OneDrive via masApps

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -234,7 +234,10 @@ in
       "Microsoft PowerPoint" = 462062816;
       "Microsoft Outlook" = 985367838;
       "Microsoft OneNote" = 784801555;
-      "OneDrive" = 823766827;
+      # OneDrive (823766827) is intentionally NOT managed via masApps: its
+      # first-time `mas install` needs an admin-password TTY, which is
+      # unavailable during non-interactive `darwin-rebuild switch`
+      # ("sudo: a terminal is required"), failing brew bundle on every rebuild.
     };
   };
 }


### PR DESCRIPTION
## What

OneDrive's first-time `mas install` needs an admin-password TTY, unavailable during non-interactive `darwin-rebuild switch` (`sudo: a terminal is required`), so `brew bundle` failed on every rebuild. Removed from `masApps`; the comment states the generic reason only (no private-instance detail).

## Verified

Integration `darwin-rebuild switch`: no OneDrive in the Brewfile, `brew bundle complete! 31 deps`, activation EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)