### PR TITLE
feat: HF_TOKEN via sops on server-class hosts (keychain-free real secrets)

### DIFF
--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -132,7 +132,16 @@
         export CONTEXT7_API_KEY=''${CONTEXT7_API_KEY:-"$(_get_keychain_secret 'CONTEXT7_API_KEY' "$_KC_USER")"}
 
         # HuggingFace - for huggingface MCP server and hf CLI (model downloads)
-        export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
+        ${
+          # Server-class hosts are keychain-free for real secrets: HF_TOKEN
+          # comes from the sops-rendered per-machine secret instead (portable
+          # across machines via the committed encrypted file + on-device age
+          # key). Workstations keep the keychain read, byte-identical.
+          if (hostConfig.class or "workstation") == "server" then
+            ''export HF_TOKEN=''${HF_TOKEN:-"$(cat /run/secrets/HF_TOKEN 2>/dev/null || echo "")"}''
+          else
+            ''export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}''
+        }
 
         unset -f _get_keychain_secret  # No longer needed after init
         unset _KC_USER _KC_AI_DB  # _KC_AI_ACCOUNT persists for runtime gh-token switching

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -87,6 +87,15 @@ in
       GH_RUNNER_PAT = userOnly // {
         sopsFile = ../../secrets/github-runner.yaml;
       };
+
+      # Hugging Face token — secrets/hf.yaml. Server-class hosts are
+      # keychain-free for real secrets (portability directive 2026-07-02):
+      # the zsh init reads this rendered path instead of the macOS keychain.
+      # Tier-2 end state is OpenBao (JAC-153); sops is the declarative,
+      # zero-prompt bridge that already rides the per-machine age keys.
+      HF_TOKEN = userOnly // {
+        sopsFile = ../../secrets/hf.yaml;
+      };
     };
 
     # Rendered templates: assemble individual secrets into complete config

--- a/secrets/hf.yaml
+++ b/secrets/hf.yaml
@@ -1,0 +1,25 @@
+HF_TOKEN: ENC[AES256_GCM,data:t8rF9U3G4anyRC19gh/wV/73O+/dWChtqjj5QRTY5boSa3wm2w==,iv:H0F+xXccr7VnZ5dSoyaxuNDc5qaQ9RBBRsHJQ6EYoSY=,tag:1QUGg3aPlAmLl9Z9oSjN+g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzS2dMbXMyTmhjTXU1Mld5
+            Slp2MnR0WVRLck9XY3RBeXlNUmY5TXFuaDNrCkJvN3FpQkJqZFBBcVNSWitSM0RW
+            aHlKa2o1djRJT0Y5LzhHa1dKcGpJRncKLS0tIEdiN2praVBJdXJaeTcwbmU2cmtF
+            WW9FUzRsNXVObzFYZjBCWG9tZkFBaWcK87Rcjl6Dg5Aq4cAjHiJsZa7Fbkk7FM2l
+            UnlPsbl/cJ7u9Agy9E6kyFqU+32+r6Wget3TScDhUOCbtQ5VjltSVQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZUtBa0swdXcrSFE0eEpw
+            WmljWHphZ1dlN0UzVWllcW15dG9TVzdSaFY4ClBsTWJDY1FkeTlsWXNKZFJIZTgz
+            cHhZVUlNRjQrUzUyamNoeEkvb2FtRHcKLS0tIGwxNVE3M0ZaU0pzNzJ0aDZleVdh
+            M0VJaU5SVlBkdjY0MldtL0VLRmVCT1UKhDV6e0NF7aKFXuDE9IVSkOMbzJK1v/B/
+            opHKEejYpMXgH6JL0xxwR6TcsyGbStPPfId8jLi2dLzy+/X2LtWuyg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
+    lastmodified: "2026-07-02T20:58:48Z"
+    mac: ENC[AES256_GCM,data:mIrxciaZv3jJxSZsF3HHXTJehkDynHz0VvHs/6kVtjV1c9W0t++XfNtGE3XTXjaDJ5QWfLxdrSD/NkZ/7kiFmxVF0QTc3bhYoAUeLMB06ifKIZXdDcLGFv9ZjyoUr+ZPBanVsBIee8PxHIdJ+xKhqhsIPWHZ69+uUygyJz7L9wE=,iv:RQI7YXnWNbpoPbix0FloxZ2NiDSrDuEDl5eFZyir6r4=,tag:hpBB9qiMvAYPwW0o+UZ+9w==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2


### PR DESCRIPTION
## Summary

Server-class hosts must not keep real (non-GitHub-tier) secrets in the macOS keychain — not portable across machines (directive 2026-07-02). HF_TOKEN moves to the declarative sops path:

- **`secrets/hf.yaml`** (new) — encrypted to both machine age recipients
- **`modules/darwin/sops.nix`** — `HF_TOKEN` secret, user-owned 0400, server-class-gated
- **`hosts/common/home.nix`** — the zsh init's HF_TOKEN export is class-conditional: servers read `/run/secrets/HF_TOKEN`, workstations keep the keychain read **byte-identically** (laptop drvPath verified equal to pristine main)

Tier-2 end state remains OpenBao (JAC-153); sops is the zero-prompt bridge riding the per-machine age keys already provisioned. Note: the scoped darwin-rebuild NOPASSWD the Studio needs is **already nix-defined** (`modules/darwin/security.nix` → `/etc/sudoers.d/darwin-rebuild`) and lands on first rebuild — no sudoers changes here.

## Verification

- `statix` 0; `darwinConfigurations."jevans-ms"` evaluates on locked inputs
- `darwinConfigurations."jevans-mbp"` drvPath **byte-identical** to pristine main (b8443ad)
- markdownlint n/a (no .md changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT