### PR TITLE
fix(mlx): set safer vllm-mlx thinking defaults

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -100,12 +100,8 @@
     # 3.0 ≈ 111.5 GB. The 118 GB wired ceiling still has a small margin for the
     # proxy and framework while keeping the resident pair warm.
     #
-    # NOTE the two swap models are different architectures: 35B is the A3B MoE
-    # (3B active, ~113 tok/s measured); 27B is DENSE (no A3B variant exists on
-    # mlx-community — the id originally registered here, Qwen3.6-27B-A3B-4bit,
-    # was a phantom repo that 404'd on every load). Dense 27B decodes slower
-    # but runs all weights per token; keep it only if quality beats 35B-A3B in
-    # evals. Verify any new model id against huggingface BEFORE registering.
+    # 35B = A3B MoE (~113 tok/s); 27B = DENSE (no A3B variant exists — a
+    # phantom id 404'd here once). Verify new model ids on HF BEFORE registering.
     mlx = {
       cacheMemoryMb = 6144;
       prefillBatchSize = 2048;
@@ -162,10 +158,8 @@
           "--tool-call-parser"
           "qwen3_coder"
         ];
-        # Qwen3.6 parser args live on their mlx.models entries below —
-        # modelExtraArgs only reaches role-registry models (nix-ai
-        # modules/mlx default.nix registryModels), so keys for ad-hoc
-        # swap-tier models here are silently ignored.
+        # Swap-tier (mlx.models) args go on those entries below; keys here
+        # only reach role-registry models and are otherwise silently ignored.
       };
       # vllm-mlx 0.4.0's paged KV cache is incompatible with gpt-oss's
       # alternating sliding-window attention: generation fails with

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -152,6 +152,11 @@
           "harmony"
           "--reasoning-parser"
           "gpt_oss"
+          # Server defaults keep request-level chat_template_kwargs overrideable.
+          "--default-chat-template-kwargs"
+          (builtins.toJSON {
+            reasoning_effort = "low";
+          })
         ];
         "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = [
           "--tool-call-parser"
@@ -222,6 +227,11 @@
           "qwen3_coder"
           "--reasoning-parser"
           "qwen3"
+          # Default thinking off at the server layer so requests can opt back in.
+          "--default-chat-template-kwargs"
+          (builtins.toJSON {
+            enable_thinking = false;
+          })
         ];
       };
       "mlx-community/Qwen3.6-27B-4bit" = {
@@ -231,6 +241,11 @@
           "qwen3_coder"
           "--reasoning-parser"
           "qwen3"
+          # Default thinking off at the server layer so requests can opt back in.
+          "--default-chat-template-kwargs"
+          (builtins.toJSON {
+            enable_thinking = false;
+          })
         ];
       };
     };


### PR DESCRIPTION
## What changed
- Set `--default-chat-template-kwargs '{"enable_thinking": false}'` on the Qwen3.6 swap models.
- Set `--default-chat-template-kwargs '{"reasoning_effort":"low"}'` on the gpt-oss model.

## Why this path
The vllm-mlx source does parse reasoning on the non-stream path, but only after `engine.chat()` has already returned cleaned final text. The streaming path uses stateful chunk parsing and can separate reasoning before the final assembly step. For Qwen3, the post-hoc parser also needs a closing `</think>` to split reasoning from content, so truncated or implicit-thinking completions can collapse into `message.content`.

I did not patch upstream vllm-mlx in-tree because the minimal safe fix is not a one-line parser swap; preserving raw output across the engine/server boundary would be a broader change. The downstream server defaults avoid the polluted-content / token-burn failure mode now.

## Thinking defaults
- Qwen3.6: default thinking off at the server layer, but request-level `chat_template_kwargs.enable_thinking` can still re-enable it.
- gpt-oss: default `reasoning_effort=low` via the harmony renderer.
- I checked the nix-ai MLX module semantics first: `llama-swap` `setParams` is documented as set/override, so I avoided proxy filters here to keep per-request opt-in available.

## Verification
- `nix flake check --no-build` passed in the nix-darwin worktree.
- I confirmed the relevant vllm-mlx docs support server-wide chat-template defaults and request-level overrides.

## Before / after
- Before: live eval on jevans-ms today showed non-streaming chat completions returning only `message.content`, with thinking text polluting content and consuming the full token budget.
- After: this branch wires the server defaults so the affected models start from the safer thinking baseline.

## Upstream follow-up
I did not find an existing upstream issue matching this exact non-streaming reasoning-content gap. Suggested follow-up text if one is filed later:

> vllm-mlx non-streaming chat completions lose reasoning separation for reasoning models when the final output does not contain a closing delimiter, while streaming responses still emit reasoning deltas. The non-stream path should preserve or parse raw output with the same reasoning state machine used by streaming, or it should expose raw text separately before cleanup.
