### PR TITLE
fix(cribl-edge): valid file-input schema, tcpjson transport, config-before-launchd ordering

### DIFF
--- a/docs/CRIBL-GITOPS.md
+++ b/docs/CRIBL-GITOPS.md
@@ -41,8 +41,10 @@ config files deployed by a config-management system (this repo) are the
 supported equivalent. With `CRIBL_VOLUME_DIR` set, the mutable copy of the
 tree lives under the data volume (`/opt/cribl-data/local/edge/`).
 
-Cribl reloads local configuration changes without a daemon restart, so
-activation only needs to install the files.
+Cribl reads these files only at startup — it does NOT hot-reload config
+written outside its own API (verified empirically). The module therefore
+installs them in `extraActivation`, which runs before nix-darwin's launchd
+phase, so any daemon (re)start always sees current config.
 
 ## Managed-mode remnants
 
@@ -60,6 +62,12 @@ compose: instance config under `local/edge/`, packs under
 
 ## Where the data goes
 
-Inline sources on this host ship over Cribl TCP (S2S) to the HAProxy-fronted
-Cribl Stream workers (port: `service_ports.cribl_s2s` in terraform-proxmox
-constants), which forward to Splunk. Index/sourcetype are stamped at the Edge.
+Inline sources on this host ship over TCP JSON to the HAProxy-fronted Cribl
+Stream workers, which forward to Splunk. Index/sourcetype are stamped at the
+Edge. TCP JSON, not Cribl TCP: the `cribl_tcp` destination is refused on a
+standalone node ("Destination is not allowed in this deployment" — it
+requires a distributed deployment) and TCP JSON is Cribl's documented
+single-instance substitute. The receiving side (contracts port
+`cribl_tcpjson`, HAProxy frontend, Stream `tcpjson` source) is tracked in
+ansible-proxmox-apps#525; until it lands, the Edge persistent queue buffers
+events locally and flushes when the port comes up.

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -60,24 +60,37 @@ in
     # Log collection agent, standalone + GitOps-managed. Shared by every host
     # that declares `mlx` (a local LLM box): the vllm-mlx log paths derive from
     # the global userConfig homeDir, so the config is identical across machines.
-    # Events ship over Cribl TCP to the HAProxy-fronted Stream workers (port from
-    # terraform-proxmox constants service_ports.cribl_s2s) which forward to the
-    # Splunk `llm` index. See docs/CRIBL-GITOPS.md.
+    # Events ship over TCP JSON to the HAProxy-fronted Stream workers, which
+    # forward to the Splunk `llm` index. TCP JSON — not Cribl TCP: the
+    # cribl_tcp destination is refused on a standalone node ("Destination is
+    # not allowed in this deployment"; it requires a distributed deployment),
+    # and TCP JSON is Cribl's documented single-instance substitute. Until the
+    # Stream fleet exposes the matching tcpjson source behind HAProxy
+    # (ansible-proxmox-apps#525), the persistent queue buffers events locally
+    # and flushes when the port comes up. See docs/CRIBL-GITOPS.md.
     # NOTE: the local-Stream cutover (→127.0.0.1:10301) is reverted while the
     # containerized Stream's CPU/DNS issue is fixed — see cribl-stream below.
     cribl-edge = lib.mkIf (hostConfig ? mlx) {
       enable = true;
       mode = "standalone";
       standalone.configFiles = {
+        # File source schema (Edge 4.18): manual mode requires `path` (a
+        # directory) + `filenames` (glob allowlist) — a bare `filenames` list
+        # fails validation ("should have required property 'path'") and takes
+        # the whole config load down with it. Shape mirrors the stock
+        # in_file_varlog entry in default/edge/inputs.yml.
         "inputs.yml" = ''
           inputs:
             in_llm_logs:
               type: file
               disabled: false
               mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
               filenames:
-                - ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/vllm-mlx.log
-                - ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/vllm-mlx.error.log
+                - vllm-mlx.log
+                - vllm-mlx.error.log
+              tailOnly: false
               sendToRoutes: false
               connections:
                 - pipeline: llm_logs
@@ -93,10 +106,12 @@ in
         "outputs.yml" = ''
           outputs:
             cribl_stream:
-              type: cribl_tcp
+              type: tcpjson
               # Homelab HAProxy (FQDN), load-balanced across the Cribl Stream workers.
+              # Port pending in homelab-contracts service-ports (cribl_tcpjson) +
+              # HAProxy frontend + Stream tcpjson source: ansible-proxmox-apps#525.
               host: haproxy.pve.jacobpevans.com
-              port: 10300
+              port: 10302
               pqEnabled: true
         '';
         # Model-server logs: the manager (Go) and its workers (Python) share

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -184,7 +184,15 @@ in
     # Always ensure dataDir + logs subdir exist with correct ownership so the
     # launchd job can write, whether or not any packs are declared. In
     # standalone mode, also install the declarative config files.
-    system.activationScripts.postActivation.text = ''
+    #
+    # extraActivation, NOT postActivation: nix-darwin's activation order is
+    # preActivation → extraActivation → etc → defaults → launchd →
+    # postActivation. Cribl does not hot-reload config files written from
+    # outside its own API, so config must be on disk BEFORE the launchd phase
+    # (re)starts the daemon. With postActivation, every plist-triggered
+    # restart came up on the previous generation's config, and a config-only
+    # change never reached the running daemon at all until the next reboot.
+    system.activationScripts.extraActivation.text = ''
       ${./scripts/cribl-edge-activate.sh} "${cfg.dataDir}" "${cfg.serviceUser}:${cfg.serviceGroup}"
       ${lib.optionalString (cfg.mode == "standalone") standaloneConfigInstall}
       ${lib.optionalString (cfg.packs != { }) (

--- a/modules/darwin/apps/scripts/cribl-edge-start.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-start.sh
@@ -25,7 +25,9 @@
 # Responsibilities (standalone mode):
 #   1. Retire any leftover fleet-enrollment state (moved aside, never
 #      deleted) so the node runs purely from its local config — which the
-#      nix-darwin activation renders into local/edge/ (GitOps).
+#      nix-darwin activation renders into local/edge/ (GitOps) BEFORE the
+#      launchd phase (extraActivation), because Cribl reads these files only
+#      at startup and does not hot-reload changes written outside its API.
 #   2. exec `cribl server`.
 
 set -euo pipefail


### PR DESCRIPTION
## Why

First Studio reboot exposed a cribl-edge EX_CONFIG crash-loop. Three defects, each root-caused against a live cribl instance run with a throwaway `CRIBL_VOLUME_DIR` (validation output in session):

1. **File-input schema**: Edge 4.18 requires `mode: manual` + `path` (directory) + `filenames` (glob allowlist). The bare `filenames` list fails schema validation (`should have required property 'path'`) and takes the whole config load down.
2. **Destination gating**: `cribl_tcp` is refused on standalone nodes ("Destination is not allowed in this deployment" — distributed-only per Cribl docs). `tcpjson` is the documented single-instance substitute.
3. **Activation ordering**: Cribl does not hot-reload config written outside its API, and `postActivation` runs after nix-darwin's launchd phase — so every daemon restart came up on the previous generation's config. Config now installs in `extraActivation` (before launchd).

## What

- `hosts/common/default.nix`: corrected `in_llm_logs` shape (mirrors stock `in_file_varlog`); output switched to `tcpjson` :10302 with `pqEnabled` — events buffer locally until the receiving side lands (dryvist/ansible-proxmox-apps#525: contracts port, HAProxy frontend, Stream tcpjson source).
- `modules/darwin/apps/cribl-edge.nix`: install moved to `extraActivation` with ordering rationale.
- Start-script comment change forces a plist change → both hosts' daemons restart on rebuild with the corrected config (needed because no hot-reload).
- `docs/CRIBL-GITOPS.md`: corrected the hot-reload claim; transport section updated.

## Verification

- Repro harness: corrected config loads with zero validation errors; `in_llm_logs` initializes; `tcpjson` connects-and-queues as designed.
- `nix fmt` / `statix` / `deadnix` / `markdownlint-cli2` clean; `nix eval` green.
- Splunk end-to-end deferred behind dryvist/ansible-proxmox-apps#525 (prioritization: inference + benchmarking first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT