### PR TITLE
feat: add review-thread-resolver caller for instant bot-thread resolution

### DIFF
--- a/.github/workflows/review-thread-resolver.yml
+++ b/.github/workflows/review-thread-resolver.yml
@@ -1,0 +1,29 @@
+# Review Thread Resolver caller.
+#
+# Instantly resolves stale/failed bot review threads (gemini, Copilot) on PR
+# events, so the org `required_review_thread_resolution` rule stops blocking
+# merges. Only touches bot-only threads that are outdated or failure notices;
+# substantive human/bot feedback is never resolved.
+#
+# Permissions are job-scoped and the App key is passed explicitly (zizmor:
+# excessive-permissions, secrets-inherit). contents: write is required by the
+# resolveReviewThread GraphQL mutation. No concurrency block on purpose: a
+# caller sharing the reusable workflow's exact concurrency group causes an
+# opaque 0-job startup_failure.
+
+name: Review Thread Resolver
+
+on:
+  pull_request:
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  resolve:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: dryvist/ai-workflows/.github/workflows/review-thread-resolver.yml@main
+    secrets:
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the thin event-driven caller for dryvist/ai-workflows' review-thread-resolver so stale/failed bot review threads (gemini, Copilot) resolve **instantly** on PR events, instead of waiting up to an hour for the hub's org sweep.

- Only touches bot-only threads that are **outdated** or **failure notices** — substantive human/bot feedback is never resolved (safety invariant).
- Job-scoped permissions + explicit App-key secret (zizmor-clean); depends on dryvist/ai-workflows#320.
- Verified end-to-end today: the resolver resolved a real outdated gemini thread on a controlled test PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD