### PR TITLE
fix(mlx): Qwen3.6 swap models crash on load — parser args in wrong attr

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -150,18 +150,10 @@
           "--tool-call-parser"
           "qwen3_coder"
         ];
-        "mlx-community/Qwen3.6-35B-A3B-4bit" = [
-          "--tool-call-parser"
-          "qwen3_coder"
-          "--reasoning-parser"
-          "qwen3"
-        ];
-        "mlx-community/Qwen3.6-27B-A3B-4bit" = [
-          "--tool-call-parser"
-          "qwen3_coder"
-          "--reasoning-parser"
-          "qwen3"
-        ];
+        # Qwen3.6 parser args live on their mlx.models entries below —
+        # modelExtraArgs only reaches role-registry models (nix-ai
+        # modules/mlx default.nix registryModels), so keys for ad-hoc
+        # swap-tier models here are silently ignored.
       };
       # vllm-mlx 0.4.0's paged KV cache is incompatible with gpt-oss's
       # alternating sliding-window attention: generation fails with
@@ -210,11 +202,29 @@
     # the router can load either model on demand, and the swap group unloads it
     # after it goes idle so it does not crowd out the resident pair.
     mlx.models = {
+      # extraArgs must be set HERE, not in modelExtraArgs above: ad-hoc
+      # models get their serve flags only from this attr. Without the
+      # tool-call parser the global --enable-auto-tool-choice makes
+      # vllm-mlx exit at argparse ("--enable-auto-tool-choice requires
+      # --tool-call-parser"), so every swap-in 500'd with llama-swap's
+      # "upstream command exited prematurely" (found 2026-07-07 eval).
       "mlx-community/Qwen3.6-35B-A3B-4bit" = {
         ttl = 900;
+        extraArgs = [
+          "--tool-call-parser"
+          "qwen3_coder"
+          "--reasoning-parser"
+          "qwen3"
+        ];
       };
       "mlx-community/Qwen3.6-27B-A3B-4bit" = {
         ttl = 900;
+        extraArgs = [
+          "--tool-call-parser"
+          "qwen3_coder"
+          "--reasoning-parser"
+          "qwen3"
+        ];
       };
     };
 


### PR DESCRIPTION
Dogfood eval battery found both Qwen3.6 swap models returning HTTP 500 on every request (`llama-swap: upstream command exited prematurely`).

**Root cause:** their `--tool-call-parser qwen3_coder --reasoning-parser qwen3` flags were declared under `mlx.modelExtraArgs`, which the nix-ai mlx module only applies to **role-registry** models. Ad-hoc swap-tier `mlx.models` entries take flags from their own `extraArgs` attr (documented in nix-ai `options-runtime.nix`), so the parser flags were silently dropped — and the global `--enable-auto-tool-choice` then makes vllm-mlx exit at argparse: `--enable-auto-tool-choice requires --tool-call-parser`.

**Fix:** move the flags onto the two `mlx.models` entries; leave a comment where they were so the next model addition doesn't repeat this. `nix flake check --no-build` passes for both hosts. Reproduced + verified the bare worker loads clean on jevans-ms.

Follow-up filed against nix-ai: an eval-time assertion when a `modelExtraArgs` key matches no registry model, so this class of misconfiguration fails at build instead of at first request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j