### PR TITLE
fix(deps): bump nix-ai for the transformers 5.12.0 pin (serving outage)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -735,11 +735,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783186471,
-        "narHash": "sha256-jyOX2/4/rkz6XwAOBAjzEHcarex1LaqGmpI5StZPcPw=",
+        "lastModified": 1783187667,
+        "narHash": "sha256-fMC30rtOPZcwdQ81ggqIUkkRmFKMGTqSVq448vxz/40=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ecf38d1980023a04779554aa6aa170af9c934b51",
+        "rev": "d923607393b62db6afb92cfb5f934c0694078e14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls [dryvist/nix-ai#1119](https://github.com/dryvist/nix-ai/pull/1119) — transformers 5.13.0 broke mlx-lm's import and crash-looped every vllm-mlx worker on both hosts. This bump delivers the pinned wrapper so a rebuild restores serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT