### PR TITLE
refactor(hosts): parameterize host config via mkHost + registry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,14 +115,9 @@
     }:
     let
       userConfig = import ./lib/user-config.nix;
+      hosts = import ./lib/hosts.nix;
       hmDefaults = import ./lib/home-manager-defaults.nix;
-
-      # Pass external sources to home-manager modules
-      # nix-ai modules get their inputs via _module.args (self-contained)
-      # nix-home modules accept userConfig with sensible defaults
-      extraSpecialArgs = {
-        inherit userConfig dotgithub;
-      };
+      inherit (nixpkgs) lib;
 
       # Guard: fail at eval time if stateVersion drifts from nixpkgs branch.
       # When Renovate bumps nixpkgs-25.11 → nixpkgs-26.05, this assertion fires
@@ -140,19 +135,25 @@
           '';
         true;
 
-      # Define configuration once, assign to multiple names
-      darwinConfig =
+      # Build one darwinSystem per registry entry. `label` is the hosts/<label>/
+      # folder; the resulting config is exposed under `host.hostName` (below).
+      mkHost =
+        label: host:
         assert _stateVersionCheck;
         darwin.lib.darwinSystem {
-          system = "aarch64-darwin";
+          inherit (host) system;
           # Pass nix-ai through so the homebrew module can pull
           # `lib.brewFormulae` (formulae required by per-agent home-manager
           # modules whose preferred install path is brew, e.g. qwen-code).
           # Keeps the agent module self-contained for future flake graduation —
           # see nix-ai/docs/architecture/per-agent-flakes.md.
-          specialArgs = { inherit nix-ai; };
+          # `hostConfig` threads the per-host attrset to every darwin module.
+          specialArgs = {
+            inherit nix-ai;
+            hostConfig = host;
+          };
           modules = [
-            ./hosts/macbook-m4/default.nix
+            ./hosts/${label}/default.nix
 
             # Determinate Nix: official module for nix.conf, GC, and determinate-nixd config
             determinate.darwinModules.default
@@ -169,8 +170,14 @@
             home-manager.darwinModules.home-manager
             {
               home-manager = hmDefaults // {
-                inherit extraSpecialArgs;
-                users.${userConfig.user.name} = import ./hosts/macbook-m4/home.nix;
+                # nix-ai modules get their inputs via _module.args (self-contained);
+                # nix-home modules accept userConfig with sensible defaults.
+                # `hostConfig` threads the per-host attrset to home-manager modules.
+                extraSpecialArgs = {
+                  inherit userConfig dotgithub;
+                  hostConfig = host;
+                };
+                users.${userConfig.user.name} = import ./hosts/${label}/home.nix;
 
                 # Shared modules from external flakes:
                 # - nix-ai: Claude, Gemini, Copilot, MCP servers, marketplace plugins
@@ -188,14 +195,15 @@
             }
           ];
         };
+
+      # Map every registry entry to darwinConfigurations.<hostName>.
+      configs = lib.mapAttrs' (label: host: lib.nameValuePair host.hostName (mkHost label host)) hosts;
     in
     {
-      # Both names point to same config:
-      # - "default" for explicit #default usage
-      # - hostname for auto-detection when # is omitted
-      darwinConfigurations = {
-        default = darwinConfig;
-        ${userConfig.host.name} = darwinConfig;
+      # One entry per host, keyed by hostName so `darwin-rebuild switch --flake .`
+      # host auto-detection resolves it, plus a `default` alias to the primary machine.
+      darwinConfigurations = configs // {
+        default = configs.${hosts.macbook-m4.hostName};
       };
 
       # CI-friendly outputs for GitHub Actions validation
@@ -205,7 +213,7 @@
         ci = {
           inherit (nix-ai.lib.ci) claudeSettingsJson;
           hmActivationPackage =
-            darwinConfig.config.home-manager.users.${userConfig.user.name}.home.activationPackage;
+            configs.${hosts.macbook-m4.hostName}.config.home-manager.users.${userConfig.user.name}.home.activationPackage;
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -198,12 +198,16 @@
 
       # Map every registry entry to darwinConfigurations.<hostName>.
       configs = lib.mapAttrs' (label: host: lib.nameValuePair host.hostName (mkHost label host)) hosts;
+
+      # Resolve the primary host dynamically (the one with `primary = true`) so
+      # flake.nix stays decoupled from specific host labels.
+      primaryHost = lib.head (lib.filter (h: h.primary or false) (lib.attrValues hosts));
     in
     {
       # One entry per host, keyed by hostName so `darwin-rebuild switch --flake .`
       # host auto-detection resolves it, plus a `default` alias to the primary machine.
       darwinConfigurations = configs // {
-        default = configs.${hosts.macbook-m4.hostName};
+        default = configs.${primaryHost.hostName};
       };
 
       # CI-friendly outputs for GitHub Actions validation
@@ -213,7 +217,7 @@
         ci = {
           inherit (nix-ai.lib.ci) claudeSettingsJson;
           hmActivationPackage =
-            configs.${hosts.macbook-m4.hostName}.config.home-manager.users.${userConfig.user.name}.home.activationPackage;
+            configs.${primaryHost.hostName}.config.home-manager.users.${userConfig.user.name}.home.activationPackage;
         };
       };
 

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -5,10 +5,16 @@
 #
 # This file imports darwin modules and configures host-specific settings.
 
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  hostConfig,
+  ...
+}:
 
 let
-  # User-specific configuration (hostname, identity, etc.)
+  # User identity (username, homeDir, etc.). Host-specific values (hostName, LAN
+  # DNS) come from the registry via `hostConfig` (specialArgs).
   userConfig = import ../../lib/user-config.nix;
 in
 {
@@ -23,7 +29,7 @@ in
   # Settings that are unique to this specific machine
   # Hostname from lib/user-config.nix
 
-  networking.hostName = userConfig.host.name;
+  networking.hostName = hostConfig.hostName;
 
   # ==========================================================================
   # System Services
@@ -166,8 +172,8 @@ in
       cpus = 1;
       memory = "1g";
       maxWorkers = 1;
-      dnsServers = userConfig.host.lanDnsServers;
-      dnsSearch = [ userConfig.host.lanSearchDomain ];
+      dnsServers = hostConfig.lanDnsServers;
+      dnsSearch = [ hostConfig.lanSearchDomain ];
       configFiles = {
         "inputs.yml" = ''
           inputs:

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -13,8 +13,8 @@
 }:
 
 let
-  # User identity (username, homeDir, etc.). Host-specific values (hostName, LAN
-  # DNS) come from the registry via `hostConfig` (specialArgs).
+  # User identity (username, homeDir, etc.). Host-specific values (hostName)
+  # come from the registry via `hostConfig` (specialArgs).
   userConfig = import ../../lib/user-config.nix;
 in
 {
@@ -162,8 +162,10 @@ in
     # --- Cribl Stream (local egress aggregator, Apple container) ---
     # Single-instance Cribl Stream in an Apple `container`: local sources ship to
     # 127.0.0.1:10301 and it forwards to the Proxmox Stream tier (haproxy:10300).
-    # Resource-capped (cpus/memory/single worker) and given the LAN DNS resolver +
-    # search domain; the output queue is bounded. See docs/CRIBL-GITOPS.md.
+    # Resource-capped (cpus/memory/single worker); the output queue is bounded.
+    # No explicit container DNS: Apple `container` forwards through the vmnet
+    # gateway to the host resolver, which already resolves the internal FQDN
+    # used in outputs.yml (verified). See docs/CRIBL-GITOPS.md.
     cribl-stream = {
       enable = true;
       user = userConfig.user.name;
@@ -172,8 +174,6 @@ in
       cpus = 1;
       memory = "1g";
       maxWorkers = 1;
-      dnsServers = hostConfig.lanDnsServers;
-      dnsSearch = [ hostConfig.lanSearchDomain ];
       configFiles = {
         "inputs.yml" = ''
           inputs:

--- a/hosts/macbook-m4/services-ai-stack.nix
+++ b/hosts/macbook-m4/services-ai-stack.nix
@@ -5,12 +5,12 @@
 # hardcoded in this repo"); the consumer supplies the value.
 #
 # The value is a non-secret public model name consumed at Nix EVAL time, so it
-# lives committed in lib/user-config.nix alongside every other eval-time
+# lives committed in lib/hosts.nix (per-host) alongside every other eval-time
 # identifier. Keeping it in-tree means evaluation stays pure — no `--impure`,
 # no keychain/env/file sourcing. Change the model via a reviewed commit.
 
-{ userConfig, ... }:
+{ hostConfig, ... }:
 
 {
-  services.aiStack.defaultLocalModelId = userConfig.ai.defaultLocalModelId;
+  services.aiStack.defaultLocalModelId = hostConfig.defaultLocalModelId;
 }

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -1,0 +1,38 @@
+# Per-host registry
+#
+# Pure static data only — NO `config`/`osConfig`/module references (that would
+# create an eval-order dependency). Consumed by flake.nix `mkHost`, which threads
+# each host's attrset to darwin modules via `specialArgs.hostConfig` and to
+# home-manager modules via `extraSpecialArgs.hostConfig`.
+#
+# Keyed by descriptive machine label (also the folder name under hosts/). The
+# darwin configuration is exposed under `hostName` (see flake.nix) so
+# `darwin-rebuild switch --flake .` host auto-detection resolves it.
+#
+# Fields are added here as consumers are wired up (PR-by-PR): `class`,
+# `otelHostName`, `mlx`, `wiredLimitMb`, and `orbstack` land with the PRs that
+# consume them, to avoid data that duplicates a host file without being read.
+{
+  macbook-m4 = {
+    # Network identity
+    hostName = "jevans-mbp";
+    system = "aarch64-darwin";
+
+    # Local MLX physical model id, consumed at Nix eval time by
+    # services.aiStack.defaultLocalModelId (hosts/*/services-ai-stack.nix, shared).
+    # Non-secret public Hugging Face name; committed so evaluation stays pure (no
+    # --impure, no keychain/env/file sourcing). Change via a reviewed commit.
+    # 2026-06-09: switched from mlx-community/Qwen3.6-35B-A3B-mxfp4 — its hybrid
+    # linear-attention architecture (qwen3_5_moe) crashes vllm-mlx whenever two
+    # requests batch (mlx-lm conv_state shape bug; 402 crash-recovery events in
+    # one log window, 0.1-4 tok/s effective). Qwen3-30B-A3B-Instruct-2507 is a
+    # standard-attention MoE (qwen3_moe): benched 80-98 tok/s single-stream,
+    # ~85 tok/s aggregate at 4-way concurrency, zero crashes, hermes tool
+    # calling. See dryvist/nix-ai#915.
+    defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
+
+    # LAN DNS resolver(s) + search domain (match the host resolver). Non-secret.
+    lanDnsServers = [ "10.0.1.1" ];
+    lanSearchDomain = "jacobpevans.com";
+  };
+}

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -18,6 +18,10 @@
     hostName = "jevans-mbp";
     system = "aarch64-darwin";
 
+    # The `primary` host backs the `default` darwinConfigurations alias and the
+    # CI hmActivationPackage output. Exactly one host should set this.
+    primary = true;
+
     # Local MLX physical model id, consumed at Nix eval time by
     # services.aiStack.defaultLocalModelId (hosts/*/services-ai-stack.nix, shared).
     # Non-secret public Hugging Face name; committed so evaluation stays pure (no

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -34,9 +34,5 @@
     # ~85 tok/s aggregate at 4-way concurrency, zero crashes, hermes tool
     # calling. See dryvist/nix-ai#915.
     defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
-
-    # LAN DNS resolver(s) + search domain (match the host resolver). Non-secret.
-    lanDnsServers = [ "10.0.1.1" ];
-    lanSearchDomain = "jacobpevans.com";
   };
 }

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -48,19 +48,6 @@ in
   };
 
   # ==========================================================================
-  # Host Configuration
-  # ==========================================================================
-  host = {
-    # Network hostname (used for networking.hostName, ComputerName, etc.)
-    name = "jevans-mbp";
-
-    # LAN DNS resolver(s) and search domain (match the host resolver). Used to
-    # give containers the same name resolution as the host. Non-secret.
-    lanDnsServers = [ "10.0.1.1" ];
-    lanSearchDomain = "jacobpevans.com";
-  };
-
-  # ==========================================================================
   # GPG Configuration
   # ==========================================================================
   # NOTE: These are PUBLIC key identifiers, NOT private keys.
@@ -149,25 +136,6 @@ in
         keychain = "elevate-access.keychain-db";
       };
     };
-  };
-
-  # ==========================================================================
-  # AI Stack Configuration
-  # ==========================================================================
-  ai = {
-    # Local MLX physical model id consumed at Nix eval time by
-    # services.aiStack.defaultLocalModelId (hosts/macbook-m4/services-ai-stack.nix).
-    # Non-secret — a public Hugging Face model name. Committed here like every
-    # other eval-time identifier so evaluation stays pure (no --impure, no
-    # keychain/env/file sourcing). Change the model via a reviewed commit.
-    # 2026-06-09: switched from mlx-community/Qwen3.6-35B-A3B-mxfp4 — its hybrid
-    # linear-attention architecture (qwen3_5_moe) crashes vllm-mlx whenever two
-    # requests batch (mlx-lm conv_state shape bug; 402 crash-recovery events in
-    # one log window, 0.1-4 tok/s effective). Qwen3-30B-A3B-Instruct-2507 is a
-    # standard-attention MoE (qwen3_moe): benched 80-98 tok/s single-stream,
-    # ~85 tok/s aggregate at 4-way concurrency, zero crashes, hermes tool
-    # calling. See dryvist/nix-ai#915.
-    defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
   };
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

First step of the multi-host parameterization effort — grow nix-darwin from a
single hardcoded host into a registry-driven layer so a second Mac (Mac Studio)
can be added without duplicating config. Mirrors the `home-profile` preset
pattern being introduced in nix-home.

The mkHost/registry refactor is behavior-neutral; it also folds in one
deliberate change — removing a hardcoded LAN DNS resolver IP from the public
repo (see Changes → Security).

## Changes

- **New `lib/hosts.nix`** — per-host registry (pure static data; `macbook-m4`
  only for now). Fields are added as consumers land in later PRs.
- **`flake.nix`** — replace the single `darwinConfig` with a `mkHost label host`
  helper; `lib.mapAttrs'` maps the registry to `darwinConfigurations.<hostName>`
  (so `darwin-rebuild switch --flake .` auto-detection resolves it). `default`
  aliases the primary host's already-built config (no re-eval). `hostConfig` is
  threaded into both darwin `specialArgs` and home-manager `extraSpecialArgs`.
- **Move `host` + `ai.defaultLocalModelId`** out of `lib/user-config.nix` into
  the registry; `user-config.nix` keeps only global identity.
- **Update consumers** to read `hostConfig`: `services-ai-stack.nix` (model id)
  and `default.nix` (`networking.hostName`).
- **Security: drop the hardcoded LAN DNS resolver.** The registry no longer
  carries a resolver IP / search domain, and the cribl-stream container no
  longer sets `--dns` / `--dns-search`. Such a literal must not live in a public
  repo (this was pre-existing on `main` in `user-config.nix`; the refactor only
  relocated it). It is also redundant: Apple `container` forwards DNS through the
  vmnet gateway to the host resolver, which already resolves the internal service
  FQDN used in `outputs.yml` — verified a container with no `--dns` resolves it
  identically. The module options remain (default `[]`) for any future host that
  needs an explicit resolver.

## Test Plan

- The mkHost/registry refactor is closure-neutral in isolation; the DNS-resolver
  removal is a deliberate delta, so the MacBook's built-system `outPath` changes
  from the pre-refactor baseline `jd05n11i…` to `asq4n4x…` — the only difference
  being the removed container `--dns` / `--dns-search` args.
- Verified a cribl-stream container with no `--dns` resolves the internal
  `outputs.yml` FQDN via the host resolver (Apple `container` vmnet DNS
  forwarding).
- `nix flake check` evaluates `darwinConfigurations.default` and `.jevans-mbp` ✅.
- `nix fmt` / `statix` / `deadnix` clean; CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)