### PR TITLE
feat: mac-studio llm-large serving gate, ephemeral GitHub runner, web UI wiring

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -214,6 +214,8 @@ Managed by nix-darwin modules but installed externally (not via nixpkgs or Homeb
 | Service | Source | Description |
 | --- | --- | --- |
 | Cribl Edge | `modules/darwin/apps/cribl-edge.nix` | Log collection agent (installed via .pkg, Nix manages LaunchDaemon + ACLs) |
+| llm-gate (Caddy) | `modules/darwin/llm-gate.nix` | TLS + bearer-token gate fronting the local LLM API and Open WebUI on server hosts (Nix-built Caddy with the route53 DNS-01 plugin; Caddyfile rendered by sops-nix, launchd daemon) |
+| GitHub Actions Runner | `modules/darwin/apps/github-runner-container.nix` | Ephemeral dryvist org runner in an Apple `container` Linux VM (env-driven vendor image `myoung34/github-runner`; PAT via sops `--env-file`) |
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -798,11 +798,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1782999071,
-        "narHash": "sha256-tkFiCtepLkY9A+XDv0DlvQm3YoPYEwitKzFyQCN2ddY=",
+        "lastModified": 1783015227,
+        "narHash": "sha256-64Be0j3TuHPGuUp92XQHHj3KNQAgBiCk3rPR738NdAI=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "bb1932f3c136d4814d8cf42bc1dade4fb682de15",
+        "rev": "999b87402dd6478745e23b3d8be52c936aa08ecc",
         "type": "github"
       },
       "original": {

--- a/hosts/common/services-ai-stack.nix
+++ b/hosts/common/services-ai-stack.nix
@@ -8,9 +8,16 @@
 # lives committed in lib/hosts.nix (per-host) alongside every other eval-time
 # identifier. Keeping it in-tree means evaluation stays pure — no `--impure`,
 # no keychain/env/file sourcing. Change the model via a reviewed commit.
+#
+# roleModelOverrides (optional per-host registry field) pins selected roles to
+# a different physical model — e.g. the Studio's `coding` role on a dedicated
+# coder model — while every other role keeps following defaultLocalModelId.
 
 { hostConfig, ... }:
 
 {
-  services.aiStack.defaultLocalModelId = hostConfig.defaultLocalModelId;
+  services.aiStack = {
+    inherit (hostConfig) defaultLocalModelId;
+    roleOverrides = hostConfig.roleModelOverrides or { };
+  };
 }

--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -6,11 +6,14 @@
 # Shared system config — module imports, networking.hostName, OrbStack, the
 # vllm-mlx Cribl log-shipping pipeline, and server-class macOS defaults
 # (Wake-on-LAN, network tuning, energyMode) — lives in ../common/default.nix.
-# This file adds only the host-unique bits: ComputerName and this machine's
-# headless inference/power tuning.
+# This file adds the host-unique bits: ComputerName, headless inference/power
+# tuning, the llm-large serving gate, and the ephemeral GitHub Actions runner.
 
-{ ... }:
+{ config, ... }:
 
+let
+  userConfig = import ../../lib/user-config.nix;
+in
 {
   imports = [ ../common/default.nix ];
 
@@ -30,6 +33,12 @@
       # 92 % of 128 GB (the module default). Benchmark on-machine.
       wiredLimitMb = 118000;
       # energyMode comes from the server class default ("unmanaged") in ../common.
+
+      # Model cache lives on the internal 4 TB SSD, not the laptop's external
+      # /Volumes/HuggingFace — this keeps the Time Machine exclusion tracking
+      # the real path (the per-folder mdutil call degrades to a logged warn;
+      # Spotlight indexing of ~/.cache is already benign).
+      huggingfaceVolume = "${userConfig.user.homeDir}/.cache/huggingface";
     };
 
     # --- Resource Limits (file descriptors / processes) ---
@@ -40,5 +49,55 @@
     # Always-on: never idle-sleep on AC (module sleep.ac default = 0). Wake-on-LAN,
     # network tuning, and energyMode come from the server class in ../common.
     energy.enable = true;
+
+    # --- Auto-login ---
+    # The MLX stack, Open WebUI, and the gh-runner lifecycle are launchd USER
+    # agents — a headless reboot serves nothing until a session exists. Auto-
+    # login gives that session with zero prompts (enable once via GUI so macOS
+    # writes the kcpassword artifact; FileVault stays off on this host).
+    defaults.loginwindow.autoLoginUser = userConfig.user.name;
+  };
+
+  # ==========================================================================
+  # llm-large Serving Gate (ADR: llm-large-studio-serving)
+  # ==========================================================================
+  # Caddy terminates TLS on the LAN address and enforces the bearer token; the
+  # model server stays on 127.0.0.1. The whole Caddyfile is a sops template
+  # (secrets inline — no wrapper scripts). tlsMode "internal" is the bring-up
+  # stopgap — flip to "route53" once the ACME AWS credentials land in
+  # secrets/llm-large.yaml (phase 3 of the Studio bring-up).
+  programs.llm-gate = {
+    enable = true;
+    domain = "jevans-ms.jacobpevans.com";
+    tlsMode = "internal";
+  };
+
+  # ==========================================================================
+  # GitHub Actions Runner (ephemeral, Apple container)
+  # ==========================================================================
+  # Org-level runner for dryvist in a restricted runner group; jobs arrive by
+  # runner long-poll (no inbound exposure, no webhook endpoint) and every job
+  # executes in a fresh Linux VM. Entirely env-driven vendor image — no
+  # custom scripts; the PAT rides in the sops-rendered env file. (The native
+  # services.github-runners module is unusable here: it hard-asserts
+  # nix.enable, which Determinate Nix keeps false.)
+  programs.github-runner-container = {
+    enable = true;
+    runnerName = "jevans-ms";
+    extraLabels = [
+      "jevans-ms"
+      "apple-container"
+      "mlx"
+    ];
+    # Restricted org runner group scoped to selected repos (created in the
+    # dryvist org settings during bring-up; registration fails safe until then).
+    runnerGroup = "llm-runners";
+    user = userConfig.user.name;
+    # Generous caps: jobs are AI coding/review tasks that mostly wait on the
+    # local LLM endpoint; the VM reservation must still leave the wired-memory
+    # budget to MLX.
+    cpus = 6;
+    memory = "16g";
+    secretsFile = config.sops.templates."github-runner.env".path;
   };
 }

--- a/hosts/mac-studio/home.nix
+++ b/hosts/mac-studio/home.nix
@@ -5,8 +5,17 @@
 # Headless server: no host-specific GUI app list — `home-profile.preset = server`
 # (from the registry class) already drops the GUI/desktop features.
 
-{ ... }:
+{ config, ... }:
 
 {
   imports = [ ../common/home.nix ];
+
+  # Model cache on the internal 4 TB SSD. The laptop's external
+  # /Volumes/HuggingFace assumption (module default) is deliberately not
+  # carried onto the Studio — ADR: llm-large-studio-serving.
+  programs.mlx.huggingFaceHome = "${config.home.homeDirectory}/.cache/huggingface";
+
+  # Manual-query chat UI on loopback; the llm-gate Caddy fronts it with TLS on
+  # the LAN (:8443). Open WebUI keeps its own login, so no bearer on that site.
+  programs.open-webui.enable = true;
 }

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -13,6 +13,7 @@ _:
     ./auto-update-prevention.nix
     ./cribl-edge.nix
     ./cribl-stream.nix
+    ./github-runner-container.nix
     ./orbstack.nix
     ./raycast.nix
     ./streamline-login.nix

--- a/modules/darwin/apps/github-runner-container.nix
+++ b/modules/darwin/apps/github-runner-container.nix
@@ -34,37 +34,36 @@ let
 
   containerBin = "/opt/homebrew/bin/container";
 
-  runArgs =
-    [
-      containerBin
-      "run"
-      "--rm"
-      "--cpus"
-      (toString cfg.cpus)
-      "--memory"
-      cfg.memory
-      "--env"
-      "RUNNER_SCOPE=org"
-      "--env"
-      "ORG_NAME=${cfg.orgName}"
-      "--env"
-      "RUNNER_NAME=${cfg.runnerName}"
-      "--env"
-      "LABELS=${lib.concatStringsSep "," cfg.extraLabels}"
-      "--env"
-      "RUNNER_GROUP=${cfg.runnerGroup}"
-      "--env"
-      "EPHEMERAL=true"
-      "--env"
-      "DISABLE_AUTO_UPDATE=true"
-      # Scrub ACCESS_TOKEN and the config vars above from the runner's
-      # environment after registration, before any workflow code runs.
-      "--env"
-      "UNSET_CONFIG_VARS=true"
-      "--env-file"
-      cfg.secretsFile
-    ]
-    ++ [ cfg.image ]; # image must be the final positional arg
+  runArgs = [
+    containerBin
+    "run"
+    "--rm"
+    "--cpus"
+    (toString cfg.cpus)
+    "--memory"
+    cfg.memory
+    "--env"
+    "RUNNER_SCOPE=org"
+    "--env"
+    "ORG_NAME=${cfg.orgName}"
+    "--env"
+    "RUNNER_NAME=${cfg.runnerName}"
+    "--env"
+    "LABELS=${lib.concatStringsSep "," cfg.extraLabels}"
+    "--env"
+    "RUNNER_GROUP=${cfg.runnerGroup}"
+    "--env"
+    "EPHEMERAL=true"
+    "--env"
+    "DISABLE_AUTO_UPDATE=true"
+    # Scrub ACCESS_TOKEN and the config vars above from the runner's
+    # environment after registration, before any workflow code runs.
+    "--env"
+    "UNSET_CONFIG_VARS=true"
+    "--env-file"
+    cfg.secretsFile
+  ]
+  ++ [ cfg.image ]; # image must be the final positional arg
 in
 {
   options.programs.github-runner-container = {
@@ -145,8 +144,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # List the base dir explicitly so it gets user ownership too (install -d
+    # would create missing parents root-owned).
     system.activationScripts.postActivation.text = ''
-      /usr/bin/install -d -o ${cfg.user} -g ${cfg.group} "${cfg.dataDir}/logs"
+      /usr/bin/install -d -o ${cfg.user} -g ${cfg.group} "${cfg.dataDir}" "${cfg.dataDir}/logs"
     '';
 
     # One-shot: bring up the container runtime/apiserver (idempotent; same

--- a/modules/darwin/apps/github-runner-container.nix
+++ b/modules/darwin/apps/github-runner-container.nix
@@ -1,0 +1,179 @@
+# GitHub Actions Self-Hosted Runner (Apple container)
+#
+# Runs an EPHEMERAL GitHub Actions org runner inside an Apple `container`
+# (v1.0) Linux VM, following the cribl-stream lifecycle pattern: a one-shot
+# runtime agent brings up the per-user container apiserver, and a foreground
+# `container run` under launchd KeepAlive supervises the runner.
+#
+# Script-free by design: the vendor image (myoung34/github-runner) is
+# entirely env-driven — it exchanges the PAT for a registration token,
+# registers, runs one job (EPHEMERAL), deregisters, and exits; KeepAlive
+# then starts a fresh VM for the next job. Non-secret config rides as
+# --env flags declared here; the PAT arrives via --env-file pointing at the
+# sops-rendered github-runner.env (never in the plist or process args), and
+# UNSET_CONFIG_VARS scrubs it from the environment before any workflow code
+# runs.
+#
+# Event flow: the runner long-polls GitHub for jobs — no inbound webhook
+# endpoint, no exposed ports. Every job executes in a brand-new Linux VM.
+#
+# `container` is per-user (talks to the login user's container-apiserver),
+# so these are user agents, not root daemons — the server host runs with
+# auto-login exactly so user agents come up unattended on boot. No --name is
+# set: `--rm` cleans up normally and an anonymous name can never collide
+# after a hard kill, so no pre-start delete step is needed.
+
+{
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.github-runner-container;
+
+  containerBin = "/opt/homebrew/bin/container";
+
+  runArgs =
+    [
+      containerBin
+      "run"
+      "--rm"
+      "--cpus"
+      (toString cfg.cpus)
+      "--memory"
+      cfg.memory
+      "--env"
+      "RUNNER_SCOPE=org"
+      "--env"
+      "ORG_NAME=${cfg.orgName}"
+      "--env"
+      "RUNNER_NAME=${cfg.runnerName}"
+      "--env"
+      "LABELS=${lib.concatStringsSep "," cfg.extraLabels}"
+      "--env"
+      "RUNNER_GROUP=${cfg.runnerGroup}"
+      "--env"
+      "EPHEMERAL=true"
+      "--env"
+      "DISABLE_AUTO_UPDATE=true"
+      # Scrub ACCESS_TOKEN and the config vars above from the runner's
+      # environment after registration, before any workflow code runs.
+      "--env"
+      "UNSET_CONFIG_VARS=true"
+      "--env-file"
+      cfg.secretsFile
+    ]
+    ++ [ cfg.image ]; # image must be the final positional arg
+in
+{
+  options.programs.github-runner-container = {
+    enable = lib.mkEnableOption "Ephemeral GitHub Actions org runner in an Apple container";
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      default = "docker.io/myoung34/github-runner:ubuntu-noble";
+      description = "Env-driven runner OCI image (multi-arch; the vendor entrypoint handles PAT→token exchange, registration, and ephemeral teardown).";
+    };
+
+    orgName = lib.mkOption {
+      type = lib.types.str;
+      default = "dryvist";
+      description = "GitHub organization the runner registers to (RUNNER_SCOPE=org).";
+    };
+
+    runnerName = lib.mkOption {
+      type = lib.types.str;
+      description = "Runner name shown in the org runner list (convention: the host's hostName).";
+    };
+
+    extraLabels = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "apple-container"
+        "mlx"
+      ];
+      description = "Labels beyond the implicit self-hosted/Linux/ARM64 set; route jobs with runs-on.";
+    };
+
+    runnerGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "Default";
+      description = "Org runner group (use a restricted group scoped to selected repos).";
+    };
+
+    cpus = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 4;
+      description = "vCPU cap for the runner VM.";
+    };
+
+    memory = lib.mkOption {
+      type = lib.types.str;
+      default = "8g";
+      description = "Memory allocation for the runner VM (Apple container reserves this for the VM).";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      description = "macOS login user that owns the log dir and runs the lifecycle agents (Apple `container` is per-user).";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "staff";
+      description = "Primary group of the login user (macOS default: staff).";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/gh-runner";
+      description = "Host directory for lifecycle logs.";
+    };
+
+    secretsFile = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        User-readable KEY=value env file containing ACCESS_TOKEN (fine-grained
+        PAT with org self-hosted-runners read/write only), consumed via
+        `container run --env-file`. Use the sops-nix rendered template:
+        config.sops.templates."github-runner.env".path
+      '';
+      example = "/run/secrets/rendered/github-runner.env";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    system.activationScripts.postActivation.text = ''
+      /usr/bin/install -d -o ${cfg.user} -g ${cfg.group} "${cfg.dataDir}/logs"
+    '';
+
+    # One-shot: bring up the container runtime/apiserver (idempotent; same
+    # no-op-after-first-run shape as cribl-stream's runtime agent — duplicate
+    # RunAtLoad one-shots are harmless if both modules are enabled).
+    launchd.user.agents.gh-runner-container-runtime.serviceConfig = {
+      Label = "com.nix-darwin.gh-runner-container-runtime";
+      ProgramArguments = [
+        containerBin
+        "system"
+        "start"
+        "--enable-kernel-install"
+      ];
+      RunAtLoad = true;
+      StandardErrorPath = "${cfg.dataDir}/logs/gh-runner-container-runtime.err.log";
+    };
+
+    # Foreground `container run` supervised by launchd KeepAlive: the VM
+    # exits after one job (EPHEMERAL) and launchd starts the next one.
+    launchd.user.agents.gh-runner.serviceConfig = {
+      Label = "com.nix-darwin.gh-runner";
+      ProgramArguments = runArgs;
+      RunAtLoad = true;
+      KeepAlive = true;
+      ThrottleInterval = 30;
+      StandardOutPath = "${cfg.dataDir}/logs/gh-runner.log";
+      StandardErrorPath = "${cfg.dataDir}/logs/gh-runner.err.log";
+    };
+  };
+}

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -27,6 +27,7 @@ in
     ./trackpad.nix
     ./system-ui.nix
     ./activation-error-tracking.nix
+    ./llm-gate.nix
     ./nix-storage.nix
     ./ws-monitor.nix
     ./apple-silicon-tunables.nix

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -1,0 +1,173 @@
+# llm-large L7 Gate (launchd Caddy)
+#
+# ADR (docs-starlight d/decisions/llm-large-studio-serving.mdx): the model
+# server stays bound to 127.0.0.1; this Caddy front terminates TLS on the
+# host's LAN address and enforces a bearer token (the OpenAI `api_key` field,
+# native in every consumer). It is the only network path to the model port.
+# A second TLS-only site fronts the local Open WebUI (which keeps its own
+# login, so no bearer there).
+#
+# Fully declarative — no wrapper scripts: the ENTIRE Caddyfile is a sops-nix
+# template rendered at activation with the secrets inline (bearer token, LAN
+# bind IP, ACME credentials), root-only 0400 under /run/secrets/rendered/.
+# The launchd daemon execs Caddy directly against that rendered path, so it
+# comes up on boot and survives reboots with zero interactive prompts (hard
+# requirement for the headless server). The bind IP rides inside the
+# encrypted secrets file so no address octets land in this public repo.
+#
+# TLS modes:
+#   route53  — real Let's Encrypt cert via DNS-01 against the public zone,
+#              using the same least-privilege `acme` AWS user Traefik already
+#              uses for *.pve ingress (credentials inline in the tls block).
+#   internal — Caddy's local CA (autonomous, no external dependency); clients
+#              must trust the CA or skip verification. Bring-up stopgap until
+#              the ACME credentials are provisioned.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.llm-gate;
+
+  # caddy-dns/route53 pinned with the FOD hash for this caddy 2.11.4 +
+  # plugin v1.6.2 pair; bump both together when either moves.
+  caddyPkg =
+    if cfg.tlsMode == "route53" then
+      pkgs.caddy.withPlugins {
+        plugins = [ "github.com/caddy-dns/route53@v1.6.2" ];
+        hash = "sha256-tkdqz0sQNlH1zqupggk5VsRul8u1/sGjpeJd9p4TB9E=";
+      }
+    else
+      pkgs.caddy;
+
+  tlsDirective =
+    if cfg.tlsMode == "route53" then
+      ''
+        tls {
+              dns route53 {
+                access_key_id "${config.sops.placeholder."LLM_GATE_AWS_ACCESS_KEY_ID"}"
+                secret_access_key "${config.sops.placeholder."LLM_GATE_AWS_SECRET_ACCESS_KEY"}"
+                region "${config.sops.placeholder."LLM_GATE_AWS_REGION"}"
+              }
+            }''
+    else
+      "tls internal";
+in
+{
+  options.programs.llm-gate = {
+    enable = lib.mkEnableOption "TLS + bearer-token gate (Caddy) in front of the local LLM stack";
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      example = "host.example.com";
+      description = "Public FQDN the gate serves (certificate subject).";
+    };
+
+    tlsMode = lib.mkOption {
+      type = lib.types.enum [
+        "route53"
+        "internal"
+      ];
+      default = "route53";
+      description = "Certificate source: Let's Encrypt DNS-01 via Route53 (needs the ACME AWS credentials in secrets/llm-large.yaml) or Caddy's internal CA (autonomous stopgap).";
+    };
+
+    apiPort = lib.mkOption {
+      type = lib.types.port;
+      default = 11434;
+      description = "Gated OpenAI-compatible API port on the LAN bind address (mirrors the loopback llama-swap port so consumers keep the :11434 convention).";
+    };
+
+    apiUpstreamPort = lib.mkOption {
+      type = lib.types.port;
+      default = 11434;
+      description = "Loopback llama-swap port the API site proxies to.";
+    };
+
+    webUiPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8443;
+      description = "TLS port for the Open WebUI site (no bearer — the UI has its own login).";
+    };
+
+    webUiUpstreamPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Loopback Open WebUI port the UI site proxies to.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/llm-gate";
+      description = "Writable state directory (certificates, Caddy storage, logs).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # The whole Caddyfile is the rendered secret: bearer token, bind IP, and
+    # (route53 mode) ACME credentials are substituted by sops-nix at
+    # activation. {$VAR} env substitution and wrapper scripts are unnecessary.
+    sops.templates."llm-gate.Caddyfile" = {
+      owner = "root";
+      group = "wheel";
+      mode = "0400";
+      content = ''
+        {
+          admin off
+          auto_https disable_redirects
+        }
+
+        https://${cfg.domain}:${toString cfg.apiPort} {
+          bind ${config.sops.placeholder."LLM_GATE_BIND_IP"}
+          ${tlsDirective}
+          @unauthorized not header Authorization "Bearer ${
+            config.sops.placeholder."LLM_LARGE_BEARER_TOKEN"
+          }"
+          respond @unauthorized 401
+          reverse_proxy 127.0.0.1:${toString cfg.apiUpstreamPort}
+        }
+
+        https://${cfg.domain}:${toString cfg.webUiPort} {
+          bind ${config.sops.placeholder."LLM_GATE_BIND_IP"}
+          ${tlsDirective}
+          reverse_proxy 127.0.0.1:${toString cfg.webUiUpstreamPort}
+        }
+      '';
+    };
+
+    system.activationScripts.postActivation.text = ''
+      /usr/bin/install -d -o root -g wheel -m 0700 "${cfg.dataDir}" "${cfg.dataDir}/data" "${cfg.dataDir}/config" "${cfg.dataDir}/logs"
+    '';
+
+    launchd.daemons.llm-gate = {
+      serviceConfig = {
+        Label = "com.nix-darwin.llm-gate";
+        ProgramArguments = [
+          (lib.getExe caddyPkg)
+          "run"
+          "--config"
+          config.sops.templates."llm-gate.Caddyfile".path
+          "--adapter"
+          "caddyfile"
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        ThrottleInterval = 15;
+        UserName = "root";
+        GroupName = "wheel";
+        WorkingDirectory = cfg.dataDir;
+        EnvironmentVariables = {
+          HOME = cfg.dataDir;
+          XDG_DATA_HOME = "${cfg.dataDir}/data";
+          XDG_CONFIG_HOME = "${cfg.dataDir}/config";
+        };
+        StandardOutPath = "${cfg.dataDir}/logs/llm-gate.log";
+        StandardErrorPath = "${cfg.dataDir}/logs/llm-gate.error.log";
+      };
+    };
+  };
+}

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -9,8 +9,17 @@
 # Public key in .sops.yaml                (committed to git)
 # Encrypted secrets in secrets/           (committed to git, safe to be public)
 # Decrypted secrets in /run/secrets/      (ephemeral, root:wheel 0400)
+#
+# Server-class extras: the llm-gate and github-runner secrets exist only on
+# `class = "server"` hosts (the Studio) — the laptop never declares or
+# decrypts them, so its closure and activation are untouched.
 
-{ config, ... }:
+{
+  config,
+  lib,
+  hostConfig,
+  ...
+}:
 
 let
   userConfig = import ../../lib/user-config.nix;
@@ -19,6 +28,14 @@ let
     group = "wheel";
     mode = "0400";
   };
+  # The GitHub runner service registers/runs as the login user, so its PAT
+  # must be readable by that user (services.github-runners tokenFile).
+  userOnly = {
+    owner = userConfig.user.name;
+    group = "staff";
+    mode = "0400";
+  };
+  isServer = (hostConfig.class or "workstation") == "server";
 in
 {
   sops = {
@@ -32,7 +49,7 @@ in
     # Age-only. Disable GPG/SSH fallback to fail fast on misconfiguration.
     gnupg.sshKeyPaths = [ ];
 
-    # Individual secret files — each decrypts to /run/secrets/<name>, root:wheel 0400
+    # Individual secret files — each decrypts to /run/secrets/<name>
     secrets = {
       # Cribl Edge enrollment credentials
       # Source: secrets/cribl-edge.yaml (age-encrypted, committed to git)
@@ -45,16 +62,55 @@ in
       CRIBL_TOKEN = rootOnly // {
         sopsFile = ../../secrets/cribl-edge.yaml;
       };
+    }
+    // lib.optionalAttrs isServer {
+      # llm-gate (Caddy TLS + bearer front) — secrets/llm-large.yaml.
+      # The bind IP lives encrypted here so no address octets sit in the repo.
+      LLM_LARGE_BEARER_TOKEN = rootOnly // {
+        sopsFile = ../../secrets/llm-large.yaml;
+      };
+      LLM_GATE_BIND_IP = rootOnly // {
+        sopsFile = ../../secrets/llm-large.yaml;
+      };
+      LLM_GATE_AWS_ACCESS_KEY_ID = rootOnly // {
+        sopsFile = ../../secrets/llm-large.yaml;
+      };
+      LLM_GATE_AWS_SECRET_ACCESS_KEY = rootOnly // {
+        sopsFile = ../../secrets/llm-large.yaml;
+      };
+      LLM_GATE_AWS_REGION = rootOnly // {
+        sopsFile = ../../secrets/llm-large.yaml;
+      };
+
+      # GitHub Actions runner org PAT (fine-grained: org self-hosted-runners
+      # RW only) — secrets/github-runner.yaml.
+      GH_RUNNER_PAT = userOnly // {
+        sopsFile = ../../secrets/github-runner.yaml;
+      };
     };
 
-    # Rendered template: assembles individual secrets into a single KEY=value file
-    # consumed by the cribl-edge activation script via awk (no shell eval).
-    templates."cribl-edge.env" = rootOnly // {
-      content = ''
-        CRIBL_ORG_ID=${config.sops.placeholder."CRIBL_ORG_ID"}
-        CRIBL_WORKSPACE_ID=${config.sops.placeholder."CRIBL_WORKSPACE_ID"}
-        CRIBL_TOKEN=${config.sops.placeholder."CRIBL_TOKEN"}
-      '';
+    # Rendered templates: assemble individual secrets into complete config
+    # files consumed directly by their services (no wrapper scripts). The
+    # llm-gate Caddyfile template lives in modules/darwin/llm-gate.nix with
+    # the rest of that module's config.
+    templates = {
+      "cribl-edge.env" = rootOnly // {
+        content = ''
+          CRIBL_ORG_ID=${config.sops.placeholder."CRIBL_ORG_ID"}
+          CRIBL_WORKSPACE_ID=${config.sops.placeholder."CRIBL_WORKSPACE_ID"}
+          CRIBL_TOKEN=${config.sops.placeholder."CRIBL_TOKEN"}
+        '';
+      };
+    }
+    // lib.optionalAttrs isServer {
+      # Consumed via `container run --env-file` by the gh-runner agent — the
+      # vendor image's ACCESS_TOKEN input (PAT → registration token exchange
+      # happens inside the image; UNSET_CONFIG_VARS scrubs it before jobs).
+      "github-runner.env" = userOnly // {
+        content = ''
+          ACCESS_TOKEN=${config.sops.placeholder."GH_RUNNER_PAT"}
+        '';
+      };
     };
   };
 }

--- a/secrets/github-runner.yaml
+++ b/secrets/github-runner.yaml
@@ -1,0 +1,16 @@
+GH_RUNNER_PAT: ENC[AES256_GCM,data:MskhdJbyf0ej/Mz8RvpR,iv:oYu9cvmNhqn+T09uWT+556TqU4XddOhs+RjPzfm6s74=,tag:pFuoIxoBKZC3fydGUsjjGg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ0Z0NmgzcFlPWEtpWXB5
+            UENjSm1CaEdzNHA4OFhsdDZScGxrUkJETlJzCkxvbjZpbkEzaFdWazgyZzhLMFRD
+            ZjNpMEp2N1JEUHMxZHdWUVdGd05TbEkKLS0tIEh2cFo2cTBvTC9Cam9yZkdqSWkw
+            c0loaTJvWGZpaXZhbWpKczFuSjY5d1kK3QXaaIMHJdXO9pSA7ws4Iq0vP7vbjNxU
+            UsQowA2H6Dww5etrtPUC66EkPmiDtmLtg9bp4QFRuvhx5lSATG1Kzw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+    lastmodified: "2026-07-02T17:31:37Z"
+    mac: ENC[AES256_GCM,data:RAvLKDk/WNUCs/QxkmOYqd0tuHQjUr3KVosg5vINPgDyeeGGbUdyjd7jEq2LTvffExL28FqBIgXC9C0uULQHGziH4K/Nz04sqJ7QoHVMJv5jW56ZMUJm2VfwiTru70icm8ccI9x0XMVwD86wEzK88ZjBxrSknADvUZplzYJ1NBM=,iv:QFl/oajBNFD0SvTBHXWiol/K7tUUc6AxzYTI7y0SATM=,tag:AAU1/gW8+EXaYdSLQhSRtA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2

--- a/secrets/llm-large.yaml
+++ b/secrets/llm-large.yaml
@@ -1,0 +1,20 @@
+LLM_LARGE_BEARER_TOKEN: ENC[AES256_GCM,data:zzplvybiiVKh2Ann44UtZKerY5IAK6uEO0ijoabATAT6gKCR40XyDSCqu+eWzyycvdqvrFYRBcLLQSRCaUix8w==,iv:rEiUep4YGU7gKL+UhKt4sLS2G4y3AcfWLWVdWWvuFdw=,tag:FoRjAOi6cMcLhI6fYIW+dw==,type:str]
+LLM_GATE_BIND_IP: ENC[AES256_GCM,data:0Thof3Y3GNgNtg==,iv:F9xFLtg1scBvtpriRYZfsNbqOy62WV2ikZOqXnsm/SY=,tag:pnyQ3S4gOiKYHxVh+rXD+Q==,type:str]
+LLM_GATE_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:d97Ir/ysYwXVa3SE4YZg,iv:Q/aXmpEky+Avly+7DeRXLBUTvPGbYDfzt/kZSkvSWgE=,tag:3a9nwj7vRgBvzXsqwbQ0Bg==,type:str]
+LLM_GATE_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:c1c7OgRTq6hQyURu4Raq,iv:i9psgT9ahG2dgXkYwhuJv1hndR7+B8BH0iBBauo5GfU=,tag:9snWI7dB8HBmGbjTPwV9ew==,type:str]
+LLM_GATE_AWS_REGION: ENC[AES256_GCM,data:7xilBKj/JobxByachPLT,iv:Q8Qt5yLlwKSSS8Tyuuh8XA2mPxHj549cfCqlUat3/LA=,tag:NZs1Nxoj18tEIMi1BKXPLA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWQktvcXRscjJnMmc5S1ox
+            MGhadC9xdTBVR2tQNFJGQjdURUE3Ny80S0VzCmFrdkRHSDJyMHNzMnFDWEtNZWda
+            Vlo3Q1c3L012T2RDckFZTlFyaWRaSGMKLS0tIE4wakNVcFZScVI4MDZjNlg4THM2
+            TE1vZFNISUFER2dLY1JlN2MzTGF6ZGsKFor1Q9ThExRY6rwpNbvzS7K2LdideUQ4
+            eJxhMc1e0KEEFWMzAB4VclY5fY5LwSIATr5s0gMNzZadjawvxTyD4w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+    lastmodified: "2026-07-02T17:31:37Z"
+    mac: ENC[AES256_GCM,data:Ezq3Yj0sAGn2PkmuA8AxfQEr9flUS9FgASiYHZbDy3FAgahvJbNRLJp5Cir9nTmv/wCNaRDu9wp390NWl4a8Pqv2RtkbNO8HnrJs4tFSZik2rW5E63URiJasCo6DTo26N653Bu/esvUgk9udo8EpQBuqD/TJMJHnNRoGb5X2J/g=,iv:uc6IyOlziFq14akrRXcewy4iEdF47P3v25JvgmwiS5s=,tag:gICu0DixfAt8ZhgSMNyjkg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2


### PR DESCRIPTION
## Summary

Mac Studio (`jevans-ms`) bring-up wave 2 — everything the 24/7 LLM server needs from nix-darwin, all gated per-host (laptop closure verified **byte-identical**):

- **`modules/darwin/llm-gate.nix`** — launchd root daemon running Nix-built Caddy as the L7 gate from the accepted ADR (`llm-large-studio-serving`): TLS on the LAN address, `Authorization: Bearer` enforced, model server stays on `127.0.0.1`; second TLS-only site fronts Open WebUI (`:8443`). `tlsMode = "route53"` (Let's Encrypt DNS-01, `caddy-dns/route53@v1.6.2` pinned) with `"internal"` as the bring-up stopgap the Studio currently uses.
- **`modules/darwin/apps/github-runner-container.nix`** — ephemeral GitHub Actions **org runner inside an Apple `container` Linux VM** (cribl-stream lifecycle pattern). PAT stays on the host; only a ~1h registration token enters the VM; `--ephemeral` + KeepAlive = fresh VM per job. GitHub-event-driven + scheduled work with zero inbound exposure. Registers to `dryvist`, runner group `llm-runners` (restricted).
- **sops**: server-class-gated secrets (`secrets/llm-large.yaml` — real bearer token + encrypted bind IP; `secrets/github-runner.yaml`) and rendered env templates.
- **hosts/mac-studio**: gate + runner enabled, auto-login (user agents need a session on a headless box), HF cache on the internal 4 TB SSD, `programs.open-webui.enable`.
- **`hosts/common/services-ai-stack.nix`**: `roleModelOverrides` registry passthrough → `services.aiStack.roleOverrides`.

## Dependencies

Draft until dryvist/nix-ai#1082 merges, then the `nix-ai` input bump lands here (`nix flake update nix-ai`) and this leaves draft.

## Verification

- `statix` 0 warnings, `deadnix` at baseline, `shellcheck` clean on all three scripts
- `darwinConfigurations."jevans-ms"` evaluates against nix-ai#1082 via `--override-input`
- `darwinConfigurations."jevans-mbp"` drvPath **byte-identical** to main under the same override — the laptop is untouched
- CI `nix flake check` + `darwin-rebuild` run after the input bump

Part of the Mac Studio 24/7 LLM server bring-up (Linear JAC-155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT