### PR TITLE
fix(mac-studio): disable idle eviction for resident models

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -90,8 +90,17 @@
     mlx = {
       cacheMemoryMb = 12288;
       prefillBatchSize = 4096;
-      # Keep both backends resident: no swap eviction, both preloaded at boot.
-      proxy.groupSwap = false;
+      # Keep both backends resident: no swap eviction, both preloaded at boot,
+      # and no idle eviction anywhere — this host's entire job is holding
+      # these weights, so the workstation rationale for aggressive TTLs
+      # (idle-weight dwell starving the desktop working set) does not apply.
+      # A TTL here would mean the first request after any quiet period pays
+      # the ~60-120 s 120B cold start.
+      proxy = {
+        groupSwap = false;
+        idleTtl = 0;
+      };
+      autoUnloadIdleSeconds = 0;
       preload = [
         "default"
         "coding"


### PR DESCRIPTION
## Why

The Studio's residents were unloading after 15 min idle (llama-swap `ttl: 900`) with a worker-side failsafe at 30 min (`--auto-unload-idle-seconds 1800`). On a dedicated 24/7 serving host that means the first request after any quiet period pays the ~60-120 s gpt-oss-120b cold start — the opposite of the always-warm contract this host exists to provide. The aggressive-TTL rationale is a workstation one (idle weights starving the desktop working set) and does not transfer.

## What

`lib/hosts.nix` (mac-studio only): `mlx.proxy.idleTtl = 0` (nix-ai's documented never-unload escape hatch) and `mlx.autoUnloadIdleSeconds = 0` (omits the worker flag). The laptop keeps its eviction defaults.

## Verification

- `nix fmt` / `statix` / `deadnix` clean; `nix eval` green for jevans-ms.
- Post-merge rebuild + reboot test on the Studio will confirm both models stay resident (report in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT