### PR TITLE
feat(logging): per-AI-CLI log capture + dedicated Cribl Edge shipping

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -1,0 +1,166 @@
+# Cribl log shipping (inference hosts) — Edge GitOps config + idle local Stream
+#
+# Split out of default.nix (repo file-size gate): the declarative Cribl Edge
+# config tree (inputs/outputs/pipelines/packs) and the disabled local Stream
+# aggregator. Imported unconditionally by ./default.nix; the Edge block gates
+# itself on `hostConfig ? mlx` (a local LLM box), so non-inference hosts get
+# nothing. See docs/CRIBL-GITOPS.md.
+
+{
+  lib,
+  pkgs,
+  hostConfig,
+  ...
+}:
+
+let
+  userConfig = import ../../lib/user-config.nix;
+in
+{
+  programs = {
+    # --- Cribl Edge (inference hosts) ---
+    # Log collection agent, standalone + GitOps-managed. Shared by every host
+    # that declares `mlx` (a local LLM box): the vllm-mlx log paths derive from
+    # the global userConfig homeDir, so the config is identical across machines.
+    # Live path: Edge ships TCP JSON to the HAProxy-fronted Cribl Stream
+    # workers' in_cribl_s2s ingest (service port 10300), which forward to the
+    # Splunk `llm` index. TCP JSON — not Cribl TCP: the cribl_tcp destination
+    # is refused on a standalone node ("Destination is not allowed in this
+    # deployment"; it requires a distributed deployment), and TCP JSON is
+    # Cribl's documented single-instance substitute. The persistent queue
+    # buffers events locally across any HAProxy/Stream downtime and flushes
+    # when the port returns. See docs/CRIBL-GITOPS.md.
+    cribl-edge = lib.mkIf (hostConfig ? mlx) {
+      enable = true;
+      mode = "standalone";
+      standalone.configFiles = {
+        # File source schema (Edge 4.18): manual mode requires `path` (a
+        # directory) + `filenames` (glob allowlist) — a bare `filenames` list
+        # fails validation ("should have required property 'path'") and takes
+        # the whole config load down with it. Shape mirrors the stock
+        # in_file_varlog entry in default/edge/inputs.yml.
+        "inputs.yml" = ''
+          inputs:
+            in_llm_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
+              filenames:
+                - vllm-mlx.log
+                - vllm-mlx.error.log
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - pipeline: llm_logs
+                  output: cribl_stream
+            in_system_metrics:
+              type: system_metrics
+              disabled: false
+              sendToRoutes: false
+              connections:
+                - pipeline: llm_metrics
+                  output: cribl_stream
+        '';
+        "outputs.yml" = ''
+          outputs:
+            cribl_stream:
+              type: tcpjson
+              # Homelab HAProxy (FQDN), load-balanced across the Cribl Stream
+              # workers' in_cribl_s2s ingest — the live path, service port 10300.
+              host: ${userConfig.logging.syslog.server}
+              port: 10300
+              pqEnabled: true
+        '';
+        # Model-server logs: the manager (Go) and its workers (Python) share
+        # the same two files; sourcetype is derived per line.
+        "pipelines/llm_logs/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "_raw.match(/^(INFO|DEBUG|WARNING|ERROR|CRITICAL):/) ? 'vllm:mlx' : 'llamaswap'"
+        '';
+        "pipelines/llm_metrics/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "'mlx:metrics'"
+        '';
+      };
+      packs = {
+        cc-edge-the-mac-pack-io = pkgs.fetchzip {
+          url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.3.0/cc-edge-the-mac-pack-io-v0.3.0.crbl";
+          extension = "tar.gz";
+          hash = "sha256-rPPAkedltxT8RWgP2xXil1o6x13HQK+SRgihuheJAks=";
+          stripRoot = false;
+        };
+      };
+    };
+
+    # --- Cribl Stream (local egress aggregator) — DISABLED (idle) ---
+    # The local-Stream cutover is reverted: cribl-edge ships directly to the
+    # Proxmox HAProxy (:10300), so a local Stream listening on :10301 receives
+    # nothing and sits idle. Apple `container` runs it as a lightweight VM whose
+    # `--memory` is the VM's RAM allocation (not a soft cap), so running it idle
+    # would tie up ~1 GB + a CPU for zero benefit — unacceptable on inference
+    # hosts where RAM is reserved for MLX. Kept configured (not deleted) so
+    # re-enabling is a one-line flip once the containerized Stream's CPU/DNS issue
+    # is fixed and the cutover is ready — right-size cpus/memory against real load
+    # THEN (the module defaults 1 cpu / 1g / 1 worker are conservative starting
+    # points, not a measured requirement). To re-enable: enable = lib.mkIf
+    # (hostConfig ? mlx) true. No explicit container DNS: Apple `container`
+    # forwards through the vmnet gateway to the host resolver. See docs/CRIBL-GITOPS.md.
+    cribl-stream = {
+      enable = false;
+      user = userConfig.user.name;
+      inputPort = 10301;
+      apiPort = 9000;
+      configFiles = {
+        "inputs.yml" = ''
+          inputs:
+            in_edge_s2s:
+              type: cribl_tcp
+              disabled: false
+              host: 0.0.0.0
+              port: 10301
+              sendToRoutes: false
+              connections:
+                - pipeline: passthrough
+                  output: proxmox_stream
+        '';
+        "outputs.yml" = ''
+          outputs:
+            proxmox_stream:
+              type: cribl_tcp
+              # Homelab HAProxy (FQDN), load-balanced across the Proxmox Cribl Stream workers.
+              host: ${userConfig.logging.syslog.server}
+              port: 10300
+              pqEnabled: true
+              # Bounded on-disk queue: cap size and drop when full.
+              pqMaxFileSize: 256 MB
+              pqMaxSize: 1 GB
+              pqOnBackpressure: drop
+        '';
+        # Passthrough for now; index/sourcetype enrichment moves here from Edge
+        # once Edge is repointed (Edge captures, Stream enriches + egresses).
+        "pipelines/passthrough/conf.yml" = ''
+          output: default
+          functions: []
+        '';
+      };
+    };
+  };
+}

--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -62,6 +62,61 @@ in
               connections:
                 - pipeline: llm_metrics
                   output: cribl_stream
+            # Per-AI-CLI session logs. Directories + rotation + the opt-in
+            # capture wrappers come from programs.ai-cli-log-shipping
+            # (enabled in ./default.nix). One input -> one dedicated tcpjson
+            # output per CLI so Stream routes/enriches per service port; no
+            # local pipeline — index/sourcetype stamping is Stream-side.
+            # `*.log` matches the wrapper typescript plus anything a CLI's
+            # own config drops into its directory.
+            in_codex_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/codex/
+              filenames:
+                - "*.log"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - output: cribl_codex
+            in_agy_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/agy/
+              filenames:
+                - "*.log"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - output: cribl_agy
+            in_copilot_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/copilot/
+              filenames:
+                - "*.log"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - output: cribl_copilot
+            in_vscode_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/vscode/
+              filenames:
+                - "*.log"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - output: cribl_vscode
         '';
         "outputs.yml" = ''
           outputs:
@@ -71,6 +126,29 @@ in
               # workers' in_cribl_s2s ingest — the live path, service port 10300.
               host: ${userConfig.logging.syslog.server}
               port: 10300
+              pqEnabled: true
+            # Per-AI-CLI service ports (one port per CLI so Stream keys
+            # routing/enrichment off the frontend). Same HAProxy target as
+            # cribl_stream; PQ buffers locally until each frontend is live.
+            cribl_codex:
+              type: tcpjson
+              host: ${userConfig.logging.syslog.server}
+              port: 10312
+              pqEnabled: true
+            cribl_agy:
+              type: tcpjson
+              host: ${userConfig.logging.syslog.server}
+              port: 10313
+              pqEnabled: true
+            cribl_copilot:
+              type: tcpjson
+              host: ${userConfig.logging.syslog.server}
+              port: 10314
+              pqEnabled: true
+            cribl_vscode:
+              type: tcpjson
+              host: ${userConfig.logging.syslog.server}
+              port: 10315
               pqEnabled: true
         '';
         # Model-server logs: the manager (Go) and its workers (Python) share
@@ -100,6 +178,9 @@ in
                     value: "'mlx:metrics'"
         '';
       };
+      # Claude Code logs stay on the pack -> cribl_stream (:10300) path; a
+      # repoint to a dedicated per-CLI port (:10311) is an optional future
+      # step once the Stream side carves out a claude frontend.
       packs = {
         cc-edge-the-mac-pack-io = pkgs.fetchzip {
           url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.3.0/cc-edge-the-mac-pack-io-v0.3.0.crbl";

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -14,6 +14,9 @@
   ...
 }:
 
+let
+  userConfig = import ../../lib/user-config.nix;
+in
 {
   imports = [
     # Darwin system modules
@@ -62,6 +65,15 @@
       enable = true;
       inherit (hostConfig) apfsContainer;
       volumes = hostConfig.apfsVolumes;
+    };
+
+    # Per-AI-CLI log directories (~/Library/Logs/<cli>/), newsyslog rotation,
+    # and opt-in `<cli>-logged` session-capture wrappers. All hosts: the dirs
+    # and rotation are harmless where a CLI is absent; the Cribl Edge file
+    # inputs that tail them (./cribl.nix) stay gated on `hostConfig ? mlx`.
+    ai-cli-log-shipping = {
+      enable = true;
+      user = userConfig.user.name;
     };
   };
 

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -3,9 +3,9 @@
 # Imported by every host's default.nix. Holds host-agnostic system config and
 # consumes registry parameters (networking.hostName, OrbStack). Inference hosts
 # (those that declare `mlx` in the registry) also get the shared vllm-mlx Cribl
-# log-shipping pipeline here — it is identical across machines. Host-specific
-# system config — streamline-login lists, energy / appleSiliconTunables values —
-# stays in hosts/<label>/default.nix.
+# log-shipping pipeline (./cribl.nix) — it is identical across machines.
+# Host-specific system config — streamline-login lists, energy /
+# appleSiliconTunables values — stays in hosts/<label>/default.nix.
 
 {
   lib,
@@ -14,13 +14,12 @@
   ...
 }:
 
-let
-  userConfig = import ../../lib/user-config.nix;
-in
 {
   imports = [
     # Darwin system modules
     ../../modules/darwin/common.nix
+    # Cribl Edge/Stream log shipping (self-gated on `hostConfig ? mlx`).
+    ./cribl.nix
   ];
 
   # Network hostname from the per-host registry.
@@ -63,151 +62,6 @@ in
       enable = true;
       inherit (hostConfig) apfsContainer;
       volumes = hostConfig.apfsVolumes;
-    };
-
-    # --- Cribl Edge (inference hosts) ---
-    # Log collection agent, standalone + GitOps-managed. Shared by every host
-    # that declares `mlx` (a local LLM box): the vllm-mlx log paths derive from
-    # the global userConfig homeDir, so the config is identical across machines.
-    # Live path: Edge ships TCP JSON to the HAProxy-fronted Cribl Stream
-    # workers' in_cribl_s2s ingest (service port 10300), which forward to the
-    # Splunk `llm` index. TCP JSON — not Cribl TCP: the cribl_tcp destination
-    # is refused on a standalone node ("Destination is not allowed in this
-    # deployment"; it requires a distributed deployment), and TCP JSON is
-    # Cribl's documented single-instance substitute. The persistent queue
-    # buffers events locally across any HAProxy/Stream downtime and flushes
-    # when the port returns. See docs/CRIBL-GITOPS.md.
-    cribl-edge = lib.mkIf (hostConfig ? mlx) {
-      enable = true;
-      mode = "standalone";
-      standalone.configFiles = {
-        # File source schema (Edge 4.18): manual mode requires `path` (a
-        # directory) + `filenames` (glob allowlist) — a bare `filenames` list
-        # fails validation ("should have required property 'path'") and takes
-        # the whole config load down with it. Shape mirrors the stock
-        # in_file_varlog entry in default/edge/inputs.yml.
-        "inputs.yml" = ''
-          inputs:
-            in_llm_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
-              filenames:
-                - vllm-mlx.log
-                - vllm-mlx.error.log
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - pipeline: llm_logs
-                  output: cribl_stream
-            in_system_metrics:
-              type: system_metrics
-              disabled: false
-              sendToRoutes: false
-              connections:
-                - pipeline: llm_metrics
-                  output: cribl_stream
-        '';
-        "outputs.yml" = ''
-          outputs:
-            cribl_stream:
-              type: tcpjson
-              # Homelab HAProxy (FQDN), load-balanced across the Cribl Stream
-              # workers' in_cribl_s2s ingest — the live path, service port 10300.
-              host: ${userConfig.logging.syslog.server}
-              port: 10300
-              pqEnabled: true
-        '';
-        # Model-server logs: the manager (Go) and its workers (Python) share
-        # the same two files; sourcetype is derived per line.
-        "pipelines/llm_logs/conf.yml" = ''
-          output: default
-          functions:
-            - id: eval
-              filter: "true"
-              conf:
-                add:
-                  - name: index
-                    value: "'llm'"
-                  - name: sourcetype
-                    value: "_raw.match(/^(INFO|DEBUG|WARNING|ERROR|CRITICAL):/) ? 'vllm:mlx' : 'llamaswap'"
-        '';
-        "pipelines/llm_metrics/conf.yml" = ''
-          output: default
-          functions:
-            - id: eval
-              filter: "true"
-              conf:
-                add:
-                  - name: index
-                    value: "'llm'"
-                  - name: sourcetype
-                    value: "'mlx:metrics'"
-        '';
-      };
-      packs = {
-        cc-edge-the-mac-pack-io = pkgs.fetchzip {
-          url = "https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/download/v0.3.0/cc-edge-the-mac-pack-io-v0.3.0.crbl";
-          extension = "tar.gz";
-          hash = "sha256-rPPAkedltxT8RWgP2xXil1o6x13HQK+SRgihuheJAks=";
-          stripRoot = false;
-        };
-      };
-    };
-
-    # --- Cribl Stream (local egress aggregator) — DISABLED (idle) ---
-    # The local-Stream cutover is reverted: cribl-edge ships directly to the
-    # Proxmox HAProxy (:10300), so a local Stream listening on :10301 receives
-    # nothing and sits idle. Apple `container` runs it as a lightweight VM whose
-    # `--memory` is the VM's RAM allocation (not a soft cap), so running it idle
-    # would tie up ~1 GB + a CPU for zero benefit — unacceptable on inference
-    # hosts where RAM is reserved for MLX. Kept configured (not deleted) so
-    # re-enabling is a one-line flip once the containerized Stream's CPU/DNS issue
-    # is fixed and the cutover is ready — right-size cpus/memory against real load
-    # THEN (the module defaults 1 cpu / 1g / 1 worker are conservative starting
-    # points, not a measured requirement). To re-enable: enable = lib.mkIf
-    # (hostConfig ? mlx) true. No explicit container DNS: Apple `container`
-    # forwards through the vmnet gateway to the host resolver. See docs/CRIBL-GITOPS.md.
-    cribl-stream = {
-      enable = false;
-      user = userConfig.user.name;
-      inputPort = 10301;
-      apiPort = 9000;
-      configFiles = {
-        "inputs.yml" = ''
-          inputs:
-            in_edge_s2s:
-              type: cribl_tcp
-              disabled: false
-              host: 0.0.0.0
-              port: 10301
-              sendToRoutes: false
-              connections:
-                - pipeline: passthrough
-                  output: proxmox_stream
-        '';
-        "outputs.yml" = ''
-          outputs:
-            proxmox_stream:
-              type: cribl_tcp
-              # Homelab HAProxy (FQDN), load-balanced across the Proxmox Cribl Stream workers.
-              host: ${userConfig.logging.syslog.server}
-              port: 10300
-              pqEnabled: true
-              # Bounded on-disk queue: cap size and drop when full.
-              pqMaxFileSize: 256 MB
-              pqMaxSize: 1 GB
-              pqOnBackpressure: drop
-        '';
-        # Passthrough for now; index/sourcetype enrichment moves here from Edge
-        # once Edge is repointed (Edge captures, Stream enriches + egresses).
-        "pipelines/passthrough/conf.yml" = ''
-          output: default
-          functions: []
-        '';
-      };
     };
   };
 

--- a/modules/darwin/apps/ai-cli-log-shipping.nix
+++ b/modules/darwin/apps/ai-cli-log-shipping.nix
@@ -1,0 +1,102 @@
+# Per-CLI AI Log Capture (directories + rotation + opt-in wrappers)
+#
+# One log home per AI coding CLI under ~/Library/Logs/<cli>/, rotated by the
+# system newsyslog run — the local half of the per-CLI Cribl Edge shipping
+# pipeline (hosts/common/cribl.nix tails each directory into its own tcpjson
+# output/service port). Model: claude-scheduled-jobs.nix (launchd logs +
+# /etc/newsyslog.d rotation) and nix-ai's fabric launchd module.
+#
+# Capture mechanism per CLI — deliberately conservative. These are
+# INTERACTIVE tools (TUIs and a GUI), not services: wrapping them in a
+# launchd agent or redirecting their stdio would break them, so no daemon is
+# invented here.
+#
+#   codex / agy / copilot — full-screen TUIs. Their stdout is the UI, so a
+#     plain `>>` redirect is useless AND breaks the TTY. Feasible capture is
+#     the opt-in `<cli>-logged` wrapper below: /usr/bin/script keeps a real
+#     pty (the TUI behaves normally) while appending the whole session
+#     typescript to ~/Library/Logs/<cli>/<cli>.log. ANSI sequences ride
+#     along; stripping is a Stream-side pipeline concern, not a capture
+#     concern. Structured logs (e.g. codex's own file logging under
+#     ~/.codex/log/) can additionally be pointed at this directory via the
+#     CLI's own configuration — that population is owned by the CLI config
+#     (nix-ai), not this module.
+#
+#   vscode — a GUI app; the `code` launcher detaches immediately, so there is
+#     nothing to wrap. The directory + rotation are still managed here; the
+#     files are populated by VS Code's own logging configuration (its native
+#     logs live under ~/Library/Application Support/Code/logs — point or copy
+#     the interesting channels here via user settings/tasks).
+#
+# Rotation uses a newsyslog glob (G flag) per directory so any additional
+# file a CLI's own config drops into its directory is rotated too — matching
+# the `*.log` glob the Edge file inputs tail.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.ai-cli-log-shipping;
+  homeDir = "/Users/${cfg.user}";
+  logRoot = "${homeDir}/Library/Logs";
+
+  # cli name -> whether an interactive pty wrapper is feasible (see header).
+  clis = {
+    codex = {
+      wrap = true;
+    };
+    agy = {
+      wrap = true;
+    };
+    copilot = {
+      wrap = true;
+    };
+    vscode = {
+      wrap = false;
+    };
+  };
+
+  wrappedClis = lib.attrNames (lib.filterAttrs (_: c: c.wrap) clis);
+
+  # Opt-in session capture: `codex-logged ...` runs codex on a real pty via
+  # /usr/bin/script, appending the typescript to the CLI's log file. The bare
+  # CLI name stays untouched — interactive use is never wrapped implicitly.
+  mkWrapper =
+    name:
+    pkgs.writeShellScriptBin "${name}-logged" ''
+      exec /usr/bin/script -q -a "${logRoot}/${name}/${name}.log" ${name} "$@"
+    '';
+in
+{
+  options.programs.ai-cli-log-shipping = {
+    enable = lib.mkEnableOption "per-AI-CLI log directories, newsyslog rotation, and opt-in session-capture wrappers";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      description = "macOS login user that owns the log directories (rotation re-creates files with this ownership).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = map mkWrapper wrappedClis;
+
+    # Create each log dir with user ownership (install -d would otherwise
+    # leave missing parents root-owned, blocking the user's log writes).
+    system.activationScripts.postActivation.text = lib.concatMapStrings (name: ''
+      /usr/bin/install -d -o ${cfg.user} -g staff "${logRoot}/${name}"
+    '') (lib.attrNames clis);
+
+    # Rotate via the system newsyslog run (reads /etc/newsyslog.d/*.conf on
+    # macOS). G = the path is a glob; J = bzip2 the rotated file.
+    environment.etc."newsyslog.d/ai-cli-logs.conf".text =
+      lib.concatStringsSep "\n" (
+        [ "# logfilename [owner:group] mode count size when flags" ]
+        ++ map (name: "${logRoot}/${name}/*.log ${cfg.user}:staff 644 3 1024 * GJ") (lib.attrNames clis)
+      )
+      + "\n";
+  };
+}

--- a/modules/darwin/apps/ai-cli-log-shipping.nix
+++ b/modules/darwin/apps/ai-cli-log-shipping.nix
@@ -68,6 +68,10 @@ let
   mkWrapper =
     name:
     pkgs.writeShellScriptBin "${name}-logged" ''
+      if ! command -v ${name} >/dev/null 2>&1; then
+        echo "Error: ${name} is not installed or not in PATH" >&2
+        exit 127
+      fi
       exec /usr/bin/script -q -a "${logRoot}/${name}/${name}.log" ${name} "$@"
     '';
 in
@@ -91,11 +95,14 @@ in
     '') (lib.attrNames clis);
 
     # Rotate via the system newsyslog run (reads /etc/newsyslog.d/*.conf on
-    # macOS). G = the path is a glob; J = bzip2 the rotated file.
+    # macOS). G = the path is a glob; J = bzip2 the rotated file; B = binary
+    # (no plain-text rotation message injected into logs Cribl Edge tails);
+    # N = no signal to syslogd (these files aren't syslogd-written). Mode 600:
+    # session transcripts carry prompts, code, and potentially tokens.
     environment.etc."newsyslog.d/ai-cli-logs.conf".text =
       lib.concatStringsSep "\n" (
         [ "# logfilename [owner:group] mode count size when flags" ]
-        ++ map (name: "${logRoot}/${name}/*.log ${cfg.user}:staff 644 3 1024 * GJ") (lib.attrNames clis)
+        ++ map (name: "${logRoot}/${name}/*.log ${cfg.user}:staff 600 3 1024 * BGJN") (lib.attrNames clis)
       )
       + "\n";
   };

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -9,6 +9,7 @@ _:
 
 {
   imports = [
+    ./ai-cli-log-shipping.nix
     ./apfs-volumes.nix
     ./apple-container-runtime.nix
     ./auto-update-prevention.nix


### PR DESCRIPTION
One log home per AI coding CLI under ~/Library/Logs/<cli>/ for codex,
agy (Antigravity), copilot, and vscode, each tailed by its own Cribl
Edge file input and shipped over its own tcpjson output/service port:

  in_codex_logs   -> cribl_codex   :10312
  in_agy_logs     -> cribl_agy     :10313
  in_copilot_logs -> cribl_copilot :10314
  in_vscode_logs  -> cribl_vscode  :10315

One port per CLI lets the Stream side key routing/enrichment off the
HAProxy frontend; no local pipeline is attached. pqEnabled buffers
locally until each frontend exists. Claude Code stays on the existing
pack -> cribl_stream (:10300) path (optional future repoint: :10311).

The new programs.ai-cli-log-shipping module owns the local half:
user-owned directories, newsyslog glob rotation
(/etc/newsyslog.d/ai-cli-logs.conf), and opt-in `<cli>-logged`
wrappers that capture a full interactive session via /usr/bin/script
(a real pty, so the TUIs behave normally). Deliberately NO launchd
daemon and NO implicit wrapping — these are interactive tools, and a
stdio redirect or daemon would break them. vscode gets directory +
rotation only (GUI app; the `code` launcher detaches), populated by
VS Code's own logging configuration.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Merge order within this repo: fix/edge-tcpjson-port-10300 → this → feat/macstudio-llm-log-routing (rebase) → feat/macos-syslog-family-521 → feat/vllm-metrics-scrape (rebase); shared Cribl block conflicts are mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)