### PR TITLE
fix(mlx): raise Mac Studio gpuMemoryUtilization to 0.75 to stop KV-cache death loop

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -102,6 +102,21 @@
     mlx = {
       cacheMemoryMb = 6144;
       prefillBatchSize = 2048;
+      # gpuMemoryUtilization is BOTH the per-worker Metal allocation ceiling
+      # AND the emergency cache-clear threshold, which vllm-mlx computes as
+      # device_mem * (util + 0.05). The global default 0.5 sets that threshold
+      # to 137.4 GB * 0.55 = 76 GB — BELOW the ~92.4 GB resident pair this host
+      # deliberately keeps warm (see sizing comment above). So the instant both
+      # backends are up (~80 GB) every worker force-clears its KV cache each
+      # step: KV thrash -> full re-prefill each turn -> agent chats die after a
+      # few messages (observed as 300+ "[Memory pressure] ... forced cache
+      # clear" events on-host). 0.5 also caps allocation_limit at 0.5*115.4 =
+      # 57.7 GB, below gpt-oss-120b's ~69 GB footprint, so it cannot even stay
+      # resident. 0.75 raises the clear threshold to 137.4 GB * 0.80 = 109.9 GB
+      # (17 GB margin over the 92.4 GB resident pair) and allocation_limit to
+      # 0.75*115.4 = 86.6 GB (holds the 69 GB 120B worker), while staying below
+      # the 115.4 GB wired ceiling so soft-clear still guards true exhaustion.
+      gpuMemoryUtilization = 0.75;
       # Keep both backends resident: no swap eviction, both preloaded at boot,
       # and no idle eviction anywhere — this host's entire job is holding
       # these weights, so the workstation rationale for aggressive TTLs


### PR DESCRIPTION
## Problem

Agent conversations on the Mac Studio brain die after a few messages. On-host logs show **300+** `[Memory pressure] 79–85GB > 76GB threshold, forced cache clear` events. Each forced clear drops the KV cache, so the next turn full-reprefills the context — the classic "no cache reuse / slow / dies after a few turns" failure.

## Root cause

`vllm-mlx` derives its emergency cache-clear threshold from `gpu_memory_utilization`:

```
threshold = device_mem * min(gpu_memory_utilization + 0.05, 0.99)
```

The Mac Studio inherits the global default `gpuMemoryUtilization = 0.5`, giving `137.4 GB * 0.55 = 76 GB`. But this host's own sizing comment plans to keep **~92.4 GB** of weights+cache resident (gpt-oss-120b 63 GB + Qwen3-Coder 17 GB + 2×6 GB caches). So the intended resident footprint sits **above** the clear threshold the same knob sets — the moment both backends are up (~80 GB), every worker force-clears each step.

`util 0.5` also caps `allocation_limit` at `0.5 * 115.4 = 57.7 GB`, below gpt-oss-120b's ~69 GB footprint, so the 120B can't reliably stay resident.

## Fix

Set `mlx.gpuMemoryUtilization = 0.75` for the Mac Studio only:

| | util 0.5 (before) | util 0.75 (after) |
| --- | --- | --- |
| clear threshold | 76 GB | 109.9 GB |
| per-worker allocation_limit | 57.7 GB | 86.6 GB |
| margin over 92.4 GB resident pair | **−16 GB (thrash)** | +17 GB |
| below 115.4 GB wired ceiling? | yes | yes (soft-clear still guards) |

Other hosts keep the 0.5 default.

## Verification

- Nix parse OK; CI build gate.
- Post-rebuild on-host: new worker startup recomputes threshold to ~110 GB; force both backends resident (~80 GB) and confirm **zero** new `forced cache clear` events; confirm gpt-oss-120b stays resident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)