### PR TITLE
feat(packages): add neat menu-bar app via homebrew cask

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -135,6 +135,13 @@ let
       name = "voiceink";
       greedy = true;
     } # Voice-to-text app (local whisper)
+    # Neat: GitHub + Linear notifications in the menu bar. Not in nixpkgs
+    # (proprietary macOS-only app from neat.run); greedy so its built-in
+    # auto-updater does not cause brew upgrade to skip it.
+    {
+      name = "neat";
+      greedy = true;
+    } # GitHub/Linear menu-bar notifications
 
     # --- Anthropic ---
     {


### PR DESCRIPTION
Adds [Neat](https://neat.run/) — a macOS menu-bar app that surfaces GitHub and Linear notifications — to the workstation Homebrew casks.

## Why Homebrew, not nixpkgs

`neat` is a proprietary, macOS-only app distributed via [neat.run](https://neat.run/) and the [official Homebrew cask](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/n/neat.rb). It is not packaged in nixpkgs (`nix search nixpkgs neat` returns only Typst templates and unrelated tools), so per the "nixpkgs first, then Homebrew" policy the cask is the correct path.

## Notes

- Placed in the Productivity / Communication section of `workstationCasks` (workstation-only; excluded from server hosts).
- `greedy = true` so its built-in auto-updater does not cause `brew upgrade` to silently skip it, consistent with the other casks.
- `nix flake check` passes locally.