### PR TITLE
fix(mac-studio): raise llama-swap concurrency limit for the serving host

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -99,6 +99,13 @@
       proxy = {
         groupSwap = false;
         idleTtl = 0;
+        # llama-swap hard-429s anything beyond concurrencyLimit (default 2),
+        # while vllm-mlx itself batches 4 sequences (max-num-seqs) and queues
+        # the rest gracefully. Measured on-host: a 4-way benchmark burst got
+        # 98/100 requests rejected at the proxy before the workers saw them.
+        # 8 = one full batch running + one queued at the worker; agents and
+        # the web UI burst-tolerate instead of hard-failing.
+        concurrencyLimit = 8;
       };
       autoUnloadIdleSeconds = 0;
       preload = [


### PR DESCRIPTION
## Why

llama-swap rejects anything beyond `concurrencyLimit` (default 2) with a hard HTTP 429, while vllm-mlx itself batches 4 sequences (`--max-num-seqs 4`) and queues excess gracefully. Measured on the Studio: a 4-way throughput-benchmark burst got **98/100 requests 429-rejected at the proxy** before the workers ever saw them. On a serving host whose consumers are agents (retry-poor) plus the web UI, bursts should queue, not fail.

## What

`lib/hosts.nix` (mac-studio only): `mlx.proxy.concurrencyLimit = 8` — one full worker batch running + one queued. Laptop keeps the default 2.

## Verification

- `nix fmt` / `statix` / `deadnix` clean; `nix eval` green for jevans-ms.
- Post-merge: throughput benchmark rerun at concurrency 4 with zero 429s (numbers reported in session; baseline at concurrency 2: Qwen3-Coder 95.8 output tok/s aggregate, TPOT 10.6 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT