### PR TITLE
fix(renovate): repair cribl-edge datasource + migrate deprecated options

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,7 +16,7 @@
   ],
 
   // Repository settings
-  "baseBranches": ["main"],
+  "baseBranchPatterns": ["main"],
   "labels": ["dependencies", "renovate"],
   "assignees": ["@JacobPEvans-personal"],
   "reviewers": ["@JacobPEvans-personal"],
@@ -32,7 +32,7 @@
     "cribl-edge": {
       "defaultRegistryUrlTemplate": "https://cdn.cribl.io/versions.json",
       "format": "json",
-      "transformTemplates": ["{\"releases\":[{\"version\":value.version}]}"]
+      "transformTemplates": ["{\"releases\":[{\"version\":version}]}"]
     }
   },
 
@@ -78,7 +78,7 @@
         "obra/superpowers-marketplace"
       ],
       "groupName": "ai-tools-external",
-      "schedule": ["after 7am every day"]
+      "schedule": ["after 7am"]
     },
 
     // GROUP 3: GitHub Actions - Weekly Monday 7am
@@ -131,5 +131,5 @@
   },
 
   // Platform-specific settings
-  "platformCommit": true // Use GitHub API for commits (enables signing)
+  "platformCommit": "enabled" // Use GitHub API for commits (enables signing)
 }


### PR DESCRIPTION
## Summary

The `cribl-edge` custom datasource has been silently failing — Renovate's dependency dashboard reports:

> Failed to look up custom.cribl-edge package `cribl-edge`: no-result

**Root cause:** the JSONata `transformTemplates` referenced `value.version`, but `https://cdn.cribl.io/versions.json` returns a **flat** object with no `value` wrapper:

```json
{"version":"4.18.2-fd1f0d2f","downloadUrl":"https://cribl.io/download"}
```

So the transform resolved to `null` → empty releases → `no-result`, and cribl-edge version tracking has been frozen (the adjacent comment on line 30 already documents the correct flat shape). Fixed by referencing `version` at the root, per Renovate's [custom datasource docs](https://docs.renovatebot.com/modules/datasource/custom/).

## Changes

- **Fix (substantive):** `transformTemplates` `value.version` → `version` — unfreezes cribl-edge updates.
- **Migrations (clears the dashboard "Config Migration Needed" nag):**
  - `baseBranches` → `baseBranchPatterns`
  - `"after 7am every day"` → `"after 7am"` (drop redundant `every day`)
  - `platformCommit: true` → `"enabled"`

## Test plan

- `renovate-config-validator --strict renovate.json5` → **validates clean, zero migration warnings** (was: 1 migration warning before, and the datasource silently broken).
- Post-merge: confirm the next Renovate run resolves cribl-edge (dashboard `no-result` warning clears) and the "Config Migration Needed" checkbox disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)