### PR TITLE
fix(mac-studio): disable paged KV cache for gpt-oss-120b

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -798,11 +798,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783023432,
-        "narHash": "sha256-I2sSKJ2tK55pSL9qWvm/uF0010fX5uwowQzZPOe+GHA=",
+        "lastModified": 1783034540,
+        "narHash": "sha256-fBOLe04JX5lCQa5kR1OE92cazaJM8GapqUo7LcuQsxA=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "49f3675cc9c0eff080977d64acab1cde472cd75e",
+        "rev": "0c3a0f74ee3bb675237f1372421a4fc17fa9e1e9",
         "type": "github"
       },
       "original": {

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -112,6 +112,18 @@
           "qwen3_coder"
         ];
       };
+      # vllm-mlx 0.4.0's paged KV cache is incompatible with gpt-oss's
+      # alternating sliding-window attention: generation fails with
+      # "[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be
+      # broadcast" (paged-cache block size vs. prompt length). Prefix caching
+      # requires the paged cache, so both go off for this model only; the
+      # Qwen coder keeps prefix caching, which its agentic workloads reuse.
+      modelFlagOverrides = {
+        "mlx-community/gpt-oss-120b-MXFP4-Q8" = {
+          pagedKvCache = false;
+          enablePrefixCaching = false;
+        };
+      };
     };
 
     # OrbStack stays OFF until the real APFS container id is confirmed on the


### PR DESCRIPTION
## Why

gpt-oss-120b could not generate on the Studio: every completion returned `finish_reason: "error"` with `[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be broadcast` in the vllm-mlx scheduler. Root cause isolated on hardware: vllm-mlx 0.4.0's paged KV cache (block size 64) is incompatible with gpt-oss's alternating sliding-window attention. The identical serve command minus `--use-paged-cache --enable-prefix-cache` generates correctly (19.3 tok/s, continuous batching still on). The Qwen coder is unaffected and keeps prefix caching.

## What

- `lib/hosts.nix` (mac-studio): `mlx.modelFlagOverrides` turns off `pagedKvCache` + `enablePrefixCaching` for `mlx-community/gpt-oss-120b-MXFP4-Q8` only — per-model override, not host-wide.
- `flake.lock`: nix-ai bump to pick up the `modelFlagOverrides` option (dryvist/nix-ai#1090) and the already-merged open-webui fix (dryvist/nix-ai#1088).

## Verification

- `nix eval .#darwinConfigurations.\"jevans-ms\".system.drvPath` green against the bumped lock, byte-identical to the pre-bump override-input eval.
- Laptop closure neutrality of the nix-ai change verified in dryvist/nix-ai#1090.
- On-host A/B: completion fails with the paged-cache flags, succeeds without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT