### PR TITLE
fix(studio): claude jobs use the vendor install path; ship ghostty terminfo on servers

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -226,4 +226,10 @@ in
     networkTuning.enable = lib.mkIf hostConfig.isServer (lib.mkDefault true); # socket buffers for LAN serving
     appleSiliconTunables.energyMode = lib.mkIf hostConfig.isServer (lib.mkDefault "unmanaged"); # no High Power Mode on a desktop
   };
+
+  # SSH sessions arrive from the workstation's Ghostty terminal; without its
+  # terminfo the remote zsh init spews "can't find terminal definition for
+  # xterm-ghostty" on every login. Workstations get the entry from the app
+  # itself; headless hosts ship just the terminfo output.
+  environment.systemPackages = lib.optionals hostConfig.isServer [ pkgs.ghostty-bin.terminfo ];
 }

--- a/modules/darwin/apps/claude-scheduled-jobs.nix
+++ b/modules/darwin/apps/claude-scheduled-jobs.nix
@@ -143,7 +143,7 @@ in
 
     claudeBin = lib.mkOption {
       type = lib.types.str;
-      default = "/Users/${cfg.user}/.local/bin/claude";
+      default = "${homeDir}/.local/bin/claude";
       description = "Path to the claude CLI binary. Default is the vendor self-updating install, bootstrapped once per host with `claude-latest-install` (shipped in the per-user profile); the nix profile carries no `claude` binary of its own.";
     };
 

--- a/modules/darwin/apps/claude-scheduled-jobs.nix
+++ b/modules/darwin/apps/claude-scheduled-jobs.nix
@@ -39,11 +39,13 @@ let
   homeDir = "/Users/${cfg.user}";
   logDir = "${homeDir}/Library/Logs/claude-jobs";
 
-  # Per-user nix profile first (where `claude`, `git`, `gh` live), then the
-  # system profile and Homebrew, then the base system — mirrors the maestro /
-  # github-runner agent PATH shape so an unattended agent resolves the same
-  # tools an interactive login shell would.
+  # Vendor-installed claude first (~/.local/bin — the self-updating build that
+  # `claude-latest-install` bootstraps), then the per-user nix profile (git,
+  # gh), the system profile and Homebrew, then the base system — mirrors an
+  # interactive login shell's resolution order so an unattended agent finds
+  # the same tools.
   agentPath = lib.concatStringsSep ":" [
+    "${homeDir}/.local/bin"
     "/etc/profiles/per-user/${cfg.user}/bin"
     "/run/current-system/sw/bin"
     "/opt/homebrew/bin"
@@ -141,8 +143,8 @@ in
 
     claudeBin = lib.mkOption {
       type = lib.types.str;
-      default = "/etc/profiles/per-user/${cfg.user}/bin/claude";
-      description = "Path to the claude CLI binary (defaults to the per-user nix profile).";
+      default = "/Users/${cfg.user}/.local/bin/claude";
+      description = "Path to the claude CLI binary. Default is the vendor self-updating install, bootstrapped once per host with `claude-latest-install` (shipped in the per-user profile); the nix profile carries no `claude` binary of its own.";
     };
 
     jobs = lib.mkOption {


### PR DESCRIPTION
## Summary

Observed on jevans-ms: `zsh: command not found: claude` plus `can't find terminal definition for xterm-ghostty` through every SSH login.

- **claudeBin default** pointed at `/etc/profiles/per-user/<user>/bin/claude`, but the nix profile ships no claude binary — the CLI is the vendor self-updating install at `~/.local/bin/claude`, bootstrapped once per host via `claude-latest-install`. Default and the agent PATH now lead with that location.
- **ghostty terminfo**: server-class hosts now ship `ghostty-bin.terminfo`, so SSH sessions from the workstation's Ghostty stop erroring through zsh init.

Operational follow-up on the Studio after merge+rebuild: run `claude-latest-install`, then `claude /login`.

## Verification

- `jevans-mbp` drvPath **byte-identical to main**; `jevans-ms` delta is the agent plist + terminfo output only
- pre-commit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT