### PR TITLE
feat: add MacBook open harness tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,6 +80,33 @@
         "type": "github"
       }
     },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -110,6 +137,43 @@
       "original": {
         "owner": "browser-use",
         "repo": "browser-use",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
         "type": "github"
       }
     },
@@ -375,6 +439,29 @@
         "type": "github"
       }
     },
+    "dryvist-github_2": {
+      "inputs": {
+        "git-hooks": "git-hooks_2",
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1783187911,
+        "narHash": "sha256-8l412ghjDfCfTizwf4KEHPYYajnpofYsklqftmOTXmg=",
+        "owner": "dryvist",
+        "repo": ".github",
+        "rev": "6cc1827f36eaebbf52ed6b1e5d7c3c5f49580641",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dryvist",
+        "repo": ".github",
+        "type": "github"
+      }
+    },
     "fabric-src": {
       "flake": false,
       "locked": {
@@ -440,6 +527,22 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -475,6 +578,49 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-ai-open-harness",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -534,11 +680,58 @@
         "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
       }
     },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "dryvist-github",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
           "nix-ai",
           "nix-claude-code",
+          "dryvist-github",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-open-harness",
           "dryvist-github",
           "git-hooks",
           "nixpkgs"
@@ -745,6 +938,58 @@
       "original": {
         "owner": "dryvist",
         "repo": "nix-ai",
+        "type": "github"
+      }
+    },
+    "nix-ai-open-harness": {
+      "inputs": {
+        "dryvist-github": "dryvist-github_2",
+        "flake-parts": "flake-parts_3",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nix-ai-tools": "nix-ai-tools",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783284729,
+        "narHash": "sha256-WEbu2RTWQ76koGE42eyioW+Gd2lGbpQ187gNYphg0iE=",
+        "ref": "refs/heads/main",
+        "rev": "af7366fcbbcf5c527a4a154d06ad2a67ca7ce5e1",
+        "revCount": 2,
+        "type": "git",
+        "url": "ssh://git@github.com/dryvist/nix-ai-open-harness.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/dryvist/nix-ai-open-harness.git"
+      }
+    },
+    "nix-ai-tools": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix_3"
+      },
+      "locked": {
+        "lastModified": 1783243767,
+        "narHash": "sha256-iiQL/IHgQlmnZgKgs4wBOiDA9+S3tRFsQPRxtYIhUYo=",
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
+        "rev": "22f1080fb54a217bdda6cfd6eca5dbf9e7afddac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
         "type": "github"
       }
     },
@@ -1031,11 +1276,12 @@
         "home-manager": "home-manager",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "nix-ai": "nix-ai",
+        "nix-ai-open-harness": "nix-ai-open-harness",
         "nix-home": "nix-home",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
-        "systems": "systems"
+        "systems": "systems_2"
       }
     },
     "sops-nix": {
@@ -1076,6 +1322,21 @@
     },
     "systems": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
         "lastModified": 1689347925,
         "narHash": "sha256-ozenz5bFe1UUqOn7f60HRmgc01BgTGIKZ4Xl+HbocGQ=",
         "owner": "nix-systems",
@@ -1095,6 +1356,50 @@
           "nix-ai",
           "nix-claude-code",
           "dryvist-github",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "dryvist-github",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-open-harness",
+          "nix-ai-tools",
           "nixpkgs"
         ]
       },

--- a/flake.lock
+++ b/flake.lock
@@ -956,15 +956,15 @@
       "locked": {
         "lastModified": 1783284729,
         "narHash": "sha256-WEbu2RTWQ76koGE42eyioW+Gd2lGbpQ187gNYphg0iE=",
-        "ref": "refs/heads/main",
+        "owner": "dryvist",
+        "repo": "nix-ai-open-harness",
         "rev": "af7366fcbbcf5c527a4a154d06ad2a67ca7ce5e1",
-        "revCount": 2,
-        "type": "git",
-        "url": "ssh://git@github.com/dryvist/nix-ai-open-harness.git"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/dryvist/nix-ai-open-harness.git"
+        "owner": "dryvist",
+        "repo": "nix-ai-open-harness",
+        "type": "github"
       }
     },
     "nix-ai-tools": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
     # Focused fallback harness for open/local-LLM agent CLIs (Crush + MiMoCode).
     # Enabled only on workstation hosts that explicitly import the module below.
     nix-ai-open-harness = {
-      url = "git+ssh://git@github.com/dryvist/nix-ai-open-harness.git";
+      url = "github:dryvist/nix-ai-open-harness";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,16 @@
       };
     };
 
+    # Focused fallback harness for open/local-LLM agent CLIs (Crush + MiMoCode).
+    # Enabled only on workstation hosts that explicitly import the module below.
+    nix-ai-open-harness = {
+      url = "git+ssh://git@github.com/dryvist/nix-ai-open-harness.git";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        home-manager.follows = "home-manager";
+      };
+    };
+
     # Cross-platform home-manager modules (git, zsh, vscode, monitoring, shells)
     nix-home = {
       url = "github:dryvist/nix-home";
@@ -91,6 +101,7 @@
       darwin,
       home-manager,
       nix-ai,
+      nix-ai-open-harness,
       nix-home,
       determinate,
       sops-nix,
@@ -179,6 +190,9 @@
                 sharedModules = [
                   nix-ai.homeManagerModules.default
                   nix-home.homeManagerModules.default
+                ]
+                ++ lib.optionals (label == "macbook-m4") [
+                  nix-ai-open-harness.homeManagerModules.default
                 ];
               };
             }

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -4,10 +4,32 @@
 # keychain/token init, copyApps, MLX, OrbStack wiring) lives in ../common/home.nix.
 # This file adds only the host-unique bits — the TCC-sensitive GUI app list.
 
-{ pkgs, ... }:
+{
+  lib,
+  pkgs,
+  userConfig,
+  ...
+}:
 
+let
+  llmEndpoint = "https://llm.${userConfig.baseDomain}/v1";
+in
 {
   imports = [ ../common/home.nix ];
+
+  # Open local-LLM fallback harness. Workstation-only: flake.nix imports the
+  # module only for macbook-m4, and this host gets the runtime token from the
+  # automation keychain instead of a server-side sops file.
+  programs.openHarness = {
+    enable = true;
+    endpoint = llmEndpoint;
+    tokenEnvVar = "OPENAI_API_KEY";
+  };
+
+  programs.zsh.initContent = lib.mkAfter ''
+    # Local LLM router bearer token for OpenAI-compatible fallback harnesses.
+    export OPENAI_API_KEY=''${OPENAI_API_KEY:-"$(security find-generic-password -s 'OPENAI_API_KEY' -a '${userConfig.keychain.aiAccount}' -w '${userConfig.keychain.aiDb}' 2>/dev/null || echo "")"}
+  '';
 
   # ==========================================================================
   # TCC-Sensitive GUI Applications (using copyApps for stable paths)


### PR DESCRIPTION
## Summary
- add the private `nix-ai-open-harness` flake input via SSH
- enable the open harness Home Manager module only for `macbook-m4`
- route Crush and MiMoCode to the standard local LLM gateway and load the token from macOS Keychain at shell startup

## Validation
- `nix flake check`
- evaluated generated Crush config for `jevans-mbp`
- evaluated generated MiMoCode config for `jevans-mbp`
- confirmed `jevans-ms` does not receive the Crush config

Refs: dryvist/nix-ai-open-harness@af7366fcbbcf5c527a4a154d06ad2a67ca7ce5e1