### PR TITLE
fix(mac-studio): raise Qwen3-Coder output cap to 32768 for the Hermes brain

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -160,6 +160,23 @@
           pagedKvCache = false;
           enablePrefixCaching = false;
         };
+        # Global programs.mlx.maxRequestTokens (8192, see modules/mlx in nix-ai)
+        # hard-caps every client-requested max_tokens on this host — good
+        # general defense against a runaway generation, but too low for this
+        # model's actual job: it is Hermes's agent brain (NousResearch
+        # hermes-agent on LXC 517000), whose multi-turn tool-calling and
+        # truncation-recovery paths legitimately need more than 8192 output
+        # tokens per turn (a ~600-word explanation alone is close to that
+        # ceiling). Raise only this model's ceiling back to vllm-mlx's own
+        # 32768 server default; gpt-oss and any future model keep the tighter
+        # 8192 safety net. 32768 (not higher) also matches hermes-agent's own
+        # hardcoded retry-boost ceiling (NousResearch/hermes-agent
+        # conversation_loop.py `max(32768, requested_cap)`), so a truncated
+        # response's retry-boost lands exactly at the server's cap instead of
+        # exceeding it.
+        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = {
+          maxRequestTokens = 32768;
+        };
       };
     };
 


### PR DESCRIPTION
## NEEDS OWNER \`darwin-rebuild switch\` ON jevans-ms
This is a serving-config change; it has **no effect until rebuilt** on the Mac Studio.

## What
The global \`programs.mlx.maxRequestTokens\` (8192, tightened after the 2026-05/06 pipe-timeout storm) hard-caps every client-requested \`max_tokens\` on jevans-ms. That is too low for the one model whose job needs headroom: the \`Qwen3-Coder-30B-A3B\` backend is Hermes's agent brain (NousResearch hermes-agent on LXC 517000), whose multi-turn tool-calling and truncation-recovery paths legitimately request more than 8192 output tokens per turn.

Raise **only this model's** ceiling to vllm-mlx's own 32768 server default via a per-model \`modelFlagOverride\`. \`gpt-oss\` and any future model keep the tighter 8192 safety net. 32768 also matches hermes-agent's hardcoded retry-boost ceiling (\`max(32768, requested_cap)\`), so a truncated-response retry lands exactly at the server cap instead of exceeding it.

Memory headroom: unchanged — this is a request-size cap, not a KV/cache reservation. Both workers stay resident within the existing 118 GB wired ceiling.

## Context (companion PR)
Pairs with dryvist/ansible-proxmox-apps#658, which fixes the live 400/500 failures. That PR clamps Hermes's outgoing \`max_tokens\` at its **config** value (currently 8192) — so this rebuild raises the *server* ceiling, and the actual bigger-output UX benefit lands when the \`hermes_agent\` role's \`config.yaml model.max_tokens\` is bumped (≤32768) **after** this rebuild is live. Bumping it before the rebuild would re-introduce the 400.

## Verify after rebuild
\`\`\`
launchctl kickstart -k gui/$(id -u)/dev.vllm-mlx.server   # or reboot; picks up new Caddyfile/llama-swap cmd
# then from a router LXC, a max_tokens=16384 request to the Qwen coder should 200, not 400
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)