### PR TITLE
feat(homebrew): install Homebrew declaratively via nix-homebrew

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,6 +80,23 @@
         "type": "github"
       }
     },
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.1",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "browser-use-skills": {
       "flake": false,
       "locked": {
@@ -894,6 +911,24 @@
         "type": "github"
       }
     },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773222311,
@@ -1078,6 +1113,7 @@
         "mac-app-util": "mac-app-util",
         "nix-ai": "nix-ai",
         "nix-home": "nix-home",
+        "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
         "systems": "systems"

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # nix-homebrew: declaratively installs and owns the /opt/homebrew prefix.
+    # nix-darwin's `homebrew` module manages the Brewfile (taps/brews/casks) but
+    # does NOT install the brew binary — so a fresh host (e.g. jevans-ms) fails
+    # `brew bundle` at activation with "command not found: brew". This module
+    # bootstraps Homebrew itself, making activation self-sufficient on any host.
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+
   };
 
   outputs =
@@ -110,6 +117,7 @@
       nix-home,
       determinate,
       sops-nix,
+      nix-homebrew,
       dotgithub,
       ...
     }:
@@ -172,6 +180,25 @@
 
             # sops-nix: decrypts age-encrypted secrets to /run/secrets at activation
             sops-nix.darwinModules.sops
+
+            # nix-homebrew: owns the /opt/homebrew install so the homebrew module's
+            # `brew bundle` works on a fresh host without a manual bootstrap.
+            nix-homebrew.darwinModules.nix-homebrew
+            {
+              nix-homebrew = {
+                enable = true;
+                # Apple Silicon only — no Intel (Rosetta) prefix needed.
+                enableRosetta = false;
+                # User that owns /opt/homebrew (same across every host).
+                user = userConfig.user.name;
+                # Adopt an existing manual install (macbook-m4) instead of failing.
+                autoMigrate = true;
+                # Keep taps mutable: nix-darwin's `homebrew.taps` and per-agent
+                # nix-ai taps are applied via `brew tap` at activation. Setting
+                # this false would make the taps dir immutable and break them.
+                mutableTaps = true;
+              };
+            }
 
             # mac-app-util: Creates trampolines for system-level apps (/Applications/Nix Apps/)
             mac-app-util.darwinModules.default


### PR DESCRIPTION
## Why

nix-darwin's `homebrew` module manages the Brewfile (taps/brews/casks) but **does not install the `brew` binary itself**. On a fresh host — the new `jevans-ms` Studio — that means `brew bundle` fails at activation with `command not found: brew`. After verifying the rest of the Studio's activation path (sops age key + recipients are already wired; llm-gate/runner/claude jobs all fail-safe at runtime), **this is the single hard blocker to a clean end-to-end `darwin-rebuild switch --flake .#jevans-ms`.**

This makes nix-darwin responsible for the Homebrew install, per the design intent that a host be fully reproducible from the flake.

## What

Add [`nix-homebrew`](https://github.com/zhaofengli/nix-homebrew) to own the `/opt/homebrew` prefix:

- `enableRosetta = false` — Apple Silicon only, no Intel prefix.
- `user` = the login user (owns the prefix; identical on every host).
- `autoMigrate = true` — adopt macbook-m4's **existing manual install** instead of failing activation.
- `mutableTaps = true` — nix-darwin's `homebrew.taps` and nix-ai's per-agent taps still apply via `brew tap`; flipping this false would make the taps dir immutable and break them.

The lock adds only `nix-homebrew` + its pinned `brew-src` (no duplicate nixpkgs), so no `follows` is required.

## Verification

- `nix flake check` passes for both `jevans-mbp` and `jevans-ms`.
- **Full `jevans-ms` system closure builds locally** (`nix build .#darwinConfigurations.jevans-ms.system` → `darwin-system-25.11.ebec37a`), including the new `setup-homebrew` and patched-`brew` derivations — no build-time blockers.
- `nix fmt` / `statix` / `deadnix` clean.

### Activation-time (needs the actual hosts — cannot run in CI or cross-build)

- **macbook-m4**: first switch runs `autoMigrate` to adopt the existing `/opt/homebrew`. This is the one behavior worth watching on the primary workstation.
- **jevans-ms**: first switch performs a clean Homebrew install, then `brew bundle` installs the `container` brew (needs network + homebrew/core auto-tap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)