### PR TITLE
chore(darwin): drop retired ollama runtime references (YAGNI)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Detailed structure of the nix-darwin configuration.
 ├── hosts/                         # Host-specific configurations
 │   └── macbook-m4/                # Active: M4 Max MacBook Pro
 │       ├── default.nix            # Darwin system settings
-│       └── home.nix               # User environment (Ollama, volumes)
+│       └── home.nix               # User environment (packages, volumes)
 │
 ├── modules/                       # Reusable configuration modules
 │   └── darwin/

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -766,7 +766,7 @@ sudo darwin-rebuild switch --flake ~/.config/nix
    { ... }:
    {
      # User-level config is provided by nix-ai and nix-home flake inputs.
-     # Host-specific user settings (e.g., Ollama, APFS volumes) go here.
+     # Host-specific user settings (e.g., APFS volumes) go here.
    }
    ```
 

--- a/docs/MACOS-LLM-PERFORMANCE-TUNING-PT2.md
+++ b/docs/MACOS-LLM-PERFORMANCE-TUNING-PT2.md
@@ -49,9 +49,6 @@ Tuned in the LLM-software session, recorded here so the boundary is explicit:
   class — the OS `iogpu.wired_limit_mb` cap alone does not prevent it.
 - **llama.cpp flags:** `-ngl 999` (offload all layers), `-fa` (flash attention), `--mlock`,
   `-t 12` (P-core count), `-c <ctx>`. `--mlock` interacts with the OS wired-memory cap.
-- **Ollama env (`OLLAMA_FLASH_ATTENTION`, `OLLAMA_KV_CACHE_TYPE=q8_0`, etc.):** N/A on this host —
-  Ollama is disabled (vllm-mlx is primary). If re-enabled it would be a LaunchAgent
-  `EnvironmentVariables` block in nix-ai, not here.
 
 ## Verification
 

--- a/docs/MACOS-LLM-PERFORMANCE-TUNING.md
+++ b/docs/MACOS-LLM-PERFORMANCE-TUNING.md
@@ -2,7 +2,7 @@
 
 Exhaustive reference for every macOS / hardware-layer knob that can affect local LLM inference on
 this machine — **Apple Silicon M4 Max MacBook Pro, 128 GB unified memory, macOS Tahoe 26.x**
-(frameworks: MLX / vllm-mlx, llama.cpp, Ollama, LM Studio).
+(frameworks: MLX / vllm-mlx, llama.cpp, LM Studio).
 
 Every parameter is recorded here even when left at its macOS default, so the OS surface is fully
 documented. Knobs that this repo wires declaratively link to their nix option; knobs that cannot be
@@ -12,7 +12,7 @@ set from nix (or belong to the LLM-software layer) are marked accordingly.
 
 This repo (`nix-darwin`) owns the **OS / launchd layer**: `sysctl`, `pmset`, `launchd`
 daemons/agents (incl. environment), `defaults`, filesystem. The **LLM-software layer** — MLX
-process-level memory limits, KV-cache bounds, llama.cpp/Ollama runtime flags — is tuned separately
+process-level memory limits, KV-cache bounds, llama.cpp runtime flags — is tuned separately
 and is listed under [Owned by the LLM-software layer](MACOS-LLM-PERFORMANCE-TUNING-PT2.md#owned-by-the-llm-software-layer-not-os-config)
 for completeness only.
 

--- a/docs/boot-failure/permanent-fix.md
+++ b/docs/boot-failure/permanent-fix.md
@@ -27,7 +27,7 @@ Boot Time (System Context)
     │    ⏳ Waits for /nix/store via /bin/wait4path
     │    ✅ Creates /run/current-system symlink ONLY
     │    No permission checks, just the critical symlink
-    │    Enables boot-time services (Ollama, OrbStack, etc.)
+    │    Enables boot-time services (OrbStack, etc.)
     │
     └──→ org.nixos.activate-system (original - LaunchDaemon)
          ❌ May fail: App Management requires GUI
@@ -204,7 +204,7 @@ After implementing, verify:
 2. **At boot (after mount)**: `org.nixos.symlink-boot` waits for `/nix/store`, then creates symlink
 3. **At boot (parallel)**: `org.nixos.activate-system` runs but may fail (no GUI) - doesn't matter,
    symlink-boot already created the symlink
-4. **Boot services start**: Ollama, OrbStack, etc. can now find their binaries
+4. **Boot services start**: OrbStack, etc. can now find their binaries
 5. **At login (fallback)**: `org.nixos.activation-recovery` checks if full activation is needed
 6. **If needed**: Runs `sudo /nix/var/nix/profiles/system/activate` with GUI context
 7. **User notified**: macOS notification confirms recovery (if it ran)

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -38,7 +38,6 @@ in
       "com.google.GoogleUpdater.wake" # Google hourly updater
       "us.zoom.updater" # Zoom hourly updater
       "us.zoom.updater.login.check" # Zoom login check at login
-      "com.ollama.ollama" # Redundant — vllm-mlx is primary inference server
       # Boot-time race condition daemons — crash-loop before dependencies ready,
       # corrupt WindowServer client dispatch table, cause sustained UI lag/freezes
       "com.apple.universalaccessd" # No accessibility features enabled

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -61,7 +61,6 @@ in
       # Remote Desktop
       "/Applications/Windows App.app"
 
-      # NOTE: Ollama runs headless via LaunchAgent, no dock icon needed.
       # NOTE: Additional AI tools (ChatGPT, Cursor) can be found in
       # ~/Applications/Home Manager Apps/, but they are not pinned to the Dock.
       # NOTE: RapidAPI, Postman, and Bitwarden removed from dock per #438


### PR DESCRIPTION
## Summary

Ollama is fully retired on both Macs (APFS volume destroyed, models archived to the HuggingFace volume, vllm-mlx is the sole local inference server). This removes the now-dead ollama references from nix-darwin under YAGNI.

## Changes
- **Config**: drop `"com.ollama.ollama"` from `disableUserServices` (`hosts/macbook-m4/default.nix`) — nothing to disable once the app is gone.
- **Comments/docs**: dock note, `ARCHITECTURE.md`, `RUNBOOK.md`, `docs/boot-failure/permanent-fix.md`, and the two `MACOS-LLM-PERFORMANCE-TUNING*.md` files.

## Deliberately kept (not the ollama runtime)
- **nix-ai** `ENABLE_OLLAMA_API = "False"` (Open WebUI) and fabric's `ollama/`-prefixed `DEFAULT_MODEL` / "ollama-compatible" comment — these reference the **API protocol** llama-swap exposes, not the ollama runtime. Removing them would break working config.
- CHANGELOG history — immutable release notes.

## Test Plan
- `nix eval` `jevans-mbp` config succeeds (disableUserServices removal valid).
- `nix fmt` + `markdownlint-cli2` clean.
- CI gate.