### PR TITLE
fix(logging): HUP syslogd after /etc/syslog.conf changes

### DIFF
--- a/modules/darwin/logging.nix
+++ b/modules/darwin/logging.nix
@@ -93,8 +93,13 @@ in
 
   # User-owned log dir (same pattern as ai-cli-log-shipping.nix: install -d
   # so a root-created parent never blocks the user's writes).
+  #
+  # Also HUP syslogd: environment.etc swaps the symlink but never signals the
+  # daemon, so without this the previous /etc/syslog.conf (including the
+  # retired remote-forward rule) keeps running from memory until reboot.
   system.activationScripts.postActivation.text = lib.mkAfter ''
     /usr/bin/install -d -o ${userConfig.user.name} -g staff "${logDir}"
+    /usr/bin/pkill -HUP syslogd 2>/dev/null || true
   '';
 
   # Rotate via the system newsyslog run. Flags per ai-cli-logs.conf: G glob,


### PR DESCRIPTION
Follow-up to #1584: `environment.etc` swaps the `/etc/syslog.conf` symlink but never signals syslogd, so the retired remote-forward rule kept running from the daemon's in-memory config after the rebuild — both Macs continued shipping skewed RFC3164 lines to the unifi syslog family port. The old module HUP'd syslogd in postActivation; the #1584 rewrite dropped that. Restore it (idempotent, `|| true` if syslogd isn't up).

Verified: `nix flake check --no-build` green. Post-merge rebuild on both hosts should stop new `host=jevans-*` events in `index=unifi` within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)