### PR TITLE
fix(llm-gate,gh-runner): KeepAlive PathState on sops-rendered inputs

### DIFF
--- a/modules/darwin/apps/github-runner-container.nix
+++ b/modules/darwin/apps/github-runner-container.nix
@@ -167,11 +167,20 @@ in
 
     # Foreground `container run` supervised by launchd KeepAlive: the VM
     # exits after one job (EPHEMERAL) and launchd starts the next one.
+    # PathState, not `true`: the --env-file lives under /run/secrets
+    # (= /private/var/run), cleared at boot and only present after the
+    # activation/boot render — a plain KeepAlive races it and launchd backs
+    # off indefinitely on loss (same failure class as llm-gate). PathState
+    # holds the agent until the file exists and self-heals if it reappears.
     launchd.user.agents.gh-runner.serviceConfig = {
       Label = "com.nix-darwin.gh-runner";
       ProgramArguments = runArgs;
       RunAtLoad = true;
-      KeepAlive = true;
+      KeepAlive = {
+        PathState = {
+          "${cfg.secretsFile}" = true;
+        };
+      };
       ThrottleInterval = 30;
       StandardOutPath = "${cfg.dataDir}/logs/gh-runner.log";
       StandardErrorPath = "${cfg.dataDir}/logs/gh-runner.err.log";

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -157,7 +157,20 @@ in
           "caddyfile"
         ];
         RunAtLoad = true;
-        KeepAlive = true;
+        # PathState, not `true`: the Caddyfile is a sops-rendered file under
+        # /run/secrets (= /private/var/run), which macOS clears at boot and
+        # which only exists after the activation/boot render. A plain
+        # KeepAlive races that render — caddy spawns first, exits, and
+        # launchd backs off indefinitely (observed: exit 78, "spawn
+        # scheduled" forever; one boot won the race, the next lost it).
+        # PathState makes launchd hold the daemon until the config exists
+        # and respawn it whenever the file reappears — which also
+        # self-heals after any mid-uptime /var/run wipe.
+        KeepAlive = {
+          PathState = {
+            "${config.sops.templates."llm-gate.Caddyfile".path}" = true;
+          };
+        };
         ThrottleInterval = 15;
         UserName = "root";
         GroupName = "wheel";


### PR DESCRIPTION
## Why

After tonight's reboot on the new VLAN the llm-gate daemon was dead: launchd `last exit code = 78`, `state = spawn scheduled`, `runs = 1`, never retried. Root cause is a **boot-order race**: the Caddyfile is a sops template under `/run/secrets` (= `/private/var/run`), cleared at boot and rendered only when activation runs — with `KeepAlive = true`, caddy can spawn before the render, exit, and sit in indefinite launchd backoff. One boot earlier tonight won the race (gate verified working); the next lost it. A separate mid-uptime `/var/run` wipe (21:15→21:46, no reboot — cause unknown, tracked in the issue below) produced the same dead-daemon end state.

## What

`KeepAlive = { PathState = { <rendered-file> = true; }; }` for both consumers of sops-rendered files:
- `llm-gate` daemon → the rendered Caddyfile
- `gh-runner` user agent → the rendered env file

launchd now holds each service until its input exists, respawns when it reappears, and stops cleanly if it vanishes — fixes the boot race and self-heals the wipe case. Merging this also force-reloads both services (plist change), recovering the currently-dead gate.

## Verification

- `nix fmt` / `statix` / `deadnix` clean; `nix eval` green for jevans-ms.
- Post-merge: Studio rebuild, then gate 401/200 + WebUI + both-model completions re-verified on 10.0.40.10 and a reboot test (results in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT