### PR TITLE
refactor: normalize host class once in mkHost

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,17 @@
       mkHost =
         label: host:
         assert _stateVersionCheck;
+        let
+          # Normalize the host class ONCE: consumers read hostConfig.class /
+          # hostConfig.isServer instead of each re-deriving the
+          # `class or "workstation"` default (previously copy-pasted across
+          # every class-gated module). The fallback keeps a host that omits
+          # `class` on the safe laptop profile rather than throwing.
+          hostConfig = host // rec {
+            class = host.class or "workstation";
+            isServer = class == "server";
+          };
+        in
         darwin.lib.darwinSystem {
           # nix-darwin is Darwin-only and every host is Apple Silicon, so the
           # registry omits `system`; default it here (overridable for an Intel host).
@@ -151,8 +162,7 @@
           # see nix-ai/docs/architecture/per-agent-flakes.md.
           # `hostConfig` threads the per-host attrset to every darwin module.
           specialArgs = {
-            inherit nix-ai;
-            hostConfig = host;
+            inherit nix-ai hostConfig;
           };
           modules = [
             ./hosts/${label}/default.nix
@@ -176,8 +186,7 @@
                 # nix-home modules accept userConfig with sensible defaults.
                 # `hostConfig` threads the per-host attrset to home-manager modules.
                 extraSpecialArgs = {
-                  inherit userConfig dotgithub;
-                  hostConfig = host;
+                  inherit userConfig dotgithub hostConfig;
                 };
                 users.${userConfig.user.name} = import ./hosts/${label}/home.nix;
 

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -211,9 +211,7 @@ in
   # value still wins. Inlined here rather than a dedicated module: it only
   # consumes `hostConfig` (already in scope) and is a handful of settings.
   # A `workstation` needs nothing — the module defaults already match the laptop.
-  # `class or "workstation"` tolerates a host that omits it (defaults to the safe
-  # laptop profile) rather than throwing on the missing attr.
-  system = lib.mkIf ((hostConfig.class or "workstation") == "server") {
+  system = lib.mkIf hostConfig.isServer {
     energy.wakeOnMagicPacket = lib.mkDefault true; # Wake-on-LAN for a headless box
     networkTuning.enable = lib.mkDefault true; # socket buffers for LAN serving
     appleSiliconTunables.energyMode = lib.mkDefault "unmanaged"; # no High Power Mode on a desktop

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -58,10 +58,9 @@
   manual.manpages.enable = false;
 
   # nix-home role preset: `workstation` enables all daily-driver GUI/desktop
-  # features; `server` drops them. Driven by the host's registry `class`.
-  # `or "workstation"` matches nix-home's own default and tolerates a host that
-  # omits `class` rather than throwing on the missing attr.
-  home-profile.preset = hostConfig.class or "workstation";
+  # features; `server` drops them. Driven by the host's registry `class`
+  # (normalized in flake.nix mkHost, so the attr always exists).
+  home-profile.preset = hostConfig.class;
 
   # ==========================================================================
   # Monitoring / Observability
@@ -137,7 +136,7 @@
           # comes from the sops-rendered per-machine secret instead (portable
           # across machines via the committed encrypted file + on-device age
           # key). Workstations keep the keychain read, byte-identical.
-          if (hostConfig.class or "workstation") == "server" then
+          if hostConfig.isServer then
             ''export HF_TOKEN=''${HF_TOKEN:-"$(cat /run/secrets/HF_TOKEN 2>/dev/null || echo "")"}''
           else
             ''export HF_TOKEN=''${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}''

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -1,9 +1,10 @@
 # Per-host registry
 #
 # Pure static data only — NO `config`/`osConfig`/module references (that would
-# create an eval-order dependency). Consumed by flake.nix `mkHost`, which threads
-# each host's attrset to darwin modules via `specialArgs.hostConfig` and to
-# home-manager modules via `extraSpecialArgs.hostConfig`.
+# create an eval-order dependency). Consumed by flake.nix `mkHost`, which
+# normalizes `class` (default "workstation") and derives `isServer`, then
+# threads each host's attrset to darwin modules via `specialArgs.hostConfig`
+# and to home-manager modules via `extraSpecialArgs.hostConfig`.
 #
 # Keyed by descriptive machine label (also the folder name under hosts/). The
 # darwin configuration is exposed under `hostName` (see flake.nix) so

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -8,7 +8,8 @@
 let
   userConfig = import ../../lib/user-config.nix;
   # Server-class hosts get no GUI packages — lean by construction.
-  isServer = (hostConfig.class or "workstation") == "server";
+  # (isServer is normalized once in flake.nix mkHost.)
+  inherit (hostConfig) isServer;
 in
 {
   imports = [

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -40,7 +40,8 @@ let
   # actively UNINSTALL anything not declared, so drift cannot accumulate.
   # (Hit on jevans-ms 2026-07-02: the ungated list installed the laptop's
   # desktop apps on the headless LLM server.)
-  isServer = (hostConfig.class or "workstation") == "server";
+  # (isServer is normalized once in flake.nix mkHost.)
+  inherit (hostConfig) isServer;
 
   # The only Homebrew packages a server host needs. Add here ONLY with a
   # written justification; everything else belongs in nixpkgs or nowhere.

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -35,7 +35,8 @@ let
     group = "staff";
     mode = "0400";
   };
-  isServer = (hostConfig.class or "workstation") == "server";
+  # (isServer is normalized once in flake.nix mkHost.)
+  inherit (hostConfig) isServer;
 in
 {
   sops = {


### PR DESCRIPTION
## Summary

`(hostConfig.class or "workstation") == "server"` was independently re-derived in five files (`modules/darwin/{sops,common,homebrew}.nix`, `hosts/common/{default,home}.nix`). `mkHost` now normalizes `class` and derives `isServer` once before threading `hostConfig` through specialArgs, so consumers read `hostConfig.class` / `hostConfig.isServer` and the omitted-class fallback lives in exactly one place.

## Verification

- **Zero output change**: `darwinConfigurations."jevans-ms"` and `"jevans-mbp"` `system.drvPath` are byte-identical to main.
- pre-commit (nixfmt, statix, deadnix, semgrep, gitleaks) green on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT