### PR TITLE
fix(llm-gate): bind all interfaces — drop the bind-IP secret entirely

### DIFF
--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -108,9 +108,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # The whole Caddyfile is the rendered secret: bearer token, bind IP, and
+    # The whole Caddyfile is the rendered secret: the bearer token and
     # (route53 mode) ACME credentials are substituted by sops-nix at
-    # activation. {$VAR} env substitution and wrapper scripts are unnecessary.
+    # activation. No bind directive: Caddy binds all interfaces (identical
+    # exposure to the LAN address on a single-NIC host), which keeps address
+    # octets out of config entirely and survives VLAN/IP moves with zero
+    # secret rotations. {$VAR} env substitution and wrapper scripts are
+    # unnecessary.
     sops.templates."llm-gate.Caddyfile" = {
       owner = "root";
       group = "wheel";
@@ -122,7 +126,6 @@ in
         }
 
         https://${cfg.domain}:${toString cfg.apiPort} {
-          bind ${config.sops.placeholder."LLM_GATE_BIND_IP"}
           ${tlsDirective}
           @unauthorized not header Authorization "Bearer ${
             config.sops.placeholder."LLM_LARGE_BEARER_TOKEN"
@@ -132,7 +135,6 @@ in
         }
 
         https://${cfg.domain}:${toString cfg.webUiPort} {
-          bind ${config.sops.placeholder."LLM_GATE_BIND_IP"}
           ${tlsDirective}
           reverse_proxy 127.0.0.1:${toString cfg.webUiUpstreamPort}
         }

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -65,11 +65,9 @@ in
     }
     // lib.optionalAttrs isServer {
       # llm-gate (Caddy TLS + bearer front) — secrets/llm-large.yaml.
-      # The bind IP lives encrypted here so no address octets sit in the repo.
+      # (The file's legacy LLM_GATE_BIND_IP key is unused: the gate binds all
+      # interfaces, so no address ever needs declaring or rotating.)
       LLM_LARGE_BEARER_TOKEN = rootOnly // {
-        sopsFile = ../../secrets/llm-large.yaml;
-      };
-      LLM_GATE_BIND_IP = rootOnly // {
         sopsFile = ../../secrets/llm-large.yaml;
       };
       LLM_GATE_AWS_ACCESS_KEY_ID = rootOnly // {


### PR DESCRIPTION
Found live on the Studio: the gate crash-looped because the encrypted `LLM_GATE_BIND_IP` carries the future vlan_ai address (10.0.40.10) which the host doesn't hold yet (`bind: can't assign requested address`). On a single-NIC host binding all interfaces (Caddy's default) is identical exposure to binding the LAN address — and it deletes a secret, keeps address octets out of configuration entirely, and survives the upcoming VLAN/IP move with zero rotations. Model server stays loopback-only; the gate is the only network listener by design.

- `darwinConfigurations."jevans-ms"` evaluates; laptop drvPath byte-identical to main; statix 0
- The legacy encrypted key stays in the yaml unused (no plaintext handling to remove it; documented in sops.nix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT