### PR TITLE
chore: remove ccusage entirely

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -158,7 +158,6 @@ Source: `modules/darwin/homebrew.nix`
 
 | Package | Description |
 | --- | --- |
-| ccusage | Claude Code usage analyzer |
 | container | Apple container CLI/runtime for Linux containers on Apple Silicon |
 | block-goose-cli | Block's Goose AI agent |
 | whisperkit-cli | Swift native on-device speech recognition (Apple Silicon) |

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -66,9 +66,6 @@ let
   agentHomebrewCasks = nix-ai.lib.homebrewCasks or [ ];
 
   workstationBrews = [
-    # CLI tools (only if not available in nixpkgs)
-    "ccusage" # Claude Code usage analyzer - not in nixpkgs
-
     # Mac App Store CLI — required by homebrew.masApps below.
     "mas"
     # Apple container CLI/runtime. Homebrew tracks current upstream while


### PR DESCRIPTION
Removes the `ccusage` Homebrew brew (Claude Code usage analyzer) and its `MANIFEST.md` row. Unused; removed at the user's request — the menu-bar item they'd flagged was actually the auto-claude SwiftBar plugin (removed separately), and ccusage itself is a redundant CLI.

The workstation install is being uninstalled directly (`cleanup = "none"` on the workstation means removing it from the Brewfile does not auto-uninstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)