### PR TITLE
refactor(hosts): class-driven system defaults + registry hygiene

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,9 @@
         label: host:
         assert _stateVersionCheck;
         darwin.lib.darwinSystem {
-          inherit (host) system;
+          # nix-darwin is Darwin-only and every host is Apple Silicon, so the
+          # registry omits `system`; default it here (overridable for an Intel host).
+          system = host.system or "aarch64-darwin";
           # Pass nix-ai through so the homebrew module can pull
           # `lib.brewFormulae` (formulae required by per-agent home-manager
           # modules whose preferred install path is brew, e.g. qwen-code).

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -53,7 +53,9 @@
   # value still wins. Inlined here rather than a dedicated module: it only
   # consumes `hostConfig` (already in scope) and is a handful of settings.
   # A `workstation` needs nothing — the module defaults already match the laptop.
-  system = lib.mkIf (hostConfig.class == "server") {
+  # `class or "workstation"` tolerates a host that omits it (defaults to the safe
+  # laptop profile) rather than throwing on the missing attr.
+  system = lib.mkIf ((hostConfig.class or "workstation") == "server") {
     energy.wakeOnMagicPacket = lib.mkDefault true; # Wake-on-LAN for a headless box
     networkTuning.enable = lib.mkDefault true; # socket buffers for LAN serving
     appleSiliconTunables.energyMode = lib.mkDefault "unmanaged"; # no High Power Mode on a desktop

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -46,4 +46,16 @@
       };
     };
   };
+
+  # --- Class-driven system defaults ---
+  # `class = "server"` (headless machines) flips a few macOS system knobs away
+  # from the laptop-oriented module defaults. `mkDefault` so an explicit host
+  # value still wins. Inlined here rather than a dedicated module: it only
+  # consumes `hostConfig` (already in scope) and is a handful of settings.
+  # A `workstation` needs nothing — the module defaults already match the laptop.
+  system = lib.mkIf (hostConfig.class == "server") {
+    energy.wakeOnMagicPacket = lib.mkDefault true; # Wake-on-LAN for a headless box
+    networkTuning.enable = lib.mkDefault true; # socket buffers for LAN serving
+    appleSiliconTunables.energyMode = lib.mkDefault "unmanaged"; # no High Power Mode on a desktop
+  };
 }

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -57,11 +57,15 @@
   # TODO: Re-enable when upstream fixes options.json context in manual.nix
   manual.manpages.enable = false;
 
+  # nix-home role preset: `workstation` enables all daily-driver GUI/desktop
+  # features; `server` drops them. Driven by the host's registry `class`.
+  home-profile.preset = hostConfig.class;
+
   # ==========================================================================
   # Monitoring / Observability
   # ==========================================================================
   # Enable monitoring infrastructure (K8s manifests, helper scripts). The OTEL
-  # resource host.name is a per-host label from the registry.
+  # resource host.name is the host's network name (single identity source).
   monitoring = {
     enable = true;
     kubernetes.enable = true;
@@ -71,8 +75,7 @@
       logPrompts = true;
       logToolDetails = true;
       resourceAttributes = {
-        # Fall back to the network hostName if a host omits an explicit OTEL label.
-        "host.name" = hostConfig.otelHostName or hostConfig.hostName;
+        "host.name" = hostConfig.hostName;
       };
     };
     cribl.enable = true;

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -59,7 +59,9 @@
 
   # nix-home role preset: `workstation` enables all daily-driver GUI/desktop
   # features; `server` drops them. Driven by the host's registry `class`.
-  home-profile.preset = hostConfig.class;
+  # `or "workstation"` matches nix-home's own default and tolerates a host that
+  # omits `class` rather than throwing on the missing attr.
+  home-profile.preset = hostConfig.class or "workstation";
 
   # ==========================================================================
   # Monitoring / Observability

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -14,9 +14,13 @@
 # avoid data that duplicates a host file without being read.
 {
   macbook-m4 = {
-    # Network identity
+    # Network identity. `system` is omitted — flake.nix mkHost defaults it to
+    # aarch64-darwin (nix-darwin is Darwin-only; every host is Apple Silicon).
     hostName = "jevans-mbp";
-    system = "aarch64-darwin";
+
+    # Host class drives macOS system defaults (hosts/common/default.nix) and
+    # nix-home's home-profile.preset (hosts/common/home.nix).
+    class = "workstation";
 
     # The `primary` host backs the `default` darwinConfigurations alias and the
     # CI hmActivationPackage output. Exactly one host should set this.
@@ -34,11 +38,6 @@
     # ~85 tok/s aggregate at 4-way concurrency, zero crashes, hermes tool
     # calling. See dryvist/nix-ai#915.
     defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
-
-    # OpenTelemetry resource identifier (monitoring.otel.resourceAttributes).
-    # Kept as an explicit label (not hostName) to preserve existing Splunk/OTEL
-    # correlation for this machine.
-    otelHostName = "macbook-m4";
 
     # Local MLX inference server sizing (programs.mlx). Multi-turn agent clients
     # re-prefill 5-40K-token contexts; the 8192 MB default left no paged-cache

--- a/modules/darwin/apple-silicon-tunables.nix
+++ b/modules/darwin/apple-silicon-tunables.nix
@@ -63,7 +63,6 @@ in
       default = 118000;
       description = ''
         iogpu.wired_limit_mb — wired-memory ceiling for the IOGPU subsystem.
-        iogpu.wired_limit_mb — wired-memory ceiling for the IOGPU subsystem.
         0 = OS default (~75% of RAM). Default 118000 = ~92% of a 128 GB host.
         Volatile: re-applied at every boot via a one-shot launchd daemon.
       '';


### PR DESCRIPTION
## Summary

Introduces a per-host `class` (`workstation` | `server`) in the host registry and
consumes it to drive macOS system defaults and the nix-home role preset — the
groundwork for adding the headless Mac Studio (`jevans-ms`) host next. Also does
registry hygiene the multi-host split exposed.

## Changes

- **`lib/hosts.nix`** — add `class = "workstation"` to `macbook-m4`; remove the
  now-redundant `system` and `otelHostName` fields.
- **`flake.nix` (`mkHost`)** — default `system` to `aarch64-darwin`
  (`host.system or …`), still overridable. nix-darwin is Darwin-only and every
  host is Apple Silicon, so the registry no longer carries `system`.
- **`hosts/common/default.nix`** — class-driven **server** macOS defaults
  (Wake-on-LAN, network tuning, `energyMode = "unmanaged"`) via `mkIf` +
  `mkDefault`, so an explicit host value still wins. `workstation` keeps the
  existing module defaults untouched. Inlined here (it only consumes `hostConfig`,
  already in scope) rather than a dedicated module.
- **`hosts/common/home.nix`** — set nix-home `home-profile.preset` from the class;
  OTEL `host.name` now uses `hostConfig.hostName` directly (drops the
  `otelHostName` fallback).
- **`modules/darwin/apple-silicon-tunables.nix`** — dedup a repeated
  `wiredLimitMb` description line.

## Behavior impact

- **MacBook (`class = workstation`) is closure-neutral** — `nix store
  diff-closures` between `origin/main` and this branch for `jevans-mbp` is
  **empty**.
- **One intended delta:** this MacBook's OTEL `host.name` label changes
  `macbook-m4 → jevans-mbp`. Splunk/OTEL searches keyed on `macbook-m4` should be
  updated to `jevans-mbp`. (Verified via eval; the value lands on a runtime/deploy
  path, not the built store closure, which is why the closure diff stays empty.)

## Test plan

- `nix store diff-closures` (main vs branch, `jevans-mbp`): empty ✅
- `nix build .#darwinConfigurations.jevans-mbp.system`: succeeds ✅
- `nix flake check` (no `--impure`): all checks pass ✅
- Pinned `statix check .` and `deadnix --fail`: clean ✅
- `nix eval` confirms `home-profile.preset = "workstation"` (== nix-home default)
  and OTEL `host.name = "jevans-mbp"` ✅

## Deferred

The nullable `energy.sleep.battery` + conditional `pmset -b` (for a batteryless
server) is **not** in this PR — doing it right requires extracting the energy
activation shell to `scripts/` (per the no-inline-shell convention), a larger
non-neutral refactor. A batteryless server running the default `pmset -b sleep 30`
just logs a harmless WARN; the extraction is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)