### PR TITLE
chore: move weekly sweep to Sun 05:00 UTC (fires tonight)

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -20,7 +20,7 @@ name: Issue Backlog Sweep
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
+    - cron: "0 5 * * 0" # Sundays 05:00 UTC (Sat night ~01:00 EDT) — weekly ai:ready top-up
 
 permissions:
   contents: read


### PR DESCRIPTION
Moves the backlog-sweep cron from Mon 09:00 UTC to Sun 05:00 UTC (~01:00 EDT) so the first wave runs tonight instead of Monday. Weekly cadence unchanged; guards intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)