### PR TITLE
refactor: share the Apple container runtime one-shot agent

### DIFF
--- a/modules/darwin/apps/apple-container-runtime.nix
+++ b/modules/darwin/apps/apple-container-runtime.nix
@@ -1,0 +1,69 @@
+# Apple `container` Runtime Bring-Up (shared one-shot)
+#
+# Every module that supervises an Apple `container` (v1.0) Linux VM needs the
+# per-user container-apiserver running first. This module owns that bring-up
+# as ONE launchd one-shot agent, shared by all consumers (cribl-stream,
+# github-runner-container) — each sets `enable = lib.mkDefault true` from its
+# own config block, so however many consumers a host activates, exactly one
+# runtime agent exists.
+#
+# `container` is per-user (talks to the login user's container-apiserver), so
+# this is a user agent, not a root daemon — server hosts run auto-login
+# exactly so user agents come up unattended on boot. `container system start`
+# is idempotent: a no-op when the apiserver is already up.
+
+{
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.apple-container-runtime;
+in
+{
+  options.programs.apple-container-runtime = {
+    enable = lib.mkEnableOption "one-shot launchd agent that brings up the Apple container runtime/apiserver";
+
+    containerBin = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/homebrew/bin/container";
+      description = "Apple container CLI path (Homebrew install). Consumers read this option for their own `container run` invocations.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      description = "macOS login user whose container-apiserver is started (Apple `container` is per-user); owns the log dir.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "staff";
+      description = "Primary group of the login user (macOS default: staff).";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/apple-container";
+      description = "Host directory for the runtime agent's logs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    system.activationScripts.postActivation.text = ''
+      /usr/bin/install -d -o ${cfg.user} -g ${cfg.group} "${cfg.dataDir}" "${cfg.dataDir}/logs"
+    '';
+
+    launchd.user.agents.apple-container-runtime.serviceConfig = {
+      Label = "com.nix-darwin.apple-container-runtime";
+      ProgramArguments = [
+        cfg.containerBin
+        "system"
+        "start"
+        "--enable-kernel-install"
+      ];
+      RunAtLoad = true;
+      StandardErrorPath = "${cfg.dataDir}/logs/apple-container-runtime.err.log";
+    };
+  };
+}

--- a/modules/darwin/apps/cribl-stream.nix
+++ b/modules/darwin/apps/cribl-stream.nix
@@ -5,11 +5,11 @@
 # Stream, which enriches, persistent-queues, and forwards once to the Proxmox
 # Stream tier (instead of many local sources each dialing Proxmox).
 #
-# Script-free: two native launchd user agents drive the lifecycle.
-#   * cribl-container-runtime — one-shot `container system start
-#     --enable-kernel-install` (installs the kata kernel non-interactively on
-#     first run; no-op thereafter). The apiserver it starts self-registers with
-#     launchd and persists independently.
+# Script-free: native launchd user agents drive the lifecycle.
+#   * apple-container-runtime (shared module) — one-shot `container system
+#     start --enable-kernel-install` (installs the kata kernel
+#     non-interactively on first run; no-op thereafter). The apiserver it
+#     starts self-registers with launchd and persists independently.
 #   * cribl-stream — `container run` in the FOREGROUND (no -d), so launchd's
 #     KeepAlive directly supervises the container: when it exits, launchd
 #     restarts it. `--rm` keeps the fixed name free across restarts.
@@ -31,7 +31,7 @@
 let
   cfg = config.programs.cribl-stream;
 
-  containerBin = "/opt/homebrew/bin/container";
+  inherit (config.programs.apple-container-runtime) containerBin;
   mount = "/opt/cribl/config-volume"; # CRIBL_VOLUME_DIR inside the container
   volumeDir = "${cfg.dataDir}/volume"; # host side of the bind mount
 
@@ -179,17 +179,12 @@ in
       ${configInstall}
     '';
 
-    # One-shot: bring up the container runtime/apiserver (idempotent).
-    launchd.user.agents.cribl-container-runtime.serviceConfig = {
-      Label = "com.nix-darwin.cribl-container-runtime";
-      ProgramArguments = [
-        containerBin
-        "system"
-        "start"
-        "--enable-kernel-install"
-      ];
-      RunAtLoad = true;
-      StandardErrorPath = "${cfg.dataDir}/logs/cribl-container-runtime.err.log";
+    # Shared one-shot brings up the container runtime/apiserver (idempotent);
+    # mkDefault so a host can still point the shared module elsewhere.
+    programs.apple-container-runtime = {
+      enable = lib.mkDefault true;
+      user = lib.mkDefault cfg.user;
+      group = lib.mkDefault cfg.group;
     };
 
     # Foreground `container run` supervised by launchd KeepAlive — no wrapper

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -10,6 +10,7 @@ _:
 {
   imports = [
     ./ai-volumes.nix
+    ./apple-container-runtime.nix
     ./auto-update-prevention.nix
     ./cribl-edge.nix
     ./cribl-stream.nix

--- a/modules/darwin/apps/github-runner-container.nix
+++ b/modules/darwin/apps/github-runner-container.nix
@@ -1,9 +1,9 @@
 # GitHub Actions Self-Hosted Runner (Apple container)
 #
 # Runs an EPHEMERAL GitHub Actions org runner inside an Apple `container`
-# (v1.0) Linux VM, following the cribl-stream lifecycle pattern: a one-shot
-# runtime agent brings up the per-user container apiserver, and a foreground
-# `container run` under launchd KeepAlive supervises the runner.
+# (v1.0) Linux VM: the shared apple-container-runtime module brings up the
+# per-user container apiserver, and a foreground `container run` under
+# launchd KeepAlive supervises the runner.
 #
 # Script-free by design: the vendor image (myoung34/github-runner) is
 # entirely env-driven — it exchanges the PAT for a registration token,
@@ -32,7 +32,7 @@
 let
   cfg = config.programs.github-runner-container;
 
-  containerBin = "/opt/homebrew/bin/container";
+  inherit (config.programs.apple-container-runtime) containerBin;
 
   runArgs = [
     containerBin
@@ -150,19 +150,12 @@ in
       /usr/bin/install -d -o ${cfg.user} -g ${cfg.group} "${cfg.dataDir}" "${cfg.dataDir}/logs"
     '';
 
-    # One-shot: bring up the container runtime/apiserver (idempotent; same
-    # no-op-after-first-run shape as cribl-stream's runtime agent — duplicate
-    # RunAtLoad one-shots are harmless if both modules are enabled).
-    launchd.user.agents.gh-runner-container-runtime.serviceConfig = {
-      Label = "com.nix-darwin.gh-runner-container-runtime";
-      ProgramArguments = [
-        containerBin
-        "system"
-        "start"
-        "--enable-kernel-install"
-      ];
-      RunAtLoad = true;
-      StandardErrorPath = "${cfg.dataDir}/logs/gh-runner-container-runtime.err.log";
+    # Shared one-shot brings up the container runtime/apiserver (idempotent);
+    # mkDefault so a host can still point the shared module elsewhere.
+    programs.apple-container-runtime = {
+      enable = lib.mkDefault true;
+      user = lib.mkDefault cfg.user;
+      group = lib.mkDefault cfg.group;
     };
 
     # Foreground `container run` supervised by launchd KeepAlive: the VM


### PR DESCRIPTION
## Summary

`cribl-stream.nix` and `github-runner-container.nix` each carried a verbatim copy of the `container system start --enable-kernel-install` RunAtLoad agent and the `containerBin` path constant (the gh-runner copy even conceded the duplication in a comment). A new `modules/darwin/apps/apple-container-runtime.nix` owns both once:

- consumers set `programs.apple-container-runtime.enable = lib.mkDefault true` from their own config block — one runtime agent per host regardless of how many container-backed services run
- `containerBin` becomes a shared option both consumers inherit

## Verification

- `jevans-mbp` `system.drvPath` **byte-identical to main** (neither consumer active on the laptop)
- `jevans-ms` delta is the renamed one-shot agent + log path only
- pre-commit (nixfmt, statix, deadnix) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT