### PR TITLE
feat(logging): move macOS syslog to the 521 family; split Cribl target

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -119,7 +119,7 @@ in
               # Homelab HAProxy (FQDN), load-balanced across the Cribl Stream workers.
               # Port pending in homelab-contracts service-ports (cribl_tcpjson) +
               # HAProxy frontend + Stream tcpjson source: ansible-proxmox-apps#525.
-              host: ${userConfig.logging.syslog.server}
+              host: ${userConfig.logging.cribl.server}
               port: 10302
               pqEnabled: true
         '';
@@ -196,7 +196,7 @@ in
             proxmox_stream:
               type: cribl_tcp
               # Homelab HAProxy (FQDN), load-balanced across the Proxmox Cribl Stream workers.
-              host: ${userConfig.logging.syslog.server}
+              host: ${userConfig.logging.cribl.server}
               port: 10300
               pqEnabled: true
               # Bounded on-disk queue: cap size and drop when full.

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -82,13 +82,21 @@ in
   # ==========================================================================
   logging = {
     syslog = {
-      # Remote syslog server for centralized log collection — the homelab
-      # HAProxy LB (also the Cribl tcpjson target in hosts/common).
-      # Logs are forwarded via macOS built-in syslogd to HAProxy -> Cribl Edge -> Splunk
+      # Remote syslog target for macOS built-in syslogd
+      # (modules/darwin/logging.nix renders it into /etc/syslog.conf).
       server = "haproxy.pve.${baseDomain}";
-      port = 1514;
+      # 521 is the dedicated macos syslog family: relayed by the ingress
+      # guest's nginx-stream UDP listener -> Cribl Edge :1521 -> Splunk
+      # index `os`, sourcetype syslog:macos.
+      port = 521;
       # Protocol: udp or tcp
       protocol = "udp";
+    };
+    cribl = {
+      # Cribl tcpjson target for every Edge output in hosts/common — its own
+      # attr (same HAProxy FQDN as syslog today) so a syslog repoint can
+      # never silently move the Edge shipping target.
+      server = "haproxy.pve.${baseDomain}";
     };
   };
 


### PR DESCRIPTION
macOS syslogd forwarding repoints from the shared :1514 intake to the
dedicated macos syslog family on :521 (still UDP): relayed by the
ingress guest's nginx-stream UDP listener -> Cribl Edge :1521 ->
Splunk index os, sourcetype syslog:macos. No module change needed —
logging.nix renders /etc/syslog.conf from these attrs.

logging.syslog.server was doing double duty as the host for every
Cribl Edge tcpjson output in hosts/common, so any future syslog
repoint would have silently dragged the Edge shipping target with it.
Introduce logging.cribl.server (identical HAProxy FQDN today) and
switch both Edge outputs.yml host references to it; rendered configs
are byte-identical except the syslog port.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Merge AFTER ansible-proxmox-apps feat/nginx-udp-macos-syslog-relay is merged AND converged (the :521 listener must exist first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)