### PR TITLE
fix(cribl-edge): install standalone config into the edge tree, not cribl

### DIFF
--- a/docs/CRIBL-GITOPS.md
+++ b/docs/CRIBL-GITOPS.md
@@ -9,23 +9,37 @@ why the node is standalone rather than fleet-managed.
   servers). macOS hosts run Cribl Edge in **standalone** mode with
   configuration owned by this repo (`programs.cribl-edge.mode = "standalone"`).
 - Configuration is declarative: `programs.cribl-edge.standalone.configFiles`
-  renders files from the Nix store into `<dataDir>/local/cribl/` on every
+  renders files from the Nix store into `<dataDir>/local/edge/` on every
   `darwin-rebuild switch`.
+
+## The `edge` config tree (load-bearing)
+
+Cribl Edge reads its I/O configuration — `inputs.yml`, `outputs.yml`,
+`pipelines/<name>/conf.yml` — from the **`edge` config tree**: it merges
+`local/edge/` over the package's `default/edge/`. The `cribl` tree
+(`local/cribl/`) is Cribl **Stream's** config location; on an Edge node it
+holds only runtime system files (`auth/`, `cribl.inited`), and any I/O config
+placed there is silently ignored.
+
+This module originally installed its files into `local/cribl/`, and the
+failure mode was invisible: the node ran healthily on the `default/edge/`
+sources (system metrics/state) while the declared file inputs and the Splunk-
+bound output simply did not exist — zero events shipped, zero errors logged.
+When debugging "no events arrive," first confirm the running inputs (worker
+log `input:<id>` channels) match the declared ones.
 
 ## Why standalone + files (the Cribl-supported shape)
 
-Cribl's documented configuration surface is a file tree under
-`$CRIBL_HOME/local/cribl/` — `inputs.yml`, `outputs.yml`,
-`pipelines/<name>/conf.yml`, `pipelines/route.yml` — and Cribl explicitly
-supports bootstrapping nodes from these files
+Cribl's documented configuration surface is a file tree —
 ([Config Files](https://docs.cribl.io/edge/configuration-files/),
-[inputs.yml](https://docs.cribl.io/edge/inputsyml/)). Cribl's GitOps feature
+[inputs.yml](https://docs.cribl.io/edge/inputsyml/)) — and Cribl explicitly
+supports bootstrapping nodes from these files. Cribl's GitOps feature
 ([GitOps](https://docs.cribl.io/stream/gitops/)) is Leader-centric — it
 version-controls a distributed deployment's Leader config — which does not
 apply to a single standalone Edge node. For a single node, version-controlled
 config files deployed by a config-management system (this repo) are the
-supported equivalent. With `CRIBL_VOLUME_DIR` set, the mutable copy of that
-tree lives under the data volume (`/opt/cribl-data/local/cribl/`).
+supported equivalent. With `CRIBL_VOLUME_DIR` set, the mutable copy of the
+tree lives under the data volume (`/opt/cribl-data/local/edge/`).
 
 Cribl reloads local configuration changes without a daemon restart, so
 activation only needs to install the files.
@@ -41,7 +55,7 @@ fleet identity remains recoverable.
 
 Packs still deploy declaratively via `programs.cribl-edge.packs`
 (GitHub-released `.crbl` archives pinned by hash). Standalone config and packs
-compose: instance config under `local/cribl/`, packs under
+compose: instance config under `local/edge/`, packs under
 `default/<pack-name>/`.
 
 ## Where the data goes

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -15,10 +15,12 @@
 #
 #   standalone — GitOps: this module owns the node's configuration. Declarative
 #                config files (standalone.configFiles) are rendered from the
-#                Nix store into <dataDir>/local/cribl/ on every activation —
-#                the config-as-code layout documented by Cribl (inputs.yml,
-#                outputs.yml, pipelines/<name>/conf.yml). Any stale fleet
-#                enrollment state is retired at startup. See docs/CRIBL-GITOPS.md.
+#                Nix store into <dataDir>/local/edge/ on every activation —
+#                the Edge-mode config tree (inputs.yml, outputs.yml,
+#                pipelines/<name>/conf.yml); Edge merges it over default/edge/
+#                and ignores Stream's local/cribl/ tree for I/O config. Any
+#                stale fleet enrollment state is retired at startup. See
+#                docs/CRIBL-GITOPS.md.
 #
 # Secrets are provided via sops-nix (modules/darwin/sops.nix), which decrypts
 # age-encrypted credentials to a root-only (0400) KEY=value file at activation
@@ -57,14 +59,24 @@ let
   };
 
   # Render each declarative standalone config file into the Nix store; the
-  # activation script installs them under <dataDir>/local/cribl/.
+  # activation script installs them under <dataDir>/local/edge/.
+  #
+  # The `edge` tree is load-bearing: Cribl Edge merges default/edge/ with
+  # local/edge/ for its I/O configuration (inputs, outputs, pipelines). This
+  # module originally installed into local/cribl/ — Stream's tree — and Edge
+  # silently ignored it: the node ran only the default/edge/inputs.yml
+  # sources and never shipped a single declared event. On an Edge node,
+  # local/cribl/ holds only runtime system files (auth, cribl.inited). The
+  # install below also removes any copy of each declared file from that
+  # legacy location so stale I/O config can't masquerade as live.
   standaloneConfigInstall = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (relPath: text: ''
       /usr/bin/install -d -o ${cfg.serviceUser} -g ${cfg.serviceGroup} \
-        "$(/usr/bin/dirname "${cfg.dataDir}/local/cribl/${relPath}")"
+        "$(/usr/bin/dirname "${cfg.dataDir}/local/edge/${relPath}")"
       /usr/bin/install -m 0644 -o ${cfg.serviceUser} -g ${cfg.serviceGroup} \
         ${pkgs.writeText (builtins.replaceStrings [ "/" ] [ "-" ] relPath) text} \
-        "${cfg.dataDir}/local/cribl/${relPath}"
+        "${cfg.dataDir}/local/edge/${relPath}"
+      /bin/rm -f "${cfg.dataDir}/local/cribl/${relPath}"
     '') cfg.standalone.configFiles
   );
 in
@@ -115,9 +127,10 @@ in
         default = { };
         description = ''
           Declarative Cribl config files for standalone mode, keyed by path
-          relative to <dataDir>/local/cribl/ (the config-as-code location
-          documented by Cribl). Installed on every activation. Cribl reloads
-          local config changes without a daemon restart.
+          relative to <dataDir>/local/edge/ (the Edge-mode config tree that
+          Cribl Edge merges over default/edge/ — NOT Stream's local/cribl/,
+          which Edge ignores for I/O config). Installed on every activation.
+          Cribl reloads local config changes without a daemon restart.
         '';
         example = lib.literalExpression ''
           {

--- a/modules/darwin/apps/scripts/cribl-edge-start.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-start.sh
@@ -25,7 +25,7 @@
 # Responsibilities (standalone mode):
 #   1. Retire any leftover fleet-enrollment state (moved aside, never
 #      deleted) so the node runs purely from its local config — which the
-#      nix-darwin activation renders into local/cribl/ (GitOps).
+#      nix-darwin activation renders into local/edge/ (GitOps).
 #   2. exec `cribl server`.
 
 set -euo pipefail
@@ -54,7 +54,7 @@ if [ "$CRIBL_MODE" = "standalone" ]; then
       echo "$(ts) [INFO] Standalone mode: retired managed-state file $_f"
     fi
   done
-  echo "$(ts) [INFO] Starting Cribl Edge standalone (config: local/cribl, GitOps-managed)."
+  echo "$(ts) [INFO] Starting Cribl Edge standalone (config: local/edge, GitOps-managed)."
   exec "$CRIBL_HOME/bin/cribl" server
 fi
 


### PR DESCRIPTION
## Why

Not one event has ever reached the Splunk `llm` index from any host — with zero errors anywhere. Root cause: Cribl **Edge** reads its I/O configuration (inputs, outputs, pipelines) from the **edge config tree** (`local/edge/` merged over `default/edge/`). The module installed `standalone.configFiles` into `local/cribl/` — **Stream's** tree — which Edge silently ignores. The node ran healthily on the `default/edge/` sources (system metrics/state), while the declared vllm-mlx file inputs and the HAProxy-bound `cribl_tcp` output simply never existed.

Evidence gathered on the running nodes:
- Worker-log `input:<id>` channels exactly matched `default/edge/inputs.yml` (including `in_system_state`, which our config never declared).
- `local/edge/` did not exist; our rendered files sat unread in `local/cribl/`.
- Splunk `| metadata type=hosts index=llm` returned nothing — the index has existed but never ingested.

## What

- `standaloneConfigInstall` now targets `<dataDir>/local/edge/` and removes each declared file from the legacy `local/cribl/` location so stale I/O config can't masquerade as live.
- Start-script log/comment strings and `docs/CRIBL-GITOPS.md` updated with the edge-vs-cribl tree distinction and a debugging heuristic (verify running `input:` channels against declared inputs).

## Verification

- `nix fmt` / `statix` / `deadnix` / `markdownlint-cli2` clean on touched files.
- `nix eval` green for both darwinConfigurations.
- Post-merge: rebuild both hosts, confirm worker log shows `input:in_llm_logs` + `output:cribl_stream`, then search `index=llm host=jevans-*` in Splunk for live events (will report results in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT