### PR TITLE
fix: log app removal + silence local nixfmt/menu-bar noise

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -255,7 +255,7 @@
       # Development shell for CI and local nix tooling
       devShells.aarch64-darwin.default = nixpkgs.legacyPackages.aarch64-darwin.mkShell {
         packages = with nixpkgs.legacyPackages.aarch64-darwin; [
-          nixfmt-rfc-style
+          nixfmt
           statix
           deadnix
           treefmt

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -214,6 +214,7 @@ in
     # 26 display-name variants (e.g. "Keynote Creator Studio.app"); the removal
     # runs as root at activation and `rm -rf` is idempotent.
     activationScripts.postActivation.text = lib.mkAfter ''
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removing unused Apple iWork/iLife apps from /Applications..."
       rm -rf /Applications/Keynote*.app /Applications/Numbers*.app /Applications/Pages*.app /Applications/GarageBand*.app /Applications/iMovie*.app
     '';
 

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -6,13 +6,13 @@
   darwinConfigurations ? { },
 }:
 {
-  # Check Nix formatting with nixfmt-rfc-style
+  # Check Nix formatting with nixfmt
   # Uses treefmt configured with nixfmt formatter
   # Copy source to writable $TMPDIR since treefmt needs to write temp files
   formatting =
     pkgs.runCommand "check-formatting"
       {
-        nativeBuildInputs = [ pkgs.nixfmt-rfc-style ];
+        nativeBuildInputs = [ pkgs.nixfmt ];
       }
       ''
         cp -r ${src} $TMPDIR/src

--- a/modules/darwin/system-ui.nix
+++ b/modules/darwin/system-ui.nix
@@ -97,7 +97,8 @@
   };
 
   # --- Activation Scripts - Menu Bar Spacing ---
-  # Must use -currentHost flag; requires logout/login to fully apply
+  # Must use -currentHost flag (nix-darwin system.defaults cannot write the
+  # ByHost domain). Changes take effect on the next logout/login.
   system.activationScripts.postActivation.text = lib.mkAfter ''
     # NOTE: Follows CRITICAL RULES from docs/ACTIVATION-SCRIPTS-RULES.md:
     #   * NEVER use 'set -e' - errors must not abort activation
@@ -105,24 +106,17 @@
     #   * Must reach /run/current-system symlink update
 
     echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Applying menu bar spacing settings (compact mode)..."
-    spacing_applied=0
 
     if defaults -currentHost write -globalDomain NSStatusItemSpacing -int 4; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Menu bar icon spacing set to 4 (compact)"
-      spacing_applied=$((spacing_applied + 1))
     else
       echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to set NSStatusItemSpacing to 4 - check defaults permissions" >&2
     fi
 
     if defaults -currentHost write -globalDomain NSStatusItemSelectionPadding -int 8; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Menu bar icon padding set to 8 (compact)"
-      spacing_applied=$((spacing_applied + 1))
     else
       echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to set NSStatusItemSelectionPadding to 8 - check defaults permissions" >&2
-    fi
-
-    if [ $spacing_applied -gt 0 ]; then
-      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Note: Menu bar spacing changes require logout/login to fully take effect"
     fi
   '';
 }


### PR DESCRIPTION
Part of a multi-repo sweep to clear every warning a `darwin-rebuild switch` emits + honor "log everything you do".

## Changes
- **Log the app removal** — `hosts/common/default.nix`: the iWork/iLife `rm` ran silently; now emits a house-format `[INFO]` line.
- **`nixfmt-rfc-style` → `nixfmt`** — `lib/checks.nix` (CI formatting check) + `flake.nix` devShell. Clears the deprecation alias for CI/devShell. *(The warning seen during a host rebuild comes from nix-home's `home.packages` — companion PR.)*
- **Menu-bar note** — `modules/darwin/system-ui.nix`: drop the passive "requires logout/login" advisory + its dead `spacing_applied` counter. The `-currentHost` activation stays (ByHost defaults aren't expressible via `system.defaults`).

## Validation
- `nix fmt` / `statix` / `deadnix --fail` clean.
- Both host closures build.

## Companion PRs (same sweep)
- nix-ai: codex `custom-instructions` → `context` rename warning.
- nix-claude-code: marketplace symlink churn (×24) + non-marketplace WARN (×3).
- nix-home: `nixfmt-rfc-style` → `nixfmt` in `home.packages` (the rebuild-visible source).