### PR TITLE
fix: first-bootstrap fixes — adopt installer nix.custom.conf; lean server-class (Homebrew/GUI gating)

### DIFF
--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -1,10 +1,14 @@
 {
+  lib,
   pkgs,
+  hostConfig,
   ...
 }:
 
 let
   userConfig = import ../../lib/user-config.nix;
+  # Server-class hosts get no GUI packages — lean by construction.
+  isServer = (hostConfig.class or "workstation") == "server";
 in
 {
   imports = [
@@ -52,39 +56,44 @@ in
   # System packages from nixpkgs
   # All packages should come from nixpkgs - homebrew is fallback only
   # NOTE: User dev tools (bat, ripgrep, jq, etc.) provided by nix-home via home.packages
-  environment.systemPackages = with pkgs; [
-    # ========================================================================
-    # Core CLI tools (bootstrapping - needed before home-manager)
-    # ========================================================================
-    git
-    gnupg
-    vim
+  environment.systemPackages =
+    with pkgs;
+    [
+      # ========================================================================
+      # Core CLI tools (bootstrapping - needed before home-manager)
+      # ========================================================================
+      git
+      gnupg
+      vim
 
-    # ========================================================================
-    # macOS-specific system tools
-    # ========================================================================
-    mas # Mac App Store CLI
-    mactop # Real-time Apple Silicon CPU/GPU/ANE/thermal monitoring
+      # ========================================================================
+      # macOS-specific system tools
+      # ========================================================================
+      mas # Mac App Store CLI
+      mactop # Real-time Apple Silicon CPU/GPU/ANE/thermal monitoring
 
-    # ========================================================================
-    # Network & process tools
-    # ========================================================================
-    ngrep # Network packet grep (useful for debugging)
+      # ========================================================================
+      # Network & process tools
+      # ========================================================================
+      ngrep # Network packet grep (useful for debugging)
 
-    # ========================================================================
-    # Audio libraries (system-level dependencies)
-    # ========================================================================
-    sox # Audio recording, conversion, and effects (Sound eXchange)
-    portaudio # Cross-platform audio I/O library
+      # ========================================================================
+      # Audio libraries (system-level dependencies)
+      # ========================================================================
+      sox # Audio recording, conversion, and effects (Sound eXchange)
+      portaudio # Cross-platform audio I/O library
 
-    # ========================================================================
-    # GUI applications (system-level, in /Applications/Nix Apps/)
-    # ========================================================================
+    ]
+    # ==========================================================================
+    # GUI applications (system-level, in /Applications/Nix Apps/) — workstation
+    # only; a headless server gets none.
+    # ==========================================================================
     # bitwarden-desktop moved to a Homebrew cask (`bitwarden`) — the nixpkgs
     # build pins EOL/insecure electron_39. See modules/darwin/homebrew.nix.
-    raycast # Productivity launcher (replaces Spotlight)
-    swiftbar # Menu bar customization
-  ];
+    ++ lib.optionals (!isServer) [
+      raycast # Productivity launcher (replaces Spotlight)
+      swiftbar # Menu bar customization
+    ];
 
   # --- Homebrew Configuration ---
   # See ./homebrew.nix for casks, brews, and masApps
@@ -92,7 +101,7 @@ in
   # --- Programs Configuration ---
   programs = {
     zsh.enable = true;
-    raycast.enable = true;
+    raycast.enable = !isServer;
   };
 
   documentation.enable = false;

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -28,10 +28,29 @@
   lib,
   pkgs,
   nix-ai,
+  hostConfig,
   ...
 }:
 
 let
+  # Server-class hosts are LEAN BY CONSTRUCTION: the entire workstation
+  # catalog below (GUI casks, Mac App Store apps, desktop AI tools) is
+  # workstation-only. A server's Homebrew surface is exactly the brews in
+  # `serverBrews` — nothing else — and cleanup = "zap" makes activation
+  # actively UNINSTALL anything not declared, so drift cannot accumulate.
+  # (Hit on jevans-ms 2026-07-02: the ungated list installed the laptop's
+  # desktop apps on the headless LLM server.)
+  isServer = (hostConfig.class or "workstation") == "server";
+
+  # The only Homebrew packages a server host needs. Add here ONLY with a
+  # written justification; everything else belongs in nixpkgs or nowhere.
+  serverBrews = [
+    # Apple container CLI/runtime — runs the ephemeral GitHub Actions
+    # runner VM (modules/darwin/apps/github-runner-container.nix).
+    # Homebrew because nixpkgs lags by a major release.
+    "container"
+  ];
+
   # Brew formulae required by per-agent nix-ai modules whose preferred
   # install source is Homebrew (e.g. programs.qwen-code with
   # installVia = "brew"). The list is owned by the agent's module in
@@ -45,6 +64,187 @@ let
   agentHomebrewTaps = nix-ai.lib.homebrewTaps or [ ];
   agentHomebrewCasks = nix-ai.lib.homebrewCasks or [ ];
 
+  workstationBrews = [
+    # CLI tools (only if not available in nixpkgs)
+    "ccusage" # Claude Code usage analyzer - not in nixpkgs
+
+    # Mac App Store CLI — required by homebrew.masApps below.
+    "mas"
+    # Apple container CLI/runtime. Homebrew tracks current upstream while
+    # nixpkgs lags by a major release.
+    "container"
+
+    # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
+
+    # Block Goose AI agent (https://github.com/block/goose)
+    # - Using homebrew as nixpkgs version was >30 days old at time of addition; homebrew actively maintained
+    # - Named 'block-goose-cli' to avoid conflict with nixpkgs 'goose' (database migration tool)
+    "block-goose-cli"
+
+    # Swift native on-device speech recognition (Apple Silicon, requires Xcode build - not in nixpkgs)
+    # Pairs with whisper-cpp + openai-whisper (those are in nix-ai home.packages as Nix derivations)
+    "whisperkit-cli"
+  ]
+  # Append formulae required by nix-ai's per-agent modules. Currently:
+  # qwen-code (Alibaba's CLI agent — see modules/qwen-code in nix-ai).
+  # `lib.unique` deduplicates in case a formula migrates between the
+  # static list above and nix-ai's exported list during a transition
+  # — `brew bundle` is idempotent but the duplicate noise is worth
+  # eliminating at the Nix layer.
+  ++ lib.unique agentBrewFormulae;
+
+  workstationCasks = [
+    # GUI applications (only if not available in nixpkgs)
+    #
+    # TCC NOTE: Homebrew casks install directly to /Applications/ (real copies,
+    # not symlinks to /nix/store), so macOS TCC permissions (camera, mic, screen
+    # recording) persist across darwin-rebuild. This is different from nixpkgs
+    # apps which require copyApps workaround in home-manager.
+    #
+    # greedy = true: required for any app that ships a built-in auto-updater.
+    # Without this flag, `brew upgrade` silently skips the app because Homebrew
+    # assumes the app will update itself. In practice, built-in updaters are
+    # unreliable (require the app to be open, can be dismissed, etc.), so greedy
+    # ensures updates land deterministically when running brew upgrade.
+    # NOTE: ChatGPT and Cursor are in nixpkgs - see home.packages.
+    # NOTE: AI-tool casks (claude-code@latest, antigravity suite) are appended
+    # below from nix-ai.lib.homebrewCasks (source: nix-ai/lib/homebrew.nix).
+
+    # --- Productivity / Communication ---
+    {
+      name = "obsidian";
+      greedy = true;
+    } # Knowledge base / note-taking
+    # Bitwarden desktop password manager. Cask, NOT nixpkgs: the nixpkgs
+    # `bitwarden-desktop` build pins `electron_39`, which is now EOL and
+    # flagged insecure, so `darwin-rebuild` refuses to evaluate it. Bitwarden
+    # upstream still pins electron_39 even on its latest release, so bumping
+    # nixpkgs does not help. This cask is Bitwarden's own signed build
+    # (independent of nixpkgs' from-source electron), so it sidesteps the EOL
+    # flag and stays current via greedy auto-update. Moved here from
+    # modules/darwin/common.nix systemPackages.
+    {
+      name = "bitwarden";
+      greedy = true;
+    } # Password manager desktop app (ex-nixpkgs; EOL electron_39)
+    {
+      name = "wispr-flow";
+      greedy = true;
+    } # AI-powered voice dictation
+    {
+      name = "voiceink";
+      greedy = true;
+    } # Voice-to-text app (local whisper)
+
+    # --- Anthropic ---
+    {
+      name = "claude";
+      greedy = true;
+    } # Claude desktop app (not in nixpkgs for Darwin)
+    # claude-code@latest moved to nix-ai/lib/homebrew.nix
+
+    # --- OpenAI ---
+    # OpenAI Codex CLI (AI coding agent) - migrated from homebrew/core to cask
+    # Moved from nixpkgs to match claude/gemini installation pattern
+    {
+      name = "codex";
+      greedy = true;
+    }
+
+    # --- Local Inference ---
+    # LM Studio: local LLM inference UI + OpenAI-compatible API server
+    {
+      name = "lm-studio";
+      greedy = true;
+    }
+
+    # antigravity suite moved to nix-ai/lib/homebrew.nix
+
+    # --- API Development ---
+    {
+      name = "postman";
+      greedy = true;
+    } # API development environment (moved from nixpkgs — version lag caused schema mismatch)
+
+    # --- OrbStack ---
+    # Installed as a Homebrew cask rather than nixpkgs so that:
+    #   1. TCC permissions (Docker socket, Linux VM) persist across rebuilds
+    #      (nixpkgs installs symlink to /nix/store path which changes on rebuild)
+    #   2. greedy = true keeps it current without relying on its built-in updater
+    # The programs.orbstack module still manages the APFS data volume; only
+    # package.enable is set to false to avoid a conflicting nixpkgs install.
+    {
+      name = "orbstack";
+      greedy = true;
+    }
+
+    # --- Microsoft ---
+    # Teams is only distributed via Homebrew (not available on Mac App Store).
+    {
+      name = "microsoft-teams";
+      greedy = true;
+    }
+    # PowerShell migrated to the nix-devenv `windows` dev shell (stable pwsh
+    # from nixpkgs): `nix develop github:dryvist/nix-devenv?dir=shells/windows`.
+    # Moved off the always-on cask per nix-package-placement (project-scoped
+    # toolchain → nix-devenv). cleanup="none", so the previously-installed
+    # cask is left in place; run `brew uninstall --cask powershell@preview`
+    # to remove it.
+
+    # --- Browsers ---
+    # Firefox is in nixpkgs (firefox-bin) but installs to /nix/store/<hash>
+    # which changes every rebuild — resets macOS TCC grants (camera, mic,
+    # screen recording). Cask installs to stable /Applications/Firefox.app.
+    {
+      name = "firefox";
+      greedy = true;
+    }
+
+    # --- Office Suite (for Claude document-skills) ---
+    # LibreOffice provides the `soffice` CLI that /document-skills:{docx,xlsx,pptx}
+    # use to convert Office docs to PDF. nixpkgs does NOT build libreoffice for
+    # aarch64-darwin, so homebrew is the correct fallback per "nixpkgs first,
+    # then brew" policy. On Linux it ships via nix-home home.packages.
+    {
+      name = "libreoffice";
+      greedy = true;
+    }
+
+    # --- Out-of-band server management ---
+    # Java Web Start replacement for iDRAC6 vKVM .jnlp launches.
+    # iDRAC6 Virtual Console requires NPAPI Java plugin, dropped by all
+    # modern browsers (Chrome 2015, Safari, Firefox, Brave). OpenWebStart
+    # runs the .jnlp file that the iDRAC web UI downloads on "Launch Virtual
+    # Console".
+    {
+      name = "openwebstart";
+      greedy = true;
+    }
+  ]
+  ++ agentHomebrewCasks; # AI-tool casks from nix-ai/lib/homebrew.nix
+
+  # Mac App Store apps (requires signed into App Store)
+  # Find app IDs: mas search <name> or https://github.com/mas-cli/mas
+  # Format: "App Name" = app_id;
+  workstationMasApps = {
+    "Toggl Track" = 1291898086; # Time tracking
+    "Monarch Money Tweaks" = 6753774259; # Personal finance enhancements
+    "Windows App" = 1295203466; # Microsoft Remote Desktop / Windows 365 / AVD client
+    # NOTE: GoPro Quik (561350520) removed - no longer needed
+
+    # Microsoft 365 bundle (https://apps.apple.com/us/app-bundle/microsoft-365/id1450038993)
+    # NOTE: First-time install requires `sudo mas install <id>` due to TTY/sudo constraints
+    # Individual apps from the bundle - replaces any non-App Store versions
+    "Microsoft Word" = 462054704;
+    "Microsoft Excel" = 462058435;
+    "Microsoft PowerPoint" = 462062816;
+    "Microsoft Outlook" = 985367838;
+    "Microsoft OneNote" = 784801555;
+    # OneDrive (823766827) is intentionally NOT managed via masApps: its
+    # first-time `mas install` needs an admin-password TTY, which is
+    # unavailable during non-interactive `darwin-rebuild switch`
+    # ("sudo: a terminal is required"), failing brew bundle on every rebuild.
+  };
 in
 {
   homebrew = {
@@ -53,193 +253,19 @@ in
       # Don't download 45MB index on every rebuild - keeps rebuilds fast and deterministic.
       # Homebrew's passive auto-update still works (triggers on command invocation after >5 minutes).
       autoUpdate = false;
-      cleanup = "none"; # Don't remove manually installed packages
+      # Workstation: "none" — don't remove manually installed packages.
+      # Server: "zap" — the Brewfile is the complete allowed set; activation
+      # uninstalls (and zaps caches/preferences of) anything outside it.
+      cleanup = if isServer then "zap" else "none";
       # Upgrades are not run during darwin-rebuild to keep rebuilds fast.
       # Run `brew upgrade --greedy` manually for updates.
       upgrade = false;
     };
     # AI-tool taps declared in nix-ai/lib/homebrew.nix. The former "aws/tap"
     # tap was removed — nothing was installed from it (audit 2026-06-30).
-    taps = agentHomebrewTaps;
-    brews = [
-      # CLI tools (only if not available in nixpkgs)
-      "ccusage" # Claude Code usage analyzer - not in nixpkgs
-
-      # Mac App Store CLI — required by homebrew.masApps below.
-      "mas"
-      # Apple container CLI/runtime. Homebrew tracks current upstream while
-      # nixpkgs lags by a major release.
-      "container"
-
-      # --- AI Agent Tools (homebrew-only; home-manager cannot manage brew formulas) ---
-
-      # Block Goose AI agent (https://github.com/block/goose)
-      # - Using homebrew as nixpkgs version was >30 days old at time of addition; homebrew actively maintained
-      # - Named 'block-goose-cli' to avoid conflict with nixpkgs 'goose' (database migration tool)
-      "block-goose-cli"
-
-      # Swift native on-device speech recognition (Apple Silicon, requires Xcode build - not in nixpkgs)
-      # Pairs with whisper-cpp + openai-whisper (those are in nix-ai home.packages as Nix derivations)
-      "whisperkit-cli"
-    ]
-    # Append formulae required by nix-ai's per-agent modules. Currently:
-    # qwen-code (Alibaba's CLI agent — see modules/qwen-code in nix-ai).
-    # `lib.unique` deduplicates in case a formula migrates between the
-    # static list above and nix-ai's exported list during a transition
-    # — `brew bundle` is idempotent but the duplicate noise is worth
-    # eliminating at the Nix layer.
-    ++ lib.unique agentBrewFormulae;
-    casks = [
-      # GUI applications (only if not available in nixpkgs)
-      #
-      # TCC NOTE: Homebrew casks install directly to /Applications/ (real copies,
-      # not symlinks to /nix/store), so macOS TCC permissions (camera, mic, screen
-      # recording) persist across darwin-rebuild. This is different from nixpkgs
-      # apps which require copyApps workaround in home-manager.
-      #
-      # greedy = true: required for any app that ships a built-in auto-updater.
-      # Without this flag, `brew upgrade` silently skips the app because Homebrew
-      # assumes the app will update itself. In practice, built-in updaters are
-      # unreliable (require the app to be open, can be dismissed, etc.), so greedy
-      # ensures updates land deterministically when running brew upgrade.
-      # NOTE: ChatGPT and Cursor are in nixpkgs - see home.packages.
-      # NOTE: AI-tool casks (claude-code@latest, antigravity suite) are appended
-      # below from nix-ai.lib.homebrewCasks (source: nix-ai/lib/homebrew.nix).
-
-      # --- Productivity / Communication ---
-      {
-        name = "obsidian";
-        greedy = true;
-      } # Knowledge base / note-taking
-      # Bitwarden desktop password manager. Cask, NOT nixpkgs: the nixpkgs
-      # `bitwarden-desktop` build pins `electron_39`, which is now EOL and
-      # flagged insecure, so `darwin-rebuild` refuses to evaluate it. Bitwarden
-      # upstream still pins electron_39 even on its latest release, so bumping
-      # nixpkgs does not help. This cask is Bitwarden's own signed build
-      # (independent of nixpkgs' from-source electron), so it sidesteps the EOL
-      # flag and stays current via greedy auto-update. Moved here from
-      # modules/darwin/common.nix systemPackages.
-      {
-        name = "bitwarden";
-        greedy = true;
-      } # Password manager desktop app (ex-nixpkgs; EOL electron_39)
-      {
-        name = "wispr-flow";
-        greedy = true;
-      } # AI-powered voice dictation
-      {
-        name = "voiceink";
-        greedy = true;
-      } # Voice-to-text app (local whisper)
-
-      # --- Anthropic ---
-      {
-        name = "claude";
-        greedy = true;
-      } # Claude desktop app (not in nixpkgs for Darwin)
-      # claude-code@latest moved to nix-ai/lib/homebrew.nix
-
-      # --- OpenAI ---
-      # OpenAI Codex CLI (AI coding agent) - migrated from homebrew/core to cask
-      # Moved from nixpkgs to match claude/gemini installation pattern
-      {
-        name = "codex";
-        greedy = true;
-      }
-
-      # --- Local Inference ---
-      # LM Studio: local LLM inference UI + OpenAI-compatible API server
-      {
-        name = "lm-studio";
-        greedy = true;
-      }
-
-      # antigravity suite moved to nix-ai/lib/homebrew.nix
-
-      # --- API Development ---
-      {
-        name = "postman";
-        greedy = true;
-      } # API development environment (moved from nixpkgs — version lag caused schema mismatch)
-
-      # --- OrbStack ---
-      # Installed as a Homebrew cask rather than nixpkgs so that:
-      #   1. TCC permissions (Docker socket, Linux VM) persist across rebuilds
-      #      (nixpkgs installs symlink to /nix/store path which changes on rebuild)
-      #   2. greedy = true keeps it current without relying on its built-in updater
-      # The programs.orbstack module still manages the APFS data volume; only
-      # package.enable is set to false to avoid a conflicting nixpkgs install.
-      {
-        name = "orbstack";
-        greedy = true;
-      }
-
-      # --- Microsoft ---
-      # Teams is only distributed via Homebrew (not available on Mac App Store).
-      {
-        name = "microsoft-teams";
-        greedy = true;
-      }
-      # PowerShell migrated to the nix-devenv `windows` dev shell (stable pwsh
-      # from nixpkgs): `nix develop github:dryvist/nix-devenv?dir=shells/windows`.
-      # Moved off the always-on cask per nix-package-placement (project-scoped
-      # toolchain → nix-devenv). cleanup="none", so the previously-installed
-      # cask is left in place; run `brew uninstall --cask powershell@preview`
-      # to remove it.
-
-      # --- Browsers ---
-      # Firefox is in nixpkgs (firefox-bin) but installs to /nix/store/<hash>
-      # which changes every rebuild — resets macOS TCC grants (camera, mic,
-      # screen recording). Cask installs to stable /Applications/Firefox.app.
-      {
-        name = "firefox";
-        greedy = true;
-      }
-
-      # --- Office Suite (for Claude document-skills) ---
-      # LibreOffice provides the `soffice` CLI that /document-skills:{docx,xlsx,pptx}
-      # use to convert Office docs to PDF. nixpkgs does NOT build libreoffice for
-      # aarch64-darwin, so homebrew is the correct fallback per "nixpkgs first,
-      # then brew" policy. On Linux it ships via nix-home home.packages.
-      {
-        name = "libreoffice";
-        greedy = true;
-      }
-
-      # --- Out-of-band server management ---
-      # Java Web Start replacement for iDRAC6 vKVM .jnlp launches.
-      # iDRAC6 Virtual Console requires NPAPI Java plugin, dropped by all
-      # modern browsers (Chrome 2015, Safari, Firefox, Brave). OpenWebStart
-      # runs the .jnlp file that the iDRAC web UI downloads on "Launch Virtual
-      # Console".
-      {
-        name = "openwebstart";
-        greedy = true;
-      }
-    ]
-    ++ agentHomebrewCasks; # AI-tool casks from nix-ai/lib/homebrew.nix
-
-    # Mac App Store apps (requires signed into App Store)
-    # Find app IDs: mas search <name> or https://github.com/mas-cli/mas
-    # Format: "App Name" = app_id;
-    masApps = {
-      "Toggl Track" = 1291898086; # Time tracking
-      "Monarch Money Tweaks" = 6753774259; # Personal finance enhancements
-      "Windows App" = 1295203466; # Microsoft Remote Desktop / Windows 365 / AVD client
-      # NOTE: GoPro Quik (561350520) removed - no longer needed
-
-      # Microsoft 365 bundle (https://apps.apple.com/us/app-bundle/microsoft-365/id1450038993)
-      # NOTE: First-time install requires `sudo mas install <id>` due to TTY/sudo constraints
-      # Individual apps from the bundle - replaces any non-App Store versions
-      "Microsoft Word" = 462054704;
-      "Microsoft Excel" = 462058435;
-      "Microsoft PowerPoint" = 462062816;
-      "Microsoft Outlook" = 985367838;
-      "Microsoft OneNote" = 784801555;
-      # OneDrive (823766827) is intentionally NOT managed via masApps: its
-      # first-time `mas install` needs an admin-password TTY, which is
-      # unavailable during non-interactive `darwin-rebuild switch`
-      # ("sudo: a terminal is required"), failing brew bundle on every rebuild.
-    };
+    taps = lib.optionals (!isServer) agentHomebrewTaps;
+    brews = if isServer then serverBrews else workstationBrews;
+    casks = lib.optionals (!isServer) workstationCasks;
+    masApps = if isServer then { } else workstationMasApps;
   };
 }

--- a/modules/darwin/nix-storage.nix
+++ b/modules/darwin/nix-storage.nix
@@ -96,6 +96,20 @@ in
   };
 
   # ============================================================================
+  # Adopt the Determinate installer's stock /etc/nix/nix.custom.conf
+  # ============================================================================
+  # On a brand-new machine the Determinate Nix installer writes a stock
+  # nix.custom.conf (two comment lines) that nix-darwin's /etc collision check
+  # does not recognize, aborting the FIRST activation with "Unexpected files
+  # in /etc" (hit on jevans-ms 2026-07-02). Listing the stock file's hash lets
+  # activation adopt and overwrite it automatically — no manual rename step on
+  # fresh installs. If a future installer version changes the stock content,
+  # append its sha256 here (shasum -a 256 /etc/nix/nix.custom.conf).
+  environment.etc."nix/nix.custom.conf".knownSha256Hashes = [
+    "3bd68ef979a42070a44f8d82c205cfd8e8cca425d91253ec2c10a88179bb34aa"
+  ];
+
+  # ============================================================================
   # Home-manager compatibility workaround
   # ============================================================================
   # home-manager's darwin module accesses nix.package even when nix is disabled


### PR DESCRIPTION
Two fixes from the live jevans-ms first activation (paired with #1403):

1. **Adopt the Determinate installer's stock `/etc/nix/nix.custom.conf`** via `knownSha256Hashes` — nix-darwin's /etc collision check aborted first activation; now fresh machines adopt it automatically (no manual rename ever).
2. **Server-class hosts are lean by construction.** The ungated Homebrew catalog installed the laptop's entire desktop set (antigravity, claude desktop, lm-studio, obsidian, firefox, teams, postman…) onto the headless server — caught live and killed mid-install. Server class now gets `brews = ["container"]` ONLY (with written-justification policy), zero casks/taps/masApps, **`cleanup = "zap"`** so activation actively uninstalls anything undeclared (the already-installed junk removes itself on the next rebuild), and no GUI systemPackages (raycast/swiftbar) or programs.raycast.

## Verification
- `darwinConfigurations."jevans-ms"` evaluates; statix 0
- `darwinConfigurations."jevans-mbp"` drvPath **byte-identical** to current main — workstation behavior untouched
- Hardware validation: the branch's first commit already activated successfully on jevans-ms (it got past both prior blockers); this rerun validates the zap cleanup live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT