### PR TITLE
fix(mac-studio): rotate real runner PAT into github-runner secret

### DIFF
--- a/secrets/github-runner.yaml
+++ b/secrets/github-runner.yaml
@@ -1,25 +1,25 @@
-GH_RUNNER_PAT: ENC[AES256_GCM,data:MskhdJbyf0ej/Mz8RvpR,iv:oYu9cvmNhqn+T09uWT+556TqU4XddOhs+RjPzfm6s74=,tag:pFuoIxoBKZC3fydGUsjjGg==,type:str]
+GH_RUNNER_PAT: ENC[AES256_GCM,data:+W0AyYwt1W2DptYPW/tSwsJtAPoV3LsGIYi5+2o9n7ohh9tJzzgyL4mbMv/shfpIl90Q1xkTmyTEnU7fQlXHQDkpOrY1euwANWa8qweU2HL6gW89uIgRBhOfNygX,iv:2WK4QhSmT6mdlr56rtB66JRfj/UKTk6iY2vKeMnl8p4=,tag:eVHsFhIS604hC75NdQNexQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VzhjT0pER0lKWDM1QnJQ
-            UEg4ZHRHZGlrUWh5TTVUcnFBSzZ3S2ZFWjNNCjA1eGxVVXUrcmR2R0pJUWdHQmFi
-            dXJsUU9oRlZPWitvR0s3bTdNRk1zS1UKLS0tIHZvY0tUTTNtSnE4Sk5odWVsdlB2
-            TlFuR3pERGIzelc4ejFGNld2dWhVaDgKTbV+0XLdTzXbNROR8BoRGAFE+a4o0iig
-            TLymLGqp3YiB/JZlCyOmB831VfWNjNarT9fC+et3jdrCYpPW8YvMqw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUeHkwWUpKMDBWeE1QeG1W
+            SWlObnJJV01RWmlaVjJjb0UvWVVWSFZucUVzCkhmWGx5Tm1ENEh4T0Yxc01WdjNz
+            UEhGc3o5YzFqVWFNT3pjOFZiWm1XRlUKLS0tIGpWV1FLeU5LZ2hrcjRvbHdTVFFo
+            d2dZelUwSGJra3ZnK2N0MUJxZmxXNkUKQN8pXqGKO+1he9oC4wRzGPsKJXUL2wS/
+            WTb2jyNA4tO/7CZesjGBX+ksXQPMiuaXFgXQsw9yIeBfltt0c2YFgw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4MndDeUlNWjlHUklvdlVF
-            bUxlOGNWZCtUeEhjUmRrLzNQRmRaVjY2dldFCkQrWGV6eENKR1krWU14aTdIaWlJ
-            RXJEY1g4bUxaNm5EYzgwMTNHb3R0ZDgKLS0tIGxXdGU4NENrOVU2QUR0ZHFDRFJu
-            dWZzODliWERyQUc5SUZqYWMxUFBET00KNjYnc2tTeHQGhFKO8vmbxG0LDQrzLwxT
-            Tm0w3CCo5pERkOqYTAP64r2llE26JMWBSizvepvlSa4kS+fKzlG3ww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXeTBhWTUzRmVQMDcwNGpP
+            YlNPWWoyN1hKODRiQ0VxTGhDN0tEVEdOU3lFCkt3UXhnVk5vS0lpd2ZXdWFJemlQ
+            ZWNkZElGREpWMmtOMElnMkl2aWl0VGsKLS0tICtzYUFkTVB0aXE4ZTcwMlp6MVAz
+            NTU5ZFZZcFlxSlJpaDNRZXI4R1NTdDgKavKN58P83c8AZpqrIx16ZaqkX7fDpw4x
+            bOAyoEwdboUldmVc4mvktWabcFB1JrZOqv+Z5zrIcq73i6lt10XHtg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
-    lastmodified: "2026-07-02T17:31:37Z"
-    mac: ENC[AES256_GCM,data:RAvLKDk/WNUCs/QxkmOYqd0tuHQjUr3KVosg5vINPgDyeeGGbUdyjd7jEq2LTvffExL28FqBIgXC9C0uULQHGziH4K/Nz04sqJ7QoHVMJv5jW56ZMUJm2VfwiTru70icm8ccI9x0XMVwD86wEzK88ZjBxrSknADvUZplzYJ1NBM=,iv:QFl/oajBNFD0SvTBHXWiol/K7tUUc6AxzYTI7y0SATM=,tag:AAU1/gW8+EXaYdSLQhSRtA==,type:str]
+    lastmodified: "2026-07-03T01:18:06Z"
+    mac: ENC[AES256_GCM,data:nukSQqTpQD2Q5f8s+iP1xB4fkmEpigTOAdw8feN7RHFyqXIe59KuO8kajNvPRERPZjAbHylyTz7vKbAa56tdMj4kCw9ZIeLIUQho+1nDIHZhsPg23ghIyHAJMUi4WIGSqlvy72W9RGbswLcVeqC38WBC+UaACt92rjQR7IqwJzQ=,iv:i6EVv2VqjX5oi+5BVVSI6KsQGYQXpHjXJB2TlCHdcmc=,tag:wEIlNuQEy4UwVfjaNqKijw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2


### PR DESCRIPTION
Replaces the `CHANGEME` placeholder in `secrets/github-runner.yaml` with the user-minted fine-grained PAT (dryvist org, "Self-hosted runners: RW" only; sourced from Doppler `gh-workflow-tokens`, encrypted stdin-only — plaintext never on disk). Verified: decrypts under both age recipients; PAT mints org runner registration tokens; the restricted `llm-runners` group (selected → mlx-benchmarks) was created with it.

Post-merge: Studio rebuild brings the ephemeral Apple-container runner online in `llm-runners`; smoke workflow follows in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT