### PR TITLE
fix(home): resolve xterm-ghostty terminfo at early login-shell init

### DIFF
--- a/hosts/common/ghostty-terminfo.nix
+++ b/hosts/common/ghostty-terminfo.nix
@@ -1,0 +1,18 @@
+# Ghostty terminfo DB (just the DB, not the GUI app) on every host, so SSHing
+# in from a Ghostty terminal — which sets TERM=xterm-ghostty — resolves cleanly
+# even on a headless server that drops the workstation GUI package list.
+#
+# Split out of home.nix to keep that file under the per-file byte cap
+# (_file-size.yml). Must be the `-bin` variant: ghostty.terminfo (source build)
+# fails its darwin assert. macbook-m4 already pulls this store path via ghostty-bin.
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.ghostty-bin.terminfo ];
+
+  # Also expose it via ~/.terminfo — the directory ncurses searches by DEFAULT,
+  # with no env var. The nix profile terminfo is only found once hm-session-vars.sh
+  # exports TERMINFO_DIRS, and that runs AFTER early login-shell init — so SSHing
+  # in printed "can't find terminal definition for xterm-ghostty" 4x before it
+  # took effect. ~/.terminfo resolves from the very first line of shell init.
+  home.file.".terminfo".source = "${pkgs.ghostty-bin.terminfo}/share/terminfo";
+}

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -8,7 +8,6 @@
 {
   config,
   lib,
-  pkgs,
   userConfig,
   osConfig,
   hostConfig,
@@ -26,6 +25,8 @@
     ./mlx-no-autodiscover.nix
     # Global git excludes seeded from the dryvist org-default (see module).
     ./git-global-excludes.nix
+    # Ghostty terminfo (package + ~/.terminfo) — split out for the byte cap.
+    ./ghostty-terminfo.nix
   ];
 
   # Share system-level Homebrew taps with nix-ai's trust.json.
@@ -200,13 +201,6 @@
   # Nix does NOT manage the volume contents — it only creates the symlink. The
   # volume itself is created by a launchd daemon (modules/darwin/apps/orbstack.nix).
   home = {
-    # Ghostty terminfo (just the DB, not the GUI app) on every host so SSHing
-    # in from a Ghostty terminal — which sets TERM=xterm-ghostty — resolves
-    # cleanly even on a headless server that drops the workstation GUI package
-    # list. Must be the `-bin` variant: ghostty.terminfo (source build) fails
-    # its darwin assert. macbook-m4 already pulls this store path via ghostty-bin.
-    packages = [ pkgs.ghostty-bin.terminfo ];
-
     file = lib.mkIf (hostConfig.orbstack.enable or false) {
       # Symlink the entire Group Container so ALL OrbStack data (Docker images,
       # containers, volumes, Linux VMs, logs) lives on the dedicated APFS volume.


### PR DESCRIPTION
## Problem
SSHing into a host from a Ghostty terminal (which sets `TERM=xterm-ghostty`) prints this **4×** at login:
```
can't find terminal definition for xterm-ghostty
```
The `ghostty-bin.terminfo` is already in `home.packages`, but that only populates the **nix profile** terminfo, which ncurses finds solely through `TERMINFO_DIRS`. That variable is exported by `hm-session-vars.sh` — which runs *after* the earliest login-shell init (`set-environment`, and `hm-session-vars.sh` itself), so during that window `xterm-ghostty` is unresolvable.

(An earlier "it's fixed" claim was wrong — that check ran `TERM=xterm-256color`, sidestepping the exact lookup that fails.)

## Fix
Symlink the ghostty terminfo into **`~/.terminfo`** — a directory ncurses searches by **default**, with no env var. So `xterm-ghostty` resolves from the very first line of shell init.

```nix
home.file.".terminfo".source = "${pkgs.ghostty-bin.terminfo}/share/terminfo";
```

Wrapped the existing OrbStack `home.file` `mkIf` in `mkMerge` to add it unconditionally. Applies to all hosts (`hosts/common`).

## Verification
- Reproduced on jevans-ms via a faithful interactive login (`printf 'exit\n' | ssh -tt`): **4 errors**.
- After symlinking `~/.terminfo/78/xterm-ghostty` → the same store entry: **0 errors**.
- `nix fmt` / `statix` / `deadnix` clean; both host closures build; eval confirms `~/.terminfo` → the ghostty terminfo store dir.

Post-merge I'll rebuild both hosts (removing the manual test symlink on jevans-ms first so home-manager takes over cleanly) and confirm a fresh login is clean.