### PR TITLE
ci: CodeQL advanced setup excluding actions/unpinned-tag

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,6 +10,10 @@
 # here. Untrusted / individual-maintainer actions are still SHA-pinned by hand.
 name: nix-darwin CodeQL config
 
+# security-extended is a superset of the default suite, so disable the default
+# queries and run the extended suite alone — explicit intent, no coverage loss.
+disable-default-queries: true
+
 queries:
   - uses: security-extended
 

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+# CodeQL advanced-setup configuration.
+#
+# Replaces GitHub's default CodeQL setup (disabled at the repo level when the
+# codeql.yml workflow goes live) so that a single query can be excluded.
+#
+# POLICY: well-known trusted actions stay on major version tags, not commit
+# SHAs — see .github/zizmor.yml (`unpinned-uses: disable`) and
+# agentsmd/rules/security-alert-triage.md. The `actions/unpinned-tag` query
+# flags that intended state and offers no per-org allowlist, so it is excluded
+# here. Untrusted / individual-maintainer actions are still SHA-pinned by hand.
+name: nix-darwin CodeQL config
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - exclude:
+      id: actions/unpinned-tag

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# CodeQL advanced setup (replaces GitHub's default setup).
+#
+# Mirrors the previous default-setup coverage: actions + python, the
+# security-extended query suite, remote threat model (CodeQL default), a weekly
+# schedule and per-PR runs. The one deviation is the config file, which excludes
+# the actions/unpinned-tag query — trusted actions intentionally use major
+# version tags (see agentsmd/rules/security-alert-triage.md and
+# .github/zizmor.yml).
+#
+# REQUIRED before this can run green: disable the repo's default CodeQL setup,
+# otherwise init fails with a default-setup conflict. Advanced and default setup
+# cannot coexist. Disable via:
+#   gh api -X PATCH repos/dryvist/nix-darwin/code-scanning/default-setup \
+#     -f state=not-configured
+name: CodeQL
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'  # Weekly Monday 04:23 UTC (off-peak minute)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Fork-PR security guard: same-repo PRs, pushes, and scheduled runs use
+    # RunsOn; only fork PRs fall back to ubuntu-latest (github-hosted) so
+    # fork-author code never touches our self-hosted runners. See ci-gate.yml
+    # header for the full rationale.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Migrates code scanning from GitHub's **default** CodeQL setup to **advanced setup**
so the `actions/unpinned-tag` query can be excluded. That query fired 10 alerts on
2026-06-29 when default setup added the `actions` language; it flags trusted actions
pinned to major version tags — this repo's intended, policy-approved state per
[`.github/zizmor.yml`](.github/zizmor.yml) (`unpinned-uses: disable`) and
`agentsmd/rules/security-alert-triage.md`. CodeQL has no per-org allowlist, and
per-alert dismissal would recur on every version bump, so the query is excluded
globally via `.github/codeql/codeql-config.yml`.

Pairs with #1432 (which restores the four trusted-org actions to major tags).

## Coverage parity

Advanced setup mirrors the prior default-setup configuration exactly:

| | Default setup (before) | Advanced setup (this PR) |
| --- | --- | --- |
| Languages | `actions`, `python` | `actions`, `python` |
| Query suite | `extended` | `security-extended` |
| Threat model | `remote` | `remote` (CodeQL default) |
| Triggers | push/PR + weekly | push/PR + weekly |
| Excluded query | — | `actions/unpinned-tag` |

## ⚠️ Required admin step before merge (draft until done)

Advanced and default setup **cannot coexist** — while default setup is enabled, this
workflow's `Initialize CodeQL` step fails with a default-setup conflict, so the
CodeQL job here stays red until default setup is disabled. An org owner / security
admin must run (elevated token with `security_events`/admin scope):

```
gh api -X PATCH repos/dryvist/nix-darwin/code-scanning/default-setup -f state=not-configured
```

Pre-flight verified: no org code-security configuration is attached to this repo
(`GET repos/dryvist/nix-darwin/code-security-configuration` → `204 No Content`), so
default setup is repo-level and can be disabled without org-policy conflict.

After disabling, mark ready → the CodeQL job runs green → merge. The 8 trusted-org
`actions/unpinned-tag` alerts then fall under the exclusion and auto-close on the
next analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
