### PR TITLE
feat: mac-studio two-resident models (gpt-oss-120b + Qwen3-Coder-30B), Studio age recipient

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,11 +2,17 @@
 # Age key: ~/.config/sops/age/keys.txt
 # Encrypt: sops --encrypt --in-place <file>
 # Edit: sops <file>
+#
+# Recipients (comma-joined; every machine that must decrypt at activation):
+#   age1y0j... — jevans-mbp (laptop, original keyholder)
+#   age1vpz... — jevans-ms (Mac Studio, generated on-device 2026-07-02)
+# Adding a recipient requires `sops updatekeys secrets/*.yaml` run by an
+# existing keyholder, merged BEFORE the new machine's first darwin-rebuild.
 
 creation_rules:
   - path_regex: ^secrets/.*\.yaml$
-    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"
+    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9,age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna"
   - path_regex: \.sops\.json$
-    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"
+    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9,age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna"
   - path_regex: \.sops\.yaml$
-    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9"
+    age: "age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9,age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna"

--- a/flake.lock
+++ b/flake.lock
@@ -798,11 +798,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783015227,
-        "narHash": "sha256-64Be0j3TuHPGuUp92XQHHj3KNQAgBiCk3rPR738NdAI=",
+        "lastModified": 1783019518,
+        "narHash": "sha256-ZCMyj47p+CGM9rC/QuvBZhlmx1McrjWQDCIok7XiZUE=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "999b87402dd6478745e23b3d8be52c936aa08ecc",
+        "rev": "05a728a7a340d4f9a2fe581ccb54d5f5155e3f27",
         "type": "github"
       },
       "original": {

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -65,16 +65,53 @@
     # defaults (hosts/common/default.nix) and nix-home's server preset.
     class = "server";
 
-    # Same model as the laptop for now. This 128 GB headless box has ample room
-    # for a larger model (more accuracy) — revisit and benchmark on-machine.
-    defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
+    # Two-resident serving pair (selected 2026-07-02; research JAC-155 —
+    # weights measured from HF safetensors, archs verified against config.json,
+    # cross-checked via codex + agy):
+    #   default — gpt-oss-120b MXFP4-Q8: 63.3 GB, model_type gpt_oss (standard
+    #     sliding+full softmax attention — NOT the qwen3_next/qwen3_5_moe
+    #     linear-attention crash class from nix-ai#915), 117B total / 5.1B
+    #     active (best TPS in its capability class), Apache-2.0. Tool calls
+    #     need the harmony parser (vllm-mlx >= 0.4.0, nix-ai#1083).
+    #   coding — Qwen3-Coder-30B-A3B 4-bit: 17.1 GB, qwen3_moe — the exact
+    #     architecture of the previously-resident known-good 30B-A3B-2507.
+    # Combined 80.4 GB weights against the 118 GB wired ceiling leaves ~37 GB
+    # for paged-KV + framework. 8-bit coder (32.4 GB) is the tracked upgrade
+    # if coding fidelity wins over KV headroom after benchmarks.
+    defaultLocalModelId = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+    roleModelOverrides = {
+      coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+    };
 
-    # MLX sizing — MAX from day one; inference is this box's sole purpose (not
-    # "start small"). The 30B-A3B model is ~17 GB resident on 128 GB, so there is
-    # large headroom. Benchmark these UPWARD on the machine.
+    # MLX sizing for TWO resident workers — cacheMemoryMb applies PER worker,
+    # so 2 x 12288 MB caches + 80.4 GB weights ≈ 105 GB, inside the 118 GB
+    # wired ceiling with slack for the proxy/framework. Benchmark these on the
+    # machine (JAC-115) before raising.
     mlx = {
-      cacheMemoryMb = 65536;
+      cacheMemoryMb = 12288;
       prefillBatchSize = 4096;
+      # Keep both backends resident: no swap eviction, both preloaded at boot.
+      proxy.groupSwap = false;
+      preload = [
+        "default"
+        "coding"
+      ];
+      # Parsers differ per backend, so the global parser is off and each
+      # physical model pins its own (harmony needs vllm-mlx >= 0.4.0).
+      # --reasoning-parser is deliberately NOT set for gpt-oss yet: it has
+      # historically conflicted with tool-call parsing in streaming mode —
+      # re-evaluate during the benchmark pass.
+      toolCallParser = null;
+      modelExtraArgs = {
+        "mlx-community/gpt-oss-120b-MXFP4-Q8" = [
+          "--tool-call-parser"
+          "harmony"
+        ];
+        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = [
+          "--tool-call-parser"
+          "qwen3_coder"
+        ];
+      };
     };
 
     # OrbStack stays OFF until the real APFS container id is confirmed on the

--- a/secrets/cribl-edge.yaml
+++ b/secrets/cribl-edge.yaml
@@ -3,15 +3,24 @@ CRIBL_WORKSPACE_ID: ENC[AES256_GCM,data:7SogmQ==,iv:YR2Ss1epxlhUFA04UiiGH0S8Kjs3
 CRIBL_TOKEN: ENC[AES256_GCM,data:0VnVdge6QsweUQiP2+o5iQsEqvV0GJlqe1/b81/hOL0=,iv:9mE+GirBSfyqgE+FKF4BUR3fjGx4uLxKOdNw8qbQavk=,tag:VIIFvqd0HYY/ojEWGJUK8g==,type:str]
 sops:
     age:
-        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJTW9WVnJ2NUwzK2tINVp1
-            MzRqUGIvdjFPbURIdEdaa0lXa3loeVRQQzAwCkNLR3ArQ2p2bGZkcGNLWGxsSHYx
-            NG5wT1QvRndSVHowNjRwaWphYVZmMDgKLS0tIGlGcnUyM1pna3daN1dqS1JpODdH
-            OFBDMGQrdi9LL2ZOOEYrS05VTmZ3Yk0KWJ3x/Qcas6ClrOqyvDnYAfM98dRipGfv
-            jZ0OXm/I3o4upvhOlMPYw/OhpHyHp82ckUxwmuHIr0SVV/+0lDXkxg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5aHdMUWxMNjExOVV2VXpE
+            K0EwM0NDc2FIaGlobWIzeWpWSnhLa0k2alYwCjRkYzRxdlh5WDlDWkdKaThGREwx
+            MENCZHN4a01pNGRHdkRicyt0SVNsMlEKLS0tIEdIY2pwY3lhWi9FTEg2Qk1mMnpX
+            NVEvQ2RsQm9FQk1BY3ROMnlYeE5ReDQKMp9zk6bzgz5cP1xCgdvxVSJFtf//yHq5
+            gfisobPM26MPkuDAX7721YlpkuFTryREvQYUCx6lHe6yWVId9ejh3w==
             -----END AGE ENCRYPTED FILE-----
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGOUQ3aXJiaFk3YU4rVnRK
+            VkVzelFKT0hlMjBRLzBML2tsMThtc28vMDFFCmwrRUY4Zzh3SVpad05RWVF5VUZq
+            cjNGVTVzSUN4ekxkeDFCUVZyQlhDTWsKLS0tIFl2Vzh6N2pZK1ErcEFqWCt3Z2F6
+            T2NZWVRhU09WdkRtZHFscHRzMnJIVEkKPVX1dmmzOpOpZX0ohv1wesaMUzM9iYNZ
+            46AHtK95AzMoMKh/4mrcGDB578NPJPj8cOsiKfm+H5hIGHCbQk2lLA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
     lastmodified: "2026-04-19T13:31:15Z"
     mac: ENC[AES256_GCM,data:40ywrvHE9CEsINgQgg4ASa+3NRHMdj+3soxAPC/RRW+NLsEhFXCFX/Srw5y9RrPVzbWK0TchAECL510guRNT1Ewd0fEOrWK38TX6BJaA2KiedItqxOrl54k1K+ZdnvqW4tiDYz5Ox4gLJMS4n4A6wZVSLHpOlJhhzBmn5SZlTj0=,iv:ZogbB/EsEn5D9ihePu7FkdKCWq1eQfBkzMtohrTCM/E=,tag:3UyYNuEo3QZzAa82GurDvg==,type:str]
     unencrypted_suffix: _unencrypted

--- a/secrets/github-runner.yaml
+++ b/secrets/github-runner.yaml
@@ -3,13 +3,22 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ0Z0NmgzcFlPWEtpWXB5
-            UENjSm1CaEdzNHA4OFhsdDZScGxrUkJETlJzCkxvbjZpbkEzaFdWazgyZzhLMFRD
-            ZjNpMEp2N1JEUHMxZHdWUVdGd05TbEkKLS0tIEh2cFo2cTBvTC9Cam9yZkdqSWkw
-            c0loaTJvWGZpaXZhbWpKczFuSjY5d1kK3QXaaIMHJdXO9pSA7ws4Iq0vP7vbjNxU
-            UsQowA2H6Dww5etrtPUC66EkPmiDtmLtg9bp4QFRuvhx5lSATG1Kzw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzhjT0pER0lKWDM1QnJQ
+            UEg4ZHRHZGlrUWh5TTVUcnFBSzZ3S2ZFWjNNCjA1eGxVVXUrcmR2R0pJUWdHQmFi
+            dXJsUU9oRlZPWitvR0s3bTdNRk1zS1UKLS0tIHZvY0tUTTNtSnE4Sk5odWVsdlB2
+            TlFuR3pERGIzelc4ejFGNld2dWhVaDgKTbV+0XLdTzXbNROR8BoRGAFE+a4o0iig
+            TLymLGqp3YiB/JZlCyOmB831VfWNjNarT9fC+et3jdrCYpPW8YvMqw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4MndDeUlNWjlHUklvdlVF
+            bUxlOGNWZCtUeEhjUmRrLzNQRmRaVjY2dldFCkQrWGV6eENKR1krWU14aTdIaWlJ
+            RXJEY1g4bUxaNm5EYzgwMTNHb3R0ZDgKLS0tIGxXdGU4NENrOVU2QUR0ZHFDRFJu
+            dWZzODliWERyQUc5SUZqYWMxUFBET00KNjYnc2tTeHQGhFKO8vmbxG0LDQrzLwxT
+            Tm0w3CCo5pERkOqYTAP64r2llE26JMWBSizvepvlSa4kS+fKzlG3ww==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
     lastmodified: "2026-07-02T17:31:37Z"
     mac: ENC[AES256_GCM,data:RAvLKDk/WNUCs/QxkmOYqd0tuHQjUr3KVosg5vINPgDyeeGGbUdyjd7jEq2LTvffExL28FqBIgXC9C0uULQHGziH4K/Nz04sqJ7QoHVMJv5jW56ZMUJm2VfwiTru70icm8ccI9x0XMVwD86wEzK88ZjBxrSknADvUZplzYJ1NBM=,iv:QFl/oajBNFD0SvTBHXWiol/K7tUUc6AxzYTI7y0SATM=,tag:AAU1/gW8+EXaYdSLQhSRtA==,type:str]
     unencrypted_suffix: _unencrypted

--- a/secrets/llm-large.yaml
+++ b/secrets/llm-large.yaml
@@ -7,13 +7,22 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWQktvcXRscjJnMmc5S1ox
-            MGhadC9xdTBVR2tQNFJGQjdURUE3Ny80S0VzCmFrdkRHSDJyMHNzMnFDWEtNZWda
-            Vlo3Q1c3L012T2RDckFZTlFyaWRaSGMKLS0tIE4wakNVcFZScVI4MDZjNlg4THM2
-            TE1vZFNISUFER2dLY1JlN2MzTGF6ZGsKFor1Q9ThExRY6rwpNbvzS7K2LdideUQ4
-            eJxhMc1e0KEEFWMzAB4VclY5fY5LwSIATr5s0gMNzZadjawvxTyD4w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFTGJCMEhFcnBqVGl5bTc4
+            azlEaElhTk9xNmJwRDk1dTc0a2RiMVUrQlFFCng5QzFWK0J1eU9XUytOcDgwR0Zl
+            ZEh2V0x1VzcvZGJtYk9SZFZ3SlZYQUkKLS0tIENMdjFwNUo4KzUwdWZTL2R1RmlW
+            aTlaUXA0ZjNrSUpBdkNEWEJvUGpOOHMKGEt30nCsWiufuZIL/bql1oSJRYFLDb1+
+            u49VGV4X0A4neDEroA3wU8RIvbS2p2C1rBM+XzKztuT233cQER83CA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPQkt5YnlYaEk4clNVZnM2
+            WWx0L2MyRjFyRVBOa0NnZktsZjIzcGpZcjBFCnNRYittWjIxcUw3TXA3bm4yb1cw
+            bi9vaGg4TGdPL05zN1k4THRqYXEwOVEKLS0tIFNZUlJUTnNHZGZYU1NOQlhvZEtl
+            dStWa2ErWTZ6ejI0YjQxRmxHTTA2WkUKQVSaXQLZhYgHRTYYl1L+xnxpDKTzBQdp
+            7KvXMCQ0ohJZSZHiug/WJMXdnvEm+gldEEobJQpIYc/FJajljZ/Lwg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
     lastmodified: "2026-07-02T17:31:37Z"
     mac: ENC[AES256_GCM,data:Ezq3Yj0sAGn2PkmuA8AxfQEr9flUS9FgASiYHZbDy3FAgahvJbNRLJp5Cir9nTmv/wCNaRDu9wp390NWl4a8Pqv2RtkbNO8HnrJs4tFSZik2rW5E63URiJasCo6DTo26N653Bu/esvUgk9udo8EpQBuqD/TJMJHnNRoGb5X2J/g=,iv:uc6IyOlziFq14akrRXcewy4iEdF47P3v25JvgmwiS5s=,tag:gICu0DixfAt8ZhgSMNyjkg==,type:str]
     unencrypted_suffix: _unencrypted


### PR DESCRIPTION
## Summary

Phase-3 data for the Studio bring-up (Linear JAC-155) — registry + secrets only, no new modules:

- **lib/hosts.nix (mac-studio)**: flip to the researched two-resident pair — `default` → `mlx-community/gpt-oss-120b-MXFP4-Q8` (63.3 GB, standard-attention MoE, 117B/5.1B active, Apache-2.0), `coding` → `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit` (17.1 GB, same `qwen3_moe` arch as the proven-good current model). Both preloaded and resident (`proxy.groupSwap = false`), `cacheMemoryMb` 12288/worker (2×12288 + 80.4 GB weights ≈ 105 GB inside the 118 GB wired ceiling), per-backend tool-call parsers via `modelExtraArgs` (harmony / qwen3_coder; global parser off). Verified by eval: the rendered role map is exactly `coding` → coder, all other roles → gpt-oss.
- **.sops.yaml**: the Studio's age public key added as second recipient (key generated on-device; private key never left the machine); `sops updatekeys` re-encrypted all secrets. **End-to-end verified**: the Studio decrypted the re-encrypted `llm-large.yaml` with its own key.
- **flake.lock**: nix-ai bump → vllm-mlx 0.4.0 + mlx 0.31.2/mlx-lm 0.31.3 (nix-ai#1083; the old #751 stream-crash hold was empirically cleared on the laptop with 3-way concurrent serving).

Laptop registry entry untouched (its drv changes only via the nix-ai runtime bump, which was smoke-tested there first).

## Verification

- `darwinConfigurations."jevans-ms"` and `."jevans-mbp"` evaluate on the locked inputs (no overrides)
- Role map eval: `{coding: Qwen3-Coder-30B-A3B-Instruct-4bit, default/…: gpt-oss-120b-MXFP4-Q8}`
- Studio-side sops decrypt test passed
- Model research provenance: HF safetensors sizes + config.json archs, cross-checked via codex and agy (Linear JAC-155 comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT