### PR TITLE
chore(deps): bump nix-ai to pick up mlx gpuMemoryUtilization 0.80 default

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -928,11 +928,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783476905,
-        "narHash": "sha256-LF/v0Pd9ogcdi7hbcR/uWWJX9Gdmu1OV76ITniwJzT0=",
+        "lastModified": 1783480296,
+        "narHash": "sha256-GI0yzMShWjyRAvxZQpjKkOg9uVJSTUiwJ0BlVHHxKns=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "18d3b388635d0e2b4cedec1f92d4fb21ee5d9eea",
+        "rev": "f6fa41f5443ec5eb8db9ebecfef2f0f4071a9ab3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls dryvist/nix-ai#1130 — the vllm-mlx KV-cache death-loop fix (default `gpuMemoryUtilization` 0.5 → 0.80) — into the hosts' serving config. Lock-only change.

Apply plan: merge, then `darwin-rebuild switch` on jevans-ms (remote, self-service) and verify the llama-swap vllm-mlx command line carries `--gpu-memory-utilization 0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfdwgg1SpMEUYNd61SfKsb