### PR TITLE
feat(llm-gate): API-only gate, extraHostnames cert SAN, route53 on studio

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -215,7 +215,7 @@ Managed by nix-darwin modules but installed externally (not via nixpkgs or Homeb
 | Service | Source | Description |
 | --- | --- | --- |
 | Cribl Edge | `modules/darwin/apps/cribl-edge.nix` | Log collection agent (installed via .pkg, Nix manages LaunchDaemon + ACLs) |
-| llm-gate (Caddy) | `modules/darwin/llm-gate.nix` | TLS + bearer gate for the LLM API and Open WebUI on server hosts; sops-rendered Caddyfile |
+| llm-gate (Caddy) | `modules/darwin/llm-gate.nix` | API-only TLS + bearer gate for the LLM API (llm-large tier) on server hosts; sops-rendered Caddyfile |
 | GitHub Actions Runner | `modules/darwin/apps/github-runner-container.nix` | Ephemeral org runner in an Apple `container` VM; env-driven image, PAT via sops |
 
 ---

--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -51,8 +51,8 @@ in
     energy.enable = true;
 
     # --- Auto-login ---
-    # The MLX stack, Open WebUI, and the gh-runner lifecycle are launchd USER
-    # agents — a headless reboot serves nothing until a session exists. Auto-
+    # The MLX stack and the gh-runner lifecycle are launchd USER agents — a
+    # headless reboot serves nothing until a session exists. Auto-
     # login gives that session with zero prompts (enable once via GUI so macOS
     # writes the kcpassword artifact; FileVault stays off on this host).
     defaults.loginwindow.autoLoginUser = userConfig.user.name;
@@ -66,13 +66,18 @@ in
     # ========================================================================
     # Caddy terminates TLS on the LAN address and enforces the bearer token; the
     # model server stays on 127.0.0.1. The whole Caddyfile is a sops template
-    # (secrets inline — no wrapper scripts). tlsMode "internal" is the bring-up
-    # stopgap — flip to "route53" once the ACME AWS credentials land in
-    # secrets/llm-large.yaml (phase 3 of the Studio bring-up).
+    # (secrets inline — no wrapper scripts). route53 mode issues a real
+    # Let's Encrypt cert via DNS-01 (the ACME AWS credentials in
+    # secrets/llm-large.yaml), so the cert covers both the host FQDN and the
+    # `llm-large` service alias below and SNI succeeds for either name.
     llm-gate = {
       enable = true;
       domain = "${hostConfig.hostName}.${userConfig.baseDomain}";
-      tlsMode = "internal";
+      tlsMode = "route53";
+      # Stable service-alias CNAME → this host, so consumers reach the gate by
+      # capability name rather than the host name. Composed from baseDomain
+      # (never a flat literal — matches the repo's FQDN convention).
+      extraHostnames = [ "llm-large.pve.${userConfig.baseDomain}" ];
     };
 
     # ========================================================================

--- a/hosts/mac-studio/home.nix
+++ b/hosts/mac-studio/home.nix
@@ -15,7 +15,6 @@
   # carried onto the Studio — ADR: llm-large-studio-serving.
   programs.mlx.huggingFaceHome = "${config.home.homeDirectory}/.cache/huggingface";
 
-  # Manual-query chat UI on loopback; the llm-gate Caddy fronts it with TLS on
-  # the LAN (:8443). Open WebUI keeps its own login, so no bearer on that site.
-  programs.open-webui.enable = true;
+  # The chat UI is no longer served here: the single cluster-hosted Open WebUI
+  # is the only chat UI. The llm-gate below is API-only (bearer-gated MLX).
 }

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -62,9 +62,11 @@ let
 
   # The API site answers for the host FQDN plus any service-alias hostnames.
   # Caddy takes a space-separated address list for a single site and obtains
-  # one certificate covering every listed hostname.
+  # one certificate covering every listed hostname. lib.unique guards against a
+  # duplicate site address (and duplicate cert request) if a consumer lists
+  # `domain` again in `extraHostnames`.
   apiSiteAddresses = lib.concatMapStringsSep " " (host: "https://${host}:${toString cfg.apiPort}") (
-    [ cfg.domain ] ++ cfg.extraHostnames
+    lib.unique ([ cfg.domain ] ++ cfg.extraHostnames)
   );
 in
 {

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -4,8 +4,10 @@
 # server stays bound to 127.0.0.1; this Caddy front terminates TLS on the
 # host's LAN address and enforces a bearer token (the OpenAI `api_key` field,
 # native in every consumer). It is the only network path to the model port.
-# A second TLS-only site fronts the local Open WebUI (which keeps its own
-# login, so no bearer there).
+# API-only: the chat UI moved to the single cluster-hosted Open WebUI, so this
+# gate no longer fronts a local web UI. `extraHostnames` lets the one API site
+# also answer for service aliases (e.g. an `llm-large.<subdomain>` CNAME) so
+# the cert/SNI covers them alongside the host FQDN.
 #
 # Fully declarative — no wrapper scripts: the ENTIRE Caddyfile is a sops-nix
 # template rendered at activation with the secrets inline (bearer token and,
@@ -57,6 +59,13 @@ let
             }''
     else
       "tls internal";
+
+  # The API site answers for the host FQDN plus any service-alias hostnames.
+  # Caddy takes a space-separated address list for a single site and obtains
+  # one certificate covering every listed hostname.
+  apiSiteAddresses = lib.concatMapStringsSep " " (host: "https://${host}:${toString cfg.apiPort}") (
+    [ cfg.domain ] ++ cfg.extraHostnames
+  );
 in
 {
   options.programs.llm-gate = {
@@ -66,6 +75,20 @@ in
       type = lib.types.str;
       example = "host.example.com";
       description = "Public FQDN the gate serves (certificate subject).";
+    };
+
+    extraHostnames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "llm-large.example.com" ];
+      description = ''
+        Additional hostnames the API site also answers for (e.g. a service-alias
+        CNAME pointing at this host). Each is added to the Caddy site address
+        list so the obtained certificate covers it and SNI succeeds — without
+        this, an alias hitting the gate fails TLS because the cert only covers
+        `domain`. In route53 mode the DNS-01 challenge is solved for every site
+        hostname automatically, so no per-name tls entry is needed.
+      '';
     };
 
     tlsMode = lib.mkOption {
@@ -87,18 +110,6 @@ in
       type = lib.types.port;
       default = 11434;
       description = "Loopback llama-swap port the API site proxies to.";
-    };
-
-    webUiPort = lib.mkOption {
-      type = lib.types.port;
-      default = 8443;
-      description = "TLS port for the Open WebUI site (no bearer — the UI has its own login).";
-    };
-
-    webUiUpstreamPort = lib.mkOption {
-      type = lib.types.port;
-      default = 8080;
-      description = "Loopback Open WebUI port the UI site proxies to.";
     };
 
     dataDir = lib.mkOption {
@@ -126,18 +137,13 @@ in
           auto_https disable_redirects
         }
 
-        https://${cfg.domain}:${toString cfg.apiPort} {
+        ${apiSiteAddresses} {
           ${tlsDirective}
           @unauthorized not header Authorization "Bearer ${
             config.sops.placeholder."LLM_LARGE_BEARER_TOKEN"
           }"
           respond @unauthorized 401
           reverse_proxy 127.0.0.1:${toString cfg.apiUpstreamPort}
-        }
-
-        https://${cfg.domain}:${toString cfg.webUiPort} {
-          ${tlsDirective}
-          reverse_proxy 127.0.0.1:${toString cfg.webUiUpstreamPort}
         }
       '';
     };


### PR DESCRIPTION
## Summary

nix-darwin side of the LLM-fabric re-architecture (Phase 4). Hardens the mac-studio `llm-large` serving gate and retires the Mac-local chat UI in favour of the single cluster-hosted Open WebUI.

Pairs with **dryvist/nix-ai#1113** (the client endpoint refactor). Independent of it at merge time — the nix-ai input follows the branch, so the open-webui-removal lock bump lands after that PR merges.

## What changed

- **Open WebUI removed locally.** Dropped `programs.open-webui.enable` from `hosts/mac-studio/home.nix`; the single cluster-hosted Open WebUI is now the only chat UI.
- **Gate is API-only.** Stripped the second (WebUI) Caddyfile site and the `webUiPort` / `webUiUpstreamPort` options from `modules/darwin/llm-gate.nix`. One site remains: the bearer-gated OpenAI-compatible API reverse-proxied to loopback llama-swap.
- **`programs.llm-gate.extraHostnames` (new).** Additional hostnames the API site answers for. They join the Caddy site address list so the obtained cert covers them and SNI succeeds for a service-alias CNAME. Without it, an alias hitting the gate fails TLS because the cert only covers `domain`. In route53 mode the DNS-01 challenge is solved for every site hostname automatically, so no per-name `tls` entry is needed.
- **Studio flipped to `tlsMode = "route53"`** (real Let's Encrypt via DNS-01) and `extraHostnames` set to the `llm-large.<subdomain>` alias, composed from `baseDomain` (never a flat literal — matches the repo's FQDN convention, same as `haproxy.pve.${baseDomain}`).
- MANIFEST + stale comments updated.

## SOPS

**No secret changes were needed.** The three route53 ACME keys (`LLM_GATE_AWS_ACCESS_KEY_ID`, `LLM_GATE_AWS_SECRET_ACCESS_KEY`, `LLM_GATE_AWS_REGION`) plus `LLM_LARGE_BEARER_TOKEN` are **already present and non-empty** in `secrets/llm-large.yaml` (encrypted to both machine age recipients). Verified non-interactively by decrypting and checking each value is a non-empty string (booleans only, values never printed). So flipping to route53 is fully provisioned — no `sops set` / `sops updatekeys` pre-rebuild step required.

## Testing

- `nix eval .#darwinConfigurations.jevans-ms.system.drvPath` — evaluates cleanly (full darwin + home-manager module tree, incl. the sops-rendered Caddyfile).
- Rendered `sops.templates."llm-gate.Caddyfile".content` inspected: **one** API site whose address list is `https://<host-fqdn>:11434 https://llm-large.<subdomain>:11434`, route53 `tls { dns route53 { … } }` with the three SOPS placeholders, the `Bearer` 401 gate, and `reverse_proxy 127.0.0.1:11434`. No WebUI site. All secrets are SOPS placeholders (rendered at activation, never plaintext in the store).
- `nixfmt`, `statix check`, `deadnix --fail` — clean on all changed files.
- Full `nix flake check` / `darwin-rebuild` runs in CI (not run locally, per repo convention).

Verification the CI can't cover: after merge + rebuild on the Studio, confirm Caddy obtains a route53 cert covering both the host FQDN and the `llm-large` alias and that an HTTPS request to the alias succeeds without an SNI/cert error.

## Follow-up (not in this PR)

`overlays/python-darwin-test-fixes.nix` patches two python packages that are runtime deps of `open-webui` (pulled in by the current-lock nix-ai). It is **intentionally kept** here: this PR does not bump the nix-ai lock, so `open-webui` is still in the closure at CI time and the overlay is still load-bearing. Once nix-ai#1113 merges and the lock bumps, that overlay becomes dead and can be removed alongside the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj