### PR TITLE
docs: correct unpinned-tag triage to default-suite mechanism

### DIFF
--- a/agentsmd/rules/security-alert-triage.md
+++ b/agentsmd/rules/security-alert-triage.md
@@ -85,16 +85,23 @@ jobs:
 
 ## Unpinned Action Tags (`actions/unpinned-tag`)
 
-CodeQL's default setup flags every third-party `uses:` that references a version tag
-instead of a commit SHA. **Do not blanket-SHA-pin in response.** This repo's pinning
-policy is the canonical one in [`.github/zizmor.yml`](../../.github/zizmor.yml)
+The CodeQL `actions/unpinned-tag` query flags any third-party `uses:` on a version
+tag instead of a commit SHA. **Do not blanket-SHA-pin in response** — that contradicts
+this repo's pinning policy, canonical in [`.github/zizmor.yml`](../../.github/zizmor.yml)
 (`unpinned-uses: disable`): *trusted actions use version tags; hash pinning is reserved
-for untrusted or lesser-known actions only.* Classify the flagged action first.
+for untrusted or lesser-known actions only.*
+
+`actions/unpinned-tag` is an **extended-only** query (it lives in
+`actions-security-extended.qls`, not the base suite). The org standard is CodeQL
+default setup on the **`default` query suite** across all public repos, so this query
+does not run and these alerts should not appear. That standard is org governance in
+[`dryvist/tofu-github`](https://github.com/dryvist/tofu-github). If an
+`actions/unpinned-tag` alert *does* surface, the repo's default setup has drifted onto
+the `extended` suite — fix the suite, do not SHA-pin trusted actions. Classify first.
 
 ### Trusted — keep on the major version tag (`@vN`)
 
-These `actions/unpinned-tag` alerts are **approved** and are excluded globally via the
-CodeQL advanced-setup config (`.github/codeql/codeql-config.yml`). Never SHA-pin them:
+Never SHA-pin these; they belong on major tags:
 
 - GitHub first-party: `actions/*`, `github/*`
 - `DeterminateSystems/*` (e.g. `determinate-nix-action`)

--- a/agentsmd/rules/security-alert-triage.md
+++ b/agentsmd/rules/security-alert-triage.md
@@ -97,7 +97,8 @@ default setup on the **`default` query suite** across all public repos, so this 
 does not run and these alerts should not appear. That standard is org governance in
 [`dryvist/tofu-github`](https://github.com/dryvist/tofu-github). If an
 `actions/unpinned-tag` alert *does* surface, the repo's default setup has drifted onto
-the `extended` suite — fix the suite, do not SHA-pin trusted actions. Classify first.
+the `extended` suite — fix the suite, do not SHA-pin trusted actions. Classify the
+flagged action first.
 
 ### Trusted — keep on the major version tag (`@vN`)
 


### PR DESCRIPTION
## Summary

Corrects the `actions/unpinned-tag` triage guidance that #1432 merged. That note said the alerts are excluded via a per-repo CodeQL advanced-setup config (`.github/codeql/codeql-config.yml`). That approach was closed as wrong altitude (#1454) — it would have to be copied into every public repo.

## What changed

`actions/unpinned-tag` is an **extended-only** query (`actions-security-extended.qls`). The org standard — governed in [dryvist/tofu-github](https://github.com/dryvist/tofu-github) — is CodeQL default setup on the **`default` query suite** across all public repos, so the query does not run and the alerts don't appear.

The rule now describes that mechanism and says: if an `actions/unpinned-tag` alert surfaces, the repo's default setup has drifted onto `extended` — fix the suite, never SHA-pin trusted actions.

Follows #1432 (pin correction, merged) and the closure of #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)