### PR TITLE
fix(cribl-edge): restart the daemon when declared config content changes

### DIFF
--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -216,6 +216,17 @@ in
         WorkingDirectory = cfg.dataDir;
         StandardOutPath = "${cfg.dataDir}/logs/cribl-stdout.log";
         StandardErrorPath = "${cfg.dataDir}/logs/cribl-stderr.log";
+        # Cribl does not hot-reload config written from outside its own API
+        # (see the extraActivation note above), so a config-only generation
+        # left the running daemon on stale config until reboot. Hashing the
+        # declared config into the plist makes nix-darwin's launchd phase
+        # restart the daemon exactly when config content changes — the env
+        # var itself is inert to Cribl.
+        EnvironmentVariables = {
+          CRIBL_DECLARED_CONFIG_SHA256 = builtins.hashString "sha256" (
+            builtins.toJSON cfg.standalone.configFiles
+          );
+        };
       };
     };
   };


### PR DESCRIPTION
Cribl does not hot-reload config files written from outside its own API,
so a config-only generation (e.g. an outputs.yml port change) left the
running daemon on stale config until reboot — observed live: outputs.yml
carried the corrected Stream port while the worker kept dialing the old
dead one for 35+ minutes. Hash the declared standalone config into the
launchd plist so nix-darwin's launchd phase restarts the daemon exactly
when config changes.

Assisted-by: Claude:claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)