### PR TITLE
fix(llm-gate,gh-runner): drop RunAtLoad — it defeats KeepAlive.PathState

### DIFF
--- a/modules/darwin/apps/github-runner-container.nix
+++ b/modules/darwin/apps/github-runner-container.nix
@@ -160,15 +160,15 @@ in
 
     # Foreground `container run` supervised by launchd KeepAlive: the VM
     # exits after one job (EPHEMERAL) and launchd starts the next one.
-    # PathState, not `true`: the --env-file lives under /run/secrets
-    # (= /private/var/run), cleared at boot and only present after the
-    # activation/boot render — a plain KeepAlive races it and launchd backs
-    # off indefinitely on loss (same failure class as llm-gate). PathState
-    # holds the agent until the file exists and self-heals if it reappears.
+    # PathState, not `true` — and NO RunAtLoad, which would spawn before the
+    # boot sops render exists and strand the job in "spawn scheduled" when
+    # the file-creation event lands between runs (the llm-gate 2026-07-04
+    # reboot failure). PathState alone starts the agent exactly when the
+    # rendered env-file exists, keeps it running while it exists, and
+    # self-heals if the file reappears after a /var/run wipe.
     launchd.user.agents.gh-runner.serviceConfig = {
       Label = "com.nix-darwin.gh-runner";
       ProgramArguments = runArgs;
-      RunAtLoad = true;
       KeepAlive = {
         PathState = {
           "${cfg.secretsFile}" = true;

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -165,16 +165,17 @@ in
           "--adapter"
           "caddyfile"
         ];
-        RunAtLoad = true;
-        # PathState, not `true`: the Caddyfile is a sops-rendered file under
-        # /run/secrets (= /private/var/run), which macOS clears at boot and
-        # which only exists after the activation/boot render. A plain
-        # KeepAlive races that render — caddy spawns first, exits, and
-        # launchd backs off indefinitely (observed: exit 78, "spawn
-        # scheduled" forever; one boot won the race, the next lost it).
-        # PathState makes launchd hold the daemon until the config exists
-        # and respawn it whenever the file reappears — which also
-        # self-heals after any mid-uptime /var/run wipe.
+        # NO RunAtLoad: it defeats KeepAlive.PathState. RunAtLoad spawns the
+        # job at boot BEFORE the sops render exists — caddy exits 78
+        # (EX_CONFIG), and because the config file's creation event fires
+        # while the job is between runs, launchd never re-evaluates and the
+        # daemon sits in "spawn scheduled" forever (observed on the
+        # 2026-07-04 reboot, runs=1). With PathState alone, launchd starts
+        # the daemon exactly when the rendered Caddyfile exists, keeps it
+        # running while it exists, and respawns it whenever the file
+        # reappears — which also self-heals after any mid-uptime /var/run
+        # wipe. The Caddyfile is sops-rendered under /run/secrets
+        # (= /private/var/run), which macOS clears at boot.
         KeepAlive = {
           PathState = {
             "${config.sops.templates."llm-gate.Caddyfile".path}" = true;


### PR DESCRIPTION
## Summary

The 2026-07-04 Studio reboot reproduced the exact failure [#1425](https://github.com/dryvist/nix-darwin/pull/1425) was meant to fix: `RunAtLoad = true` spawns caddy at boot **before** the sops render exists → exit 78 (EX_CONFIG) → the rendered file's creation fsevent lands while the job is between runs → launchd never re-evaluates → `spawn scheduled` forever (`runs = 1`).

PathState only works if launchd is also allowed to defer the **first** spawn. Dropping `RunAtLoad` gives the canonical run-while-file-exists semantics: start exactly when the rendered config exists, respawn whenever it reappears (mid-uptime /var/run wipes included). Same correction applied to the gh-runner agent, which shares the pattern.

## Verification

- `jevans-mbp` drvPath byte-identical to main (neither module active on the laptop)
- pre-commit green
- Rollout: Studio rebuild reloads both plists (changed content), which bootstraps the gate with the config present — restoring the LAN endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT