### PR TITLE
chore: drop eliminated bind-IP secret, post-Studio doc currency

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,9 +1,10 @@
 # Manifest
 
-> **Note**: This repo is part of a trio. See also
-> [nix-ai](https://github.com/JacobPEvans/nix-ai) and
-> [nix-home](https://github.com/JacobPEvans/nix-home)
-> for AI tools and dev environment documentation.
+> **Note**: This repo has companion repos. See
+> [nix-ai](https://github.com/JacobPEvans/nix-ai),
+> [nix-home](https://github.com/JacobPEvans/nix-home), and
+> [nix-devenv](https://github.com/JacobPEvans/nix-devenv)
+> for AI tools, dev environment, and dev shell documentation.
 
 Complete inventory of everything installed and managed by this nix-darwin configuration.
 Each entry lists the source file where it is declared.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 
 ## What Is This?
 
-A flakes-only nix-darwin configuration for M4 Max MacBook Pro. Manages macOS
-system-level settings: system packages, Dock, Finder, keyboard, security,
-Homebrew, and LaunchDaemons -- all declaratively. User-level configuration
-(dotfiles, dev tools, LaunchAgents) is layered on top via external
-home-manager modules consumed as flake inputs.
+A flakes-only, multi-host nix-darwin configuration: an M4 Max MacBook Pro
+workstation and an always-on Mac Studio LLM server, both defined in a single
+host registry (`lib/hosts.nix`). Manages macOS system-level settings: system
+packages, Dock, Finder, keyboard, security, Homebrew, and LaunchDaemons --
+all declaratively. User-level configuration (dotfiles, dev tools,
+LaunchAgents) is layered on top via external home-manager modules consumed
+as flake inputs.
 
 ## Prerequisites
 
@@ -83,7 +85,9 @@ See **[MANIFEST.md](MANIFEST.md)** for the complete package inventory.
 .
 ├── flake.nix                  # Main entry point
 ├── hosts/                     # Host-specific configurations
-│   └── macbook-m4/            # Active M4 Max MacBook Pro
+│   ├── common/                # Config shared by every host
+│   ├── macbook-m4/            # M4 Max MacBook Pro (workstation)
+│   └── mac-studio/            # M4 Max Mac Studio (LLM server)
 ├── modules/                   # Reusable configuration modules
 │   └── darwin/                # macOS system settings
 ├── overlays/                  # Nixpkgs overlays

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -8,12 +8,13 @@
 # login, so no bearer there).
 #
 # Fully declarative — no wrapper scripts: the ENTIRE Caddyfile is a sops-nix
-# template rendered at activation with the secrets inline (bearer token, LAN
-# bind IP, ACME credentials), root-only 0400 under /run/secrets/rendered/.
-# The launchd daemon execs Caddy directly against that rendered path, so it
-# comes up on boot and survives reboots with zero interactive prompts (hard
-# requirement for the headless server). The bind IP rides inside the
-# encrypted secrets file so no address octets land in this public repo.
+# template rendered at activation with the secrets inline (bearer token and,
+# in route53 mode, ACME credentials), root-only 0400 under
+# /run/secrets/rendered/. The launchd daemon execs Caddy directly against
+# that rendered path, so it comes up on boot and survives reboots with zero
+# interactive prompts (hard requirement for the headless server). Caddy binds
+# all interfaces — no bind address exists anywhere, so no address octets land
+# in this public repo (see the config comment below).
 #
 # TLS modes:
 #   route53  — real Let's Encrypt cert via DNS-01 against the public zone,

--- a/modules/darwin/sops.nix
+++ b/modules/darwin/sops.nix
@@ -28,8 +28,9 @@ let
     group = "wheel";
     mode = "0400";
   };
-  # The GitHub runner service registers/runs as the login user, so its PAT
-  # must be readable by that user (services.github-runners tokenFile).
+  # The GitHub runner agent runs as the login user (Apple `container` is
+  # per-user), so its PAT env-file must be readable by that user — consumed
+  # via `container run --env-file` (modules/darwin/apps/github-runner-container.nix).
   userOnly = {
     owner = userConfig.user.name;
     group = "staff";
@@ -65,8 +66,6 @@ in
     }
     // lib.optionalAttrs isServer {
       # llm-gate (Caddy TLS + bearer front) — secrets/llm-large.yaml.
-      # (The file's legacy LLM_GATE_BIND_IP key is unused: the gate binds all
-      # interfaces, so no address ever needs declaring or rotating.)
       LLM_LARGE_BEARER_TOKEN = rootOnly // {
         sopsFile = ../../secrets/llm-large.yaml;
       };

--- a/secrets/llm-large.yaml
+++ b/secrets/llm-large.yaml
@@ -1,5 +1,4 @@
 LLM_LARGE_BEARER_TOKEN: ENC[AES256_GCM,data:zzplvybiiVKh2Ann44UtZKerY5IAK6uEO0ijoabATAT6gKCR40XyDSCqu+eWzyycvdqvrFYRBcLLQSRCaUix8w==,iv:rEiUep4YGU7gKL+UhKt4sLS2G4y3AcfWLWVdWWvuFdw=,tag:FoRjAOi6cMcLhI6fYIW+dw==,type:str]
-LLM_GATE_BIND_IP: ENC[AES256_GCM,data:0Thof3Y3GNgNtg==,iv:F9xFLtg1scBvtpriRYZfsNbqOy62WV2ikZOqXnsm/SY=,tag:pnyQ3S4gOiKYHxVh+rXD+Q==,type:str]
 LLM_GATE_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:d97Ir/ysYwXVa3SE4YZg,iv:Q/aXmpEky+Avly+7DeRXLBUTvPGbYDfzt/kZSkvSWgE=,tag:3a9nwj7vRgBvzXsqwbQ0Bg==,type:str]
 LLM_GATE_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:c1c7OgRTq6hQyURu4Raq,iv:i9psgT9ahG2dgXkYwhuJv1hndR7+B8BH0iBBauo5GfU=,tag:9snWI7dB8HBmGbjTPwV9ew==,type:str]
 LLM_GATE_AWS_REGION: ENC[AES256_GCM,data:7xilBKj/JobxByachPLT,iv:Q8Qt5yLlwKSSS8Tyuuh8XA2mPxHj549cfCqlUat3/LA=,tag:NZs1Nxoj18tEIMi1BKXPLA==,type:str]
@@ -23,7 +22,7 @@ sops:
             7KvXMCQ0ohJZSZHiug/WJMXdnvEm+gldEEobJQpIYc/FJajljZ/Lwg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1vpznq8w06ldc8d4z6g348st45het7yt5d5c6rtgnvzgtvrt0gcxss73qna
-    lastmodified: "2026-07-02T17:31:37Z"
-    mac: ENC[AES256_GCM,data:Ezq3Yj0sAGn2PkmuA8AxfQEr9flUS9FgASiYHZbDy3FAgahvJbNRLJp5Cir9nTmv/wCNaRDu9wp390NWl4a8Pqv2RtkbNO8HnrJs4tFSZik2rW5E63URiJasCo6DTo26N653Bu/esvUgk9udo8EpQBuqD/TJMJHnNRoGb5X2J/g=,iv:uc6IyOlziFq14akrRXcewy4iEdF47P3v25JvgmwiS5s=,tag:gICu0DixfAt8ZhgSMNyjkg==,type:str]
+    lastmodified: "2026-07-03T02:31:18Z"
+    mac: ENC[AES256_GCM,data:9lPRXbZzK2kc9ZCb42TgAB9fQmvSoOvLtfO5SCSk1q1RnjobmXM6KHB1HRjmV4NYJY+fz3USlsBQDUPkvWpaYII1ccK7rZS11KrRS1djBNoDky3vRyTSbHjpCkXyHYMAxSpQHPkkpDQtZyyJ1YdcPsfEFMNG83E6qXKrGYZDunQ=,iv:pmmPI6QJzTgXUqCPIggxDLXM6Vv4fzJYLBbEkHErOig=,tag:nW1HlnUKRVB0WBWFWkae9A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2


### PR DESCRIPTION
## Summary

Cleanup pass after the Studio bring-up PR chain:

- **`secrets/llm-large.yaml`** — `sops unset` the legacy `LLM_GATE_BIND_IP` key. The gate binds all interfaces since #1409; no sops secret or template consumes it. Both age recipients preserved; remaining keys verified decryptable.
- **`llm-gate.nix`** — header comment still claimed the bind IP rides in the encrypted secrets file, contradicting both the code and the module's own config comment.
- **`sops.nix`** — drop the now-moot legacy-key note; fix the PAT comment that attributed consumption to `services.github-runners` (unusable with Determinate Nix) instead of the Apple-container `--env-file` path.
- **`MANIFEST.md`** — companion-repos wording (no baked-in count), add missing nix-devenv.
- **`README.md`** — multi-host intro + directory tree (mac-studio, hosts/common).

## Verification

- `darwinConfigurations."jevans-ms"` evals cleanly (drv delta vs main is the re-encrypted secrets file only)
- pre-commit green on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT