### PR TITLE
fix: drop the custom /run pre-check that aborts first bootstrap

### DIFF
--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -125,12 +125,12 @@ in
         }
         trap cleanup INT TERM
 
-        # Verify /run is writable (required to update /run/current-system symlink)
-        if [ ! -w /run ]; then
-          echo "❌ ERROR: Cannot write to /run directory" >&2
-          echo "Check permissions and ensure running as root" >&2
-          exit 1
-        fi
+        # NOTE: do NOT pre-check /run here. On a fresh Mac /run does not exist
+        # until upstream nix-darwin's own createRun activation step provisions
+        # it (synthetic.conf + apfs.util, modules/system/base.nix) — a check
+        # this early aborts first bootstrap on brand-new machines (hit on
+        # jevans-ms 2026-07-02). Upstream already fails loudly if /run cannot
+        # be created, so a duplicate guard adds risk and no protection.
       '';
 
       # Runs after all activation scripts, just before symlink update


### PR DESCRIPTION
First `darwin-rebuild` on the brand-new Mac Studio failed with `Cannot write to /run directory` — from **our own** preActivation guard, not from anything vanilla. Upstream nix-darwin's `createRun` step ([modules/system/base.nix](https://github.com/nix-darwin/nix-darwin/blob/master/modules/system/base.nix)) provisions `/run` itself on fresh machines (synthetic.conf + `apfs.util`, with its own clear error path), but our check runs earlier and aborts before upstream gets the chance. Pure duplication that breaks the standard bootstrap; removed with an explanatory comment so it doesn't come back.

Verified: `darwinConfigurations."jevans-ms"` and `."jevans-mbp"` evaluate; statix clean. Behavior change is activation-script-only (no closure content beyond the script text).

Unblocks JAC-155 first activation with zero manual /run steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT