### PR TITLE
fix(llm-gate): move service alias to the public zone so DNS-01 issues

### DIFF
--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -75,10 +75,15 @@ in
       enable = true;
       domain = "${hostConfig.hostName}.${userConfig.baseDomain}";
       tlsMode = "route53";
-      # Stable service-alias CNAME → this host, so consumers reach the gate by
-      # capability name rather than the host name. Composed from baseDomain
-      # (never a flat literal — matches the repo's FQDN convention).
-      extraHostnames = [ "llm-large.pve.${userConfig.baseDomain}" ];
+      # Stable service-alias → this host, so consumers reach the gate by
+      # capability name rather than the host name. Placed one label directly
+      # under the base domain, NOT under an internal-only subdomain: the Caddy
+      # route53 resolver strips a single label to find the hosted zone, so a
+      # deeper name under a subdomain the public DNS provider does not host
+      # resolves to a zone it cannot write to and DNS-01 fails. One label under
+      # the public zone issues cleanly, same as the host FQDN. (A future
+      # public-facing capability name is tracked separately.)
+      extraHostnames = [ "llm-large.${userConfig.baseDomain}" ];
     };
 
     # ========================================================================

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -30,8 +30,8 @@
 #
 # TLS modes:
 #   route53  — real Let's Encrypt cert via DNS-01 against the public zone,
-#              using the same least-privilege `acme` AWS user Traefik already
-#              uses for *.pve ingress (credentials injected from Doppler).
+#              using the same least-privilege `acme` AWS user the cluster
+#              ingress already uses (credentials injected from Doppler).
 #   internal — Caddy's local CA (autonomous, no external dependency); clients
 #              must trust the CA or skip verification. Bring-up stopgap only.
 


### PR DESCRIPTION
## Summary

The gate's service alias sat one level too deep — under an internal-only subdomain the public DNS provider does not host. Caddy's route53 resolver strips a single label to find the hosted zone, so that name resolved to a zone it cannot write to and Let's Encrypt DNS-01 failed (`HostedZoneNotFound`). Placing the alias one label directly under the public base domain issues cleanly, the same as the host FQDN.

Also genericizes domain/topology literals that had crept into the gate module comments.

## Safety

Issuing this cert only creates and then removes a temporary `_acme-challenge` TXT record for the alias. The public apex, `www`, and docs records are untouched, and the `acme` IAM user is scoped to TXT writes only.

## Note

The cert issues regardless of DNS, but reaching the gate by the alias needs an A/CNAME → the host (additive, like the host FQDN already resolves) — a separate DNS step.

## Test plan

- Studio config evaluates clean; laptop drvPath byte-identical to main (server-class only).
- Post-merge: rebuild Studio, confirm the alias cert issues and serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)