### PR TITLE
fix(cribl): logLevel is required on the prometheus input schema

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -72,6 +72,10 @@ in
             in_llm_prom:
               type: prometheus
               disabled: false
+              # Required by the prometheus input schema: without it the input
+              # fails init ("should have required property 'logLevel'") and
+              # silently never scrapes — llm_metrics stays empty.
+              logLevel: info
               discoveryType: static
               targetList:
                 - http://127.0.0.1:11434/metrics


### PR DESCRIPTION
`in_llm_prom` (#1564) has never scraped: the Edge 4.18 prometheus input requires `logLevel` and fails init without it (`should have required property 'logLevel'` in the worker log) — silently, since every other input keeps running; the only symptom is an empty `llm_metrics` index. Pins `logLevel: info` with a comment stating the constraint.

Same schema requirement just bit the homelab Edge pair's new scrape input (ansible-proxmox-apps#726), where it was worse — that build rejects the whole inputs.yml.

Verification: merge → rebuild both inference Macs (Edge restarts on config hash) → `| mstats count where index=llm_metrics earliest=-10m` > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE