### PR TITLE
chore(deps): bump nix-ai flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -735,11 +735,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783270783,
-        "narHash": "sha256-VGxMmg33CZWPYrZbrbi8K9GcELByMD8Gngib5ve9huY=",
+        "lastModified": 1783271791,
+        "narHash": "sha256-d83or+bgCmG8XtyytO++vcMaWgxkyriJI09hRTgbrz0=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "0540279af00d8dad2b9698e9c59e17cff3d551dd",
+        "rev": "683595dd3259c8d7acdc9092df179c0ea00675b2",
         "type": "github"
       },
       "original": {
@@ -793,11 +793,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783187475,
-        "narHash": "sha256-Sbmy+fUtUHNiN6MaDK9arKYr5S7Qs2SIesRtKt748kM=",
+        "lastModified": 1783271602,
+        "narHash": "sha256-OiWFfUJ+tQhwfXxUnsdxY9E2xQd2NAOg0quSkMZ1sdg=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "c995e68cd1ac294d5f0ce85b39059f5af001b1a2",
+        "rev": "e058e7451002e90c49ed12e51dcdf4ab0cfc6492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Pulls in dryvist/nix-ai#1123 (bumps nix-claude-code, which itself picked up the nixos-26.05/release-26.05 doc updates from dryvist/nix-claude-code#82).

https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K