### PR TITLE
feat(mlx): register Qwen3-Next-80B Thinking as the swap-tier large brain

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -212,6 +212,23 @@
           maxNumSeqs = 2;
           maxRequestTokens = 32768;
         };
+        # Qwen3-Next-80B swap brain (see mlx.models entry above). Cache kept at
+        # 4096 MB — deliberately small so the on-demand swap-in stays under the
+        # ~109 GB trip (58.6 + 42 + 4 ≈ 104.6); idle-unload at 900 s frees the
+        # 42 GB back to the two-brain baseline. maxRequestTokens 32768 lifts the
+        # global 8192 cap (too low for the agent brain's multi-turn / retry
+        # boost) to hermes-agent's own retry ceiling; maxNumSeqs 2 keeps one
+        # continuous batch for the big model within the tight cache budget.
+        # enablePrefixCaching off: automatic prefix caching is unsupported for
+        # the qwen3_next hybrid-attention family (mlx-benchmarks model-notes) —
+        # batching still works, only cross-request TTFT reuse is lost.
+        "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = {
+          cacheMemoryMb = 4096;
+          autoUnloadIdleSeconds = 900;
+          maxNumSeqs = 2;
+          maxRequestTokens = 32768;
+          enablePrefixCaching = false;
+        };
       };
     };
 
@@ -238,6 +255,30 @@
           # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
           "--default-chat-template-kwargs"
           "'{\"enable_thinking\":false}'"
+        ];
+      };
+      # Qwen3-Next-80B-A3B Thinking 4-bit — the LARGE brain for the fabric's
+      # daily rotation (ansible-proxmox-apps: ai_default_model_large). Non-
+      # resident swap tier: the router loads it on demand and it idle-unloads,
+      # so it never crowds the resident pair. Capacity fits the 128 GB box:
+      # 58.6 GB residents (coder + OptiQ) + ~42 GB weights + 4 GB cache ≈ 104.6
+      # GB, under the ~109 GB cache-clear trip (gpuMemoryUtilization 0.80). No
+      # enable_thinking kwarg: this is the dedicated *Thinking* variant — its
+      # chat template has no enable_thinking switch and always opens a <think>
+      # block (verified against the HF chat_template.jinja), so thinking is
+      # always-on and passing the kwarg would be a no-op. hermes tool parser
+      # (Qwen3 XML tool format, same as the OptiQ resident brain) + qwen3
+      # reasoning; --timeout 3600 keeps the guard chain server 3600 > router
+      # 2400 > client 1800. Native context 262144 (max_position_embeddings).
+      "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = {
+        ttl = 900;
+        extraArgs = [
+          "--tool-call-parser"
+          "hermes"
+          "--reasoning-parser"
+          "qwen3"
+          "--timeout"
+          "3600"
         ];
       };
     };


### PR DESCRIPTION
## What

Registers `mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit` in the jevans-ms **swap tier** so the fabric's daily brain rotation (dryvist/ansible-proxmox-apps#791) can load it on demand as the **large-phase brain** — 00:00–12:00 UTC. It is non-resident and idle-unloads, so it never crowds the resident pair.

## Why this model as the large brain

The rotation's optimized brain is the resident OptiQ-4bit 35B (agentic-bench winner). The large phase needs a genuinely bigger brain that is **still a competent tool-caller** — `gpt-oss-120b` scored 0% valid agentic tool calls in the same grid, so using it as the agent brain 12h/day would break Hermes tool-calling. Qwen3-Next-80B-A3B-Thinking benched 100% valid (single-run, provisional), degrades ~round 17, ~12 tok/s.

## Implementation (mirrors the stock-35B swap idiom)

- **`mlx.models`** entry: `ttl = 900`, `extraArgs = [--tool-call-parser hermes, --reasoning-parser qwen3, --timeout 3600]`.
- **`modelFlagOverrides`** entry: `cacheMemoryMb = 4096`, `autoUnloadIdleSeconds = 900`, `maxNumSeqs = 2`, `maxRequestTokens = 32768`, `enablePrefixCaching = false`.

### Two verified specifics

- **No `enable_thinking` kwarg.** This is the dedicated *Thinking* variant. Its `chat_template.jinja` (fetched from HF) has **no** `enable_thinking` switch and `add_generation_prompt` always opens `<think>`, so thinking is always-on — passing the kwarg would be a no-op. Omitted.
- **`enablePrefixCaching = false`.** Automatic prefix caching is unsupported for the `qwen3_next` hybrid-attention family (mlx-benchmarks model-notes); batching still works, only cross-request TTFT reuse is lost. Kept `pagedKvCache` at default (the global `enablePrefixCaching → pagedKvCache` assertion is satisfied).
- **`maxRequestTokens = 32768`** lifts the global 8192 cap (too low for the agent brain's multi-turn/retry-boost) to hermes-agent's own retry ceiling; `32768` (not OptiQ's 65536) suits the deliberately small 4 GB cache.

## Capacity

`58.6 GB` residents (coder + OptiQ) + `~42 GB` weights + `4 GB` cache **≈ 104.6 GB**, under the `~109 GB` cache-clear trip (`gpuMemoryUtilization 0.80` on 128 GB). Native context `262144` (`max_position_embeddings`).

## Proof

`nix eval .#darwinConfigurations.jevans-ms.config.system.build.toplevel.drvPath` → valid `.drv` (forces the full module eval, including the `modelFlagOverrides` overridable-key assertion). `nix fmt` clean (0 changed).

## NOT done here

- **Not rebuilt on jevans-ms, not merged** — gated. Load-test the alias flip after rebuild before enabling the rotation.
- The rotation itself (dryvist/ansible-proxmox-apps#791) still ships **disabled**; flipping `ai_rotation_enabled` is a separate step after this merges + rebuild + live load test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)