### PR TITLE
feat(llm): scrape llama-swap Prometheus metrics into the llm_metrics index

### DIFF
--- a/hosts/common/cribl-stream-local.nix
+++ b/hosts/common/cribl-stream-local.nix
@@ -1,0 +1,66 @@
+# Cribl Stream (local egress aggregator) — DISABLED (idle)
+#
+# Split out of cribl.nix (repo file-size gate). See that file for the Edge
+# config; this module only carries the idle local-Stream + container runtime.
+
+_:
+
+let
+  userConfig = import ../../lib/user-config.nix;
+in
+{
+  programs = {
+    # --- Cribl Stream (local egress aggregator) — DISABLED (idle) ---
+    # The local-Stream cutover is reverted: cribl-edge ships directly to the
+    # Proxmox HAProxy (:10300), so a local Stream listening on :10301 receives
+    # nothing and sits idle. Apple `container` runs it as a lightweight VM whose
+    # `--memory` is the VM's RAM allocation (not a soft cap), so running it idle
+    # would tie up ~1 GB + a CPU for zero benefit — unacceptable on inference
+    # hosts where RAM is reserved for MLX. Kept configured (not deleted) so
+    # re-enabling is a one-line flip once the containerized Stream's CPU/DNS issue
+    # is fixed and the cutover is ready — right-size cpus/memory against real load
+    # THEN (the module defaults 1 cpu / 1g / 1 worker are conservative starting
+    # points, not a measured requirement). To re-enable: enable = lib.mkIf
+    # (hostConfig ? mlx) true. No explicit container DNS: Apple `container`
+    # forwards through the vmnet gateway to the host resolver. See docs/CRIBL-GITOPS.md.
+    cribl-stream = {
+      enable = false;
+      user = userConfig.user.name;
+      inputPort = 10301;
+      apiPort = 9000;
+      configFiles = {
+        "inputs.yml" = ''
+          inputs:
+            in_edge_s2s:
+              type: cribl_tcp
+              disabled: false
+              host: 0.0.0.0
+              port: 10301
+              sendToRoutes: false
+              connections:
+                - pipeline: passthrough
+                  output: proxmox_stream
+        '';
+        "outputs.yml" = ''
+          outputs:
+            proxmox_stream:
+              type: cribl_tcp
+              # Homelab HAProxy (FQDN), load-balanced across the Proxmox Cribl Stream workers.
+              host: ${userConfig.logging.syslog.server}
+              port: 10300
+              pqEnabled: true
+              # Bounded on-disk queue: cap size and drop when full.
+              pqMaxFileSize: 256 MB
+              pqMaxSize: 1 GB
+              pqOnBackpressure: drop
+        '';
+        # Passthrough for now; index/sourcetype enrichment moves here from Edge
+        # once Edge is repointed (Edge captures, Stream enriches + egresses).
+        "pipelines/passthrough/conf.yml" = ''
+          output: default
+          functions: []
+        '';
+      };
+    };
+  };
+}

--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -41,83 +41,101 @@ in
         # the whole config load down with it. Shape mirrors the stock
         # in_file_varlog entry in default/edge/inputs.yml.
         "inputs.yml" = ''
-          inputs:
-            in_llm_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
-              filenames:
-                - vllm-mlx.log
-                - vllm-mlx.error.log
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - pipeline: llm_logs
-                  output: cribl_llm
-            in_system_metrics:
-              type: system_metrics
-              disabled: false
-              sendToRoutes: false
-              connections:
-                - pipeline: llm_metrics
-                  output: cribl_stream
-            # Per-AI-CLI session logs. Directories + rotation + the opt-in
-            # capture wrappers come from programs.ai-cli-log-shipping
-            # (enabled in ./default.nix). One input -> one dedicated tcpjson
-            # output per CLI so Stream routes/enriches per service port; no
-            # local pipeline — index/sourcetype stamping is Stream-side.
-            # `*.log` matches the wrapper typescript plus anything a CLI's
-            # own config drops into its directory.
-            in_codex_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/codex/
-              filenames:
-                - "*.log"
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - output: cribl_codex
-            in_agy_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/agy/
-              filenames:
-                - "*.log"
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - output: cribl_agy
-            in_copilot_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/copilot/
-              filenames:
-                - "*.log"
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - output: cribl_copilot
-            in_vscode_logs:
-              type: file
-              disabled: false
-              mode: manual
-              interval: 10
-              path: ${userConfig.user.homeDir}/Library/Logs/vscode/
-              filenames:
-                - "*.log"
-              tailOnly: false
-              sendToRoutes: false
-              connections:
-                - output: cribl_vscode
+                    inputs:
+                      in_llm_logs:
+                        type: file
+                        disabled: false
+                        mode: manual
+                        interval: 10
+                        path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
+                        filenames:
+                          - vllm-mlx.log
+                          - vllm-mlx.error.log
+                        tailOnly: false
+                        sendToRoutes: false
+                        connections:
+                          - pipeline: llm_logs
+                            output: cribl_llm
+                      in_system_metrics:
+                        type: system_metrics
+                        disabled: false
+                        sendToRoutes: false
+                        connections:
+                          - pipeline: llm_metrics
+                            output: cribl_stream
+                      # vllm-mlx Prometheus metrics. The per-worker /metrics endpoints
+                      # (programs.mlx enableMetrics, on by default) live on ephemeral
+                      # llama-swap-managed ports (startPort 11436+), so the only
+                      # statically scrapeable surface is the llama-swap proxy itself on
+                      # the loopback :11434 convention (nix-ai programs.mlx.port
+                      # default, mirrored by llm-gate's apiUpstreamPort).
+                      in_llm_prom:
+                        type: prometheus
+                        disabled: false
+                        discoveryType: static
+                        targetList:
+                          - http://127.0.0.1:11434/metrics
+                        interval: 15
+                        sendToRoutes: false
+                        connections:
+                          - pipeline: llm_prom
+                            output: cribl_llm
+                      # Per-AI-CLI session logs. Directories + rotation + the opt-in
+                      # capture wrappers come from programs.ai-cli-log-shipping
+                      # (enabled in ./default.nix). One input -> one dedicated tcpjson
+                      # output per CLI so Stream routes/enriches per service port; no
+                      # local pipeline — index/sourcetype stamping is Stream-side.
+                      # `*.log` matches the wrapper typescript plus anything a CLI's
+                      # own config drops into its directory.
+                      in_codex_logs:
+                        type: file
+                        disabled: false
+                        mode: manual
+                        interval: 10
+                        path: ${userConfig.user.homeDir}/Library/Logs/codex/
+                        filenames:
+                          - "*.log"
+                        tailOnly: false
+                        sendToRoutes: false
+                        connections:
+                          - output: cribl_codex
+                      in_agy_logs:
+                        type: file
+                        disabled: false
+                        mode: manual
+                        interval: 10
+                        path: ${userConfig.user.homeDir}/Library/Logs/agy/
+                        filenames:
+                          - "*.log"
+                        tailOnly: false
+                        sendToRoutes: false
+                        connections:
+                          - output: cribl_agy
+                      in_copilot_logs:
+                        type: file
+                        disabled: false
+                        mode: manual
+                        interval: 10
+                        path: ${userConfig.user.homeDir}/Library/Logs/copilot/
+                        filenames:
+                          - "*.log"
+                        tailOnly: false
+                        sendToRoutes: false
+                        connections:
+                          - output: cribl_copilot
+                      in_vscode_logs:
+                        type: file
+                        disabled: false
+                        mode: manual
+                        interval: 10
+                        path: ${userConfig.user.homeDir}/Library/Logs/vscode/
+                        filenames:
+                          - "*.log"
+                        tailOnly: false
+                        sendToRoutes: false
+                        connections:
+                          - output: cribl_vscode
+          ||||||| parent of 410ecbf (feat(llm): scrape llama-swap Prometheus metrics into the llm_metrics index)
         ''
         # Appended only where programs.llm-gate is enabled (Studio-only
         # module): other mlx hosts get no input for a path that never exists.
@@ -207,6 +225,18 @@ in
                   - name: sourcetype
                     value: "'mlx:metrics'"
         '';
+        # Scraped inference metrics land in the llm_metrics METRIC index
+        # (unlike the llm event index the log pipelines stamp).
+        "pipelines/llm_prom/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm_metrics'"
+        '';
       };
       # Claude Code logs stay on the pack -> cribl_stream (:10300) path; a
       # repoint to a dedicated per-CLI port (:10311) is an optional future
@@ -221,57 +251,5 @@ in
       };
     };
 
-    # --- Cribl Stream (local egress aggregator) — DISABLED (idle) ---
-    # The local-Stream cutover is reverted: cribl-edge ships directly to the
-    # Proxmox HAProxy (:10300), so a local Stream listening on :10301 receives
-    # nothing and sits idle. Apple `container` runs it as a lightweight VM whose
-    # `--memory` is the VM's RAM allocation (not a soft cap), so running it idle
-    # would tie up ~1 GB + a CPU for zero benefit — unacceptable on inference
-    # hosts where RAM is reserved for MLX. Kept configured (not deleted) so
-    # re-enabling is a one-line flip once the containerized Stream's CPU/DNS issue
-    # is fixed and the cutover is ready — right-size cpus/memory against real load
-    # THEN (the module defaults 1 cpu / 1g / 1 worker are conservative starting
-    # points, not a measured requirement). To re-enable: enable = lib.mkIf
-    # (hostConfig ? mlx) true. No explicit container DNS: Apple `container`
-    # forwards through the vmnet gateway to the host resolver. See docs/CRIBL-GITOPS.md.
-    cribl-stream = {
-      enable = false;
-      user = userConfig.user.name;
-      inputPort = 10301;
-      apiPort = 9000;
-      configFiles = {
-        "inputs.yml" = ''
-          inputs:
-            in_edge_s2s:
-              type: cribl_tcp
-              disabled: false
-              host: 0.0.0.0
-              port: 10301
-              sendToRoutes: false
-              connections:
-                - pipeline: passthrough
-                  output: proxmox_stream
-        '';
-        "outputs.yml" = ''
-          outputs:
-            proxmox_stream:
-              type: cribl_tcp
-              # Homelab HAProxy (FQDN), load-balanced across the Proxmox Cribl Stream workers.
-              host: ${userConfig.logging.syslog.server}
-              port: 10300
-              pqEnabled: true
-              # Bounded on-disk queue: cap size and drop when full.
-              pqMaxFileSize: 256 MB
-              pqMaxSize: 1 GB
-              pqOnBackpressure: drop
-        '';
-        # Passthrough for now; index/sourcetype enrichment moves here from Edge
-        # once Edge is repointed (Edge captures, Stream enriches + egresses).
-        "pipelines/passthrough/conf.yml" = ''
-          output: default
-          functions: []
-        '';
-      };
-    };
   };
 }

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -23,6 +23,7 @@ in
     ../../modules/darwin/common.nix
     # Cribl Edge/Stream log shipping (self-gated on `hostConfig ? mlx`).
     ./cribl.nix
+    ./cribl-stream-local.nix
   ];
 
   # Network hostname from the per-host registry.


### PR DESCRIPTION
New Cribl Edge prometheus-scraper input in_llm_prom polling the
llama-swap proxy's loopback /metrics (http://127.0.0.1:11434/metrics,
15 s interval) -> NEW llm_prom pipeline stamping index 'llm_metrics'
(the metric index, distinct from the llm event index the log pipelines
stamp) -> shipped via the cribl_llm tcpjson output (:10321).

Scrape-target choice: nix-ai's programs.mlx exposes native Prometheus
/metrics on each vllm-mlx WORKER (enableMetrics, default true), but the
workers live on ephemeral llama-swap-managed ports (startPort 11436+),
so per-worker scraping is not statically configurable from Nix. The
llama-swap proxy on the fixed :11434 loopback convention (programs.mlx
port default, mirrored by llm-gate.apiUpstreamPort) is the one static
surface, so that is what gets scraped. Limitation: this captures the
proxy's own /metrics aggregate; if the installed llama-swap build does
not serve /metrics, the input polls harmlessly and the executor should
repoint the target (e.g. /upstream/<model>/metrics passthrough) rather
than invent worker ports.

Based on feat/macstudio-llm-log-routing (depends on its cribl_llm
output); the first commit here splits hosts/common/cribl.nix out of
default.nix for the 12 KB file-size gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Stacked on feat/macstudio-llm-log-routing. Verify llama-swap build serves /metrics before converging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)