### PR TITLE
chore(homebrew): declare mas, drop dead aws/tap

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -58,13 +58,15 @@ in
       # Run `brew upgrade --greedy` manually for updates.
       upgrade = false;
     };
-    taps = [
-      "aws/tap" # AWS SAM CLI and other AWS tools
-    ]
-    ++ agentHomebrewTaps; # AI-tool taps declared in nix-ai/lib/homebrew.nix
+    # AI-tool taps declared in nix-ai/lib/homebrew.nix. The former "aws/tap"
+    # tap was removed — nothing was installed from it (audit 2026-06-30).
+    taps = agentHomebrewTaps;
     brews = [
       # CLI tools (only if not available in nixpkgs)
       "ccusage" # Claude Code usage analyzer - not in nixpkgs
+
+      # Mac App Store CLI — required by homebrew.masApps below.
+      "mas"
       # Apple container CLI/runtime. Homebrew tracks current upstream while
       # nixpkgs lags by a major release.
       "container"


### PR DESCRIPTION
## Context

Audit of Homebrew packages actually installed on the machine vs. what `modules/darwin/homebrew.nix` declares. Because `onActivation.cleanup = "none"`, manually `brew install`-ed packages persist forever and drift away from the declarative config. This reconciles the two.

## Declarative changes (this PR)

- **Declare `mas`** — it backs `homebrew.masApps` but was an undeclared leaf.
- **Remove the dead `aws/tap`** — nothing was installed from it.

## Out-of-band cleanup (done on the machine, not config)

Uninstalled redundant / orphan / dev-shell-covered leaves so `brew leaves` now matches the declared set:

| Leaf | Why removed |
|------|-------------|
| `poppler` | nix-home already ships `poppler-utils` |
| `coreutils` | pulled into nixpkgs derivations as needed |
| `python@3.12` | `python3` resolves to nix; nothing `brew uses` it |
| `libvisio` | dead LibreOffice-formula leftover (libreoffice is now a cask) |
| `azure-cli` | nix-devenv `azure` shell |
| `kubeconform` | nix-devenv `kubernetes` shell |
| `azcopy` | migrated into nix-devenv `azure` shell ([dryvist/nix-devenv#58](https://github.com/dryvist/nix-devenv/pull/58)) |
| `gnu-tar`, `vncsnapshot` | unused |

**Kept:** `sops` — the only local `sops` CLI for editing `secrets/*.yaml` (nix-home doesn't ship one). Revisit later.

## Verification

- `nix flake check` — pass
- `darwin-rebuild switch --flake .` — generation 730, applied
- `brew bundle check` — "dependencies are satisfied"
- `command -v az kubeconform` → gone; `sops`/`mas` → brew; `python3` → nix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
