### PR TITLE
fix(mlx): quote Qwen3.6 chat-template kwargs for llama-swap shell parsing

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -222,10 +222,12 @@
           "--reasoning-parser"
           "qwen3"
           # Default thinking off at the server layer so requests can opt back in.
+          # Ad-hoc mlx.models extraArgs are raw-concatenated into the llama-swap
+          # cmd (registry modelExtraArgs get escapeShellArgs; this path does
+          # not), and llama-swap shell-parses the cmd — so the JSON must carry
+          # its own single quotes to survive with double quotes intact.
           "--default-chat-template-kwargs"
-          (builtins.toJSON {
-            enable_thinking = false;
-          })
+          "'{\"enable_thinking\":false}'"
         ];
       };
       "mlx-community/Qwen3.6-27B-4bit" = {
@@ -236,10 +238,12 @@
           "--reasoning-parser"
           "qwen3"
           # Default thinking off at the server layer so requests can opt back in.
+          # Ad-hoc mlx.models extraArgs are raw-concatenated into the llama-swap
+          # cmd (registry modelExtraArgs get escapeShellArgs; this path does
+          # not), and llama-swap shell-parses the cmd — so the JSON must carry
+          # its own single quotes to survive with double quotes intact.
           "--default-chat-template-kwargs"
-          (builtins.toJSON {
-            enable_thinking = false;
-          })
+          "'{\"enable_thinking\":false}'"
         ];
       };
     };

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -221,11 +221,8 @@
           "qwen3_coder"
           "--reasoning-parser"
           "qwen3"
-          # Default thinking off at the server layer so requests can opt back in.
-          # Ad-hoc mlx.models extraArgs are raw-concatenated into the llama-swap
-          # cmd (registry modelExtraArgs get escapeShellArgs; this path does
-          # not), and llama-swap shell-parses the cmd — so the JSON must carry
-          # its own single quotes to survive with double quotes intact.
+          # Thinking off by default (requests can opt back in). extraArgs are
+          # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
           "--default-chat-template-kwargs"
           "'{\"enable_thinking\":false}'"
         ];
@@ -237,11 +234,8 @@
           "qwen3_coder"
           "--reasoning-parser"
           "qwen3"
-          # Default thinking off at the server layer so requests can opt back in.
-          # Ad-hoc mlx.models extraArgs are raw-concatenated into the llama-swap
-          # cmd (registry modelExtraArgs get escapeShellArgs; this path does
-          # not), and llama-swap shell-parses the cmd — so the JSON must carry
-          # its own single quotes to survive with double quotes intact.
+          # Thinking off by default (requests can opt back in). extraArgs are
+          # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
           "--default-chat-template-kwargs"
           "'{\"enable_thinking\":false}'"
         ];


### PR DESCRIPTION
Battery #3 found both Qwen3.6 swap models crashing at argparse after #1555: `--default-chat-template-kwargs must be a valid JSON object: Expecting property name enclosed in double quotes`.

Root cause: quoting asymmetry in the nix-ai mlx module — **registry** `modelExtraArgs` go through `lib.escapeShellArgs` (gpt-oss's kwargs arrive as `'{\"reasoning_effort\":\"low\"}'` and work), but **ad-hoc** `mlx.models.*.extraArgs` are raw-concatenated, and llama-swap shell-parses the cmd, eating the JSON's double quotes.

Fix: carry explicit single quotes in the two Qwen3.6 kwargs args (with a comment explaining why). Module-level normalization belongs in nix-ai — noted on dryvist/nix-ai#1128 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j