### PR TITLE
fix(mac-studio): 256-token paged-cache blocks + DRY serving groups

### DIFF
--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -64,190 +64,218 @@
     ];
   };
 
-  mac-studio = {
-    # Network identity. `system` omitted (mkHost defaults to aarch64-darwin).
-    hostName = "jevans-ms";
-
-    # Headless, always-on LAN inference/batch server. Drives server-class macOS
-    # defaults (hosts/common/default.nix) and nix-home's server preset.
-    class = "server";
-
-    # Resident brains (2026-07-08 agentic tool-calling bench; verdicts + capacity
-    # in HF JacobPEvans/mlx-benchmarks + apps docs/BRAIN_ROTATION.md):
-    #   tool-calling — Qwen3.6-35B-A3B OptiQ-4bit (~19.5 GB, qwen3_5_moe): bench
-    #     winner, the brain Hermes routes to by physical id. glm47 + stock 8-bit
-    #     degraded, left unregistered.
-    #   coding — Qwen3-Coder-30B-A3B 4-bit (17.1 GB, qwen3_moe).
-    # gpt-oss-120b (63.3 GB, default/oss) is NOT preloaded — 0% on the agentic
-    # gate, so on-demand + idle-unload. Resident weights ≈ 36.6 GB.
-    defaultLocalModelId = "mlx-community/gpt-oss-120b-MXFP4-Q8";
-    roleModelOverrides = {
-      tool-calling = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
-      coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-    };
-
-    # MLX sizing (per-worker cacheMemoryMb; derivations in mlx-benchmarks
-    # docs/RUNBOOK.md): residents ≈ 58.6 GB (coder + OptiQ weights + 6 + 16 GB
-    # caches), far under the ~109 GB cache-clear trip (gpuMemoryUtilization 0.80
-    # on 128 GB, never > 0.85). An on-demand gpt-oss swap-in transiently exceeds
-    # the trip — pre-existing; it idle-unloads back to baseline.
-    mlx = {
-      cacheMemoryMb = 6144;
-      prefillBatchSize = 2048;
-      # Server host: no group swap, no global idle eviction (per-model unloads
-      # are set below). A blanket TTL would make each resident brain pay a
-      # 60-120 s cold start after any quiet period.
-      proxy = {
-        groupSwap = false;
-        idleTtl = 0;
-        # 8 (up from the default 2): llama-swap hard-429s beyond this while
-        # vllm-mlx batches + queues gracefully — a 4-way burst measured 98/100
-        # rejected at the proxy. 8 = one batch running + one queued.
-        concurrencyLimit = 8;
-      };
-      autoUnloadIdleSeconds = 0;
-      # Resident brains warmed at boot: coder (coding) + OptiQ (tool-calling).
-      # gpt-oss (default) is deliberately omitted — see the composition note.
-      preload = [
-        "coding"
-        "tool-calling"
+  mac-studio =
+    let
+      # ---- Serving groups (single source for values shared across models) ----
+      # A value repeated across models means they belong to a FAMILY (same
+      # model lineage → same parser stack) or a CLASS (same serving role →
+      # same lifecycle/sizing). Set shared values here, never per-model.
+      #
+      # Family: Qwen3.6/Next MoE general lineage. The XML tool format needs
+      # the hermes parser (qwen3_coder mis-parses it → empty function.name
+      # repair storms) + qwen3 reasoning extraction.
+      qwenMoeGeneralParser = [
+        "--tool-call-parser"
+        "hermes"
+        "--reasoning-parser"
+        "qwen3"
       ];
-      # Global parser off; each backend pins its own below (harmony needs
-      # vllm-mlx >= 0.4.0). gpt-oss MUST set --reasoning-parser gpt_oss — unset,
-      # its harmony channel markers ("analysis"/"assistantfinal") leak into
-      # streamed message.content (root-caused 2026-07-06; nix-ai#1083).
-      toolCallParser = null;
-      modelExtraArgs = {
-        "mlx-community/gpt-oss-120b-MXFP4-Q8" = [
-          "--tool-call-parser"
-          "harmony"
-          "--reasoning-parser"
-          "gpt_oss"
-          # Server defaults keep request-level chat_template_kwargs overrideable.
-          "--default-chat-template-kwargs"
-          (builtins.toJSON {
-            reasoning_effort = "low";
-          })
-        ];
-        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = [
-          "--tool-call-parser"
-          "qwen3_coder"
-          "--timeout"
-          "3600"
-        ];
-        # tool-calling role (resident agent brain). hermes parser for the general
-        # Qwen3.6 XML tool format (qwen3_coder mis-parses it → empty function.name
-        # repair storms); qwen3 reasoning, thinking ON (bench winner). --timeout
-        # 3600 (on both residents) lifts the 300s disconnect_guard; keeps the
-        # guard chain strict: server 3600 > router 2400 > client 1800.
-        "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" = [
-          "--tool-call-parser"
-          "hermes"
-          "--reasoning-parser"
-          "qwen3"
-          "--default-chat-template-kwargs"
-          (builtins.toJSON {
-            enable_thinking = true;
-          })
-          "--timeout"
-          "3600"
-        ];
-        # Swap-tier (mlx.models) args go on those entries below; keys here
-        # only reach role-registry models and are otherwise silently ignored.
+      # Class: agentic backends on the timeout guard chain. 3600 lifts the
+      # 300 s disconnect_guard; keeps the chain strict:
+      # server 3600 > router 2400 > client 1800.
+      agentTimeout = [
+        "--timeout"
+        "3600"
+      ];
+      # Class: resident brains (preloaded, long-lived). 256-token paged-cache
+      # blocks (up from the 64 default): a long agentic session near the
+      # 65536-token ceiling shatters into ~1000 blocks/seq × layers × K/V
+      # Metal buffers and trips MLX's buffer-COUNT limit ("[metal::malloc]
+      # Resource limit (499000) exceeded" at ~66 GB active — not a byte OOM),
+      # aborting the request mid-stream (litellm.MidStreamFallbackError).
+      # 256-token blocks cut the count 4× while keeping paged cache + prefix
+      # reuse. Validated 2026-07-09 on OptiQ solo: the repro prompt that
+      # reliably tripped block-size 64 completes clean at 256.
+      residentBrainArgs = agentTimeout ++ [
+        "--paged-cache-block-size"
+        "256"
+      ];
+      # Class: swap tier (on-demand, idle-unloaded after 900 s so it never
+      # crowds the residents; small footprint caps).
+      swapTierTtl = 900;
+      swapTierFlags = {
+        autoUnloadIdleSeconds = swapTierTtl;
+        maxNumSeqs = 2;
+        maxRequestTokens = 32768;
       };
-      # gpt-oss needs pagedKvCache + prefix caching OFF: its sliding-window
-      # attention hits a [broadcast_shapes] failure with vllm-mlx 0.4.0's paged
-      # cache. The Qwen models keep prefix caching for agentic reuse.
-      modelFlagOverrides = {
-        # gpt-oss: demoted from preload. The global autoUnloadIdleSeconds = 0
-        # would pin it resident-forever once loaded on demand, so re-arm a 15-min
-        # idle unload to free its 63 GB back to the two-brain baseline.
-        "mlx-community/gpt-oss-120b-MXFP4-Q8" = {
-          pagedKvCache = false;
-          enablePrefixCaching = false;
-          autoUnloadIdleSeconds = 900;
+    in
+    {
+      # Network identity. `system` omitted (mkHost defaults to aarch64-darwin).
+      hostName = "jevans-ms";
+
+      # Headless, always-on LAN inference/batch server. Drives server-class macOS
+      # defaults (hosts/common/default.nix) and nix-home's server preset.
+      class = "server";
+
+      # Resident brains (2026-07-08 agentic tool-calling bench; verdicts + capacity
+      # in HF JacobPEvans/mlx-benchmarks + apps docs/BRAIN_ROTATION.md):
+      #   tool-calling — Qwen3.6-35B-A3B OptiQ-4bit (~19.5 GB, qwen3_5_moe): bench
+      #     winner, the brain Hermes routes to by physical id. glm47 + stock 8-bit
+      #     degraded, left unregistered.
+      #   coding — Qwen3-Coder-30B-A3B 4-bit (17.1 GB, qwen3_moe).
+      # gpt-oss-120b (63.3 GB, default/oss) is NOT preloaded — 0% on the agentic
+      # gate, so on-demand + idle-unload. Resident weights ≈ 36.6 GB.
+      defaultLocalModelId = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+      roleModelOverrides = {
+        tool-calling = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
+        coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      };
+
+      # MLX sizing (per-worker cacheMemoryMb; derivations in mlx-benchmarks
+      # docs/RUNBOOK.md): residents ≈ 58.6 GB (coder + OptiQ weights + 6 + 16 GB
+      # caches), far under the ~109 GB cache-clear trip (gpuMemoryUtilization 0.80
+      # on 128 GB, never > 0.85). An on-demand gpt-oss swap-in transiently exceeds
+      # the trip — pre-existing; it idle-unloads back to baseline.
+      mlx = {
+        cacheMemoryMb = 6144;
+        prefillBatchSize = 2048;
+        # Server host: no group swap, no global idle eviction (per-model unloads
+        # are set below). A blanket TTL would make each resident brain pay a
+        # 60-120 s cold start after any quiet period.
+        proxy = {
+          groupSwap = false;
+          idleTtl = 0;
+          # 8 (up from the default 2): llama-swap hard-429s beyond this while
+          # vllm-mlx batches + queues gracefully — a 4-way burst measured 98/100
+          # rejected at the proxy. 8 = one batch running + one queued.
+          concurrencyLimit = 8;
         };
-        # coding: resident, unchanged. The global maxRequestTokens (8192, modules/
-        # mlx in nix-ai) is too low for agentic multi-turn, so keep 32768.
-        "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = {
-          maxRequestTokens = 32768;
+        autoUnloadIdleSeconds = 0;
+        # Resident brains warmed at boot: coder (coding) + OptiQ (tool-calling).
+        # gpt-oss (default) is deliberately omitted — see the composition note.
+        preload = [
+          "coding"
+          "tool-calling"
+        ];
+        # Global parser off; each backend pins its own below (harmony needs
+        # vllm-mlx >= 0.4.0). gpt-oss MUST set --reasoning-parser gpt_oss — unset,
+        # its harmony channel markers ("analysis"/"assistantfinal") leak into
+        # streamed message.content (root-caused 2026-07-06; nix-ai#1083).
+        toolCallParser = null;
+        modelExtraArgs = {
+          "mlx-community/gpt-oss-120b-MXFP4-Q8" = [
+            "--tool-call-parser"
+            "harmony"
+            "--reasoning-parser"
+            "gpt_oss"
+            # Server defaults keep request-level chat_template_kwargs overrideable.
+            "--default-chat-template-kwargs"
+            (builtins.toJSON {
+              reasoning_effort = "low";
+            })
+          ];
+          "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = [
+            "--tool-call-parser"
+            "qwen3_coder"
+          ]
+          ++ residentBrainArgs;
+          # tool-calling role (resident agent brain): family parser stack;
+          # thinking ON (bench winner).
+          "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" =
+            qwenMoeGeneralParser
+            ++ [
+              "--default-chat-template-kwargs"
+              (builtins.toJSON {
+                enable_thinking = true;
+              })
+            ]
+            ++ residentBrainArgs;
+          # Swap-tier (mlx.models) args go on those entries below; keys here
+          # only reach role-registry models and are otherwise silently ignored.
         };
-        # tool-calling (resident brain): HIGH KV budget for 40-58K-token contexts;
-        # maxNumSeqs 8 = one continuous batch. The 65536 ceiling replaces the 32768
-        # cap that fed the truncation/retry death-loop.
-        "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" = {
-          cacheMemoryMb = 16384;
-          maxNumSeqs = 8;
-          maxRequestTokens = 65536;
+        # gpt-oss needs pagedKvCache + prefix caching OFF: its sliding-window
+        # attention hits a [broadcast_shapes] failure with vllm-mlx 0.4.0's paged
+        # cache. The Qwen models keep prefix caching for agentic reuse.
+        modelFlagOverrides = {
+          # gpt-oss: demoted from preload. The global autoUnloadIdleSeconds = 0
+          # would pin it resident-forever once loaded on demand, so re-arm a 15-min
+          # idle unload to free its 63 GB back to the two-brain baseline.
+          "mlx-community/gpt-oss-120b-MXFP4-Q8" = {
+            pagedKvCache = false;
+            enablePrefixCaching = false;
+            autoUnloadIdleSeconds = swapTierTtl;
+          };
+          # coding: resident, unchanged. The global maxRequestTokens (8192, modules/
+          # mlx in nix-ai) is too low for agentic multi-turn, so keep 32768.
+          "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = {
+            maxRequestTokens = 32768;
+          };
+          # tool-calling (resident brain): HIGH KV budget for 40-58K-token contexts;
+          # maxNumSeqs 8 = one continuous batch. The 65536 ceiling replaces the 32768
+          # cap that fed the truncation/retry death-loop.
+          "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" = {
+            cacheMemoryMb = 16384;
+            maxNumSeqs = 8;
+            maxRequestTokens = 65536;
+          };
+          "mlx-community/Qwen3.6-35B-A3B-4bit" = swapTierFlags // {
+            cacheMemoryMb = 3072;
+          };
+          # Qwen3-Next-80B swap brain (mlx.models entry below). Small 4096 MB cache
+          # keeps the on-demand swap-in under the ~109 GB trip (≈104.6 GB with
+          # residents; derivation in mlx-benchmarks docs/RUNBOOK.md); idle-unload
+          # frees it. prefixCaching off — unsupported for the qwen3_next
+          # hybrid-attention family (mlx-benchmarks model-notes).
+          "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = swapTierFlags // {
+            cacheMemoryMb = 4096;
+            enablePrefixCaching = false;
+          };
         };
+      };
+
+      # Non-resident swap tier: router loads on demand, idle-unloads so it never
+      # crowds the resident pair. (Dense 27B retired 2026-07-07: 4x slower.)
+      mlx.models = {
+        # Swap-tier serve flags go on extraArgs HERE (modelExtraArgs only reaches
+        # role-registry models). The tool-call parser is required — the global
+        # --enable-auto-tool-choice makes vllm-mlx exit at argparse without it.
+        # NOTE: parser anomaly — this stock sibling still runs qwen3_coder while
+        # the family group uses hermes (which the OptiQ bench showed is required
+        # for the general XML tool format). Predates the 2026-07-08 bench; flip
+        # to qwenMoeGeneralParser only with a bench validating this variant.
         "mlx-community/Qwen3.6-35B-A3B-4bit" = {
-          cacheMemoryMb = 3072;
-          autoUnloadIdleSeconds = 900;
-          maxNumSeqs = 2;
-          maxRequestTokens = 32768;
+          ttl = swapTierTtl;
+          extraArgs = [
+            "--tool-call-parser"
+            "qwen3_coder"
+            "--reasoning-parser"
+            "qwen3"
+            # Thinking off by default (requests can opt back in). extraArgs are
+            # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
+            "--default-chat-template-kwargs"
+            "'{\"enable_thinking\":false}'"
+          ];
         };
-        # Qwen3-Next-80B swap brain (mlx.models entry below). Small 4096 MB cache
-        # keeps the on-demand swap-in under the ~109 GB trip (≈104.6 GB with
-        # residents; derivation in mlx-benchmarks docs/RUNBOOK.md); idle-unload
-        # frees it. prefixCaching off — unsupported for the qwen3_next
-        # hybrid-attention family (mlx-benchmarks model-notes).
+        # Qwen3-Next-80B-A3B Thinking 4-bit — the LARGE daily-rotation brain (apps
+        # ai_default_model_large; rotation + capacity in apps docs/BRAIN_ROTATION.md
+        # and mlx-benchmarks docs/RUNBOOK.md). No enable_thinking kwarg: the
+        # dedicated Thinking variant is always-on (no chat-template switch).
         "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = {
-          cacheMemoryMb = 4096;
-          autoUnloadIdleSeconds = 900;
-          maxNumSeqs = 2;
-          maxRequestTokens = 32768;
-          enablePrefixCaching = false;
+          ttl = swapTierTtl;
+          extraArgs = qwenMoeGeneralParser ++ agentTimeout;
         };
       };
+
+      # OrbStack stays OFF — this host uses the Apple `container` runtime, not
+      # OrbStack. The ContainerData volume is still created (apfsVolumes below).
+      orbstack.enable = false;
+
+      # Same dedicated APFS volumes as the workstation, created identically.
+      # Container id confirmed via `diskutil apfs list` (single 4TB internal).
+      apfsContainer = "disk3";
+      apfsVolumes = [
+        "HuggingFace"
+        "ContainerData"
+      ];
     };
-
-    # Non-resident swap tier: router loads on demand, idle-unloads so it never
-    # crowds the resident pair. (Dense 27B retired 2026-07-07: 4x slower.)
-    mlx.models = {
-      # Swap-tier serve flags go on extraArgs HERE (modelExtraArgs only reaches
-      # role-registry models). The tool-call parser is required — the global
-      # --enable-auto-tool-choice makes vllm-mlx exit at argparse without it.
-      "mlx-community/Qwen3.6-35B-A3B-4bit" = {
-        ttl = 900;
-        extraArgs = [
-          "--tool-call-parser"
-          "qwen3_coder"
-          "--reasoning-parser"
-          "qwen3"
-          # Thinking off by default (requests can opt back in). extraArgs are
-          # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
-          "--default-chat-template-kwargs"
-          "'{\"enable_thinking\":false}'"
-        ];
-      };
-      # Qwen3-Next-80B-A3B Thinking 4-bit — the LARGE daily-rotation brain (apps
-      # ai_default_model_large; rotation + capacity in apps docs/BRAIN_ROTATION.md
-      # and mlx-benchmarks docs/RUNBOOK.md). No enable_thinking kwarg: the
-      # dedicated Thinking variant is always-on (no chat-template switch). hermes
-      # tool parser + qwen3 reasoning; --timeout 3600 per the guard chain above.
-      "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = {
-        ttl = 900;
-        extraArgs = [
-          "--tool-call-parser"
-          "hermes"
-          "--reasoning-parser"
-          "qwen3"
-          "--timeout"
-          "3600"
-        ];
-      };
-    };
-
-    # OrbStack stays OFF — this host uses the Apple `container` runtime, not
-    # OrbStack. The ContainerData volume is still created (apfsVolumes below).
-    orbstack.enable = false;
-
-    # Same dedicated APFS volumes as the workstation, created identically.
-    # Container id confirmed via `diskutil apfs list` (single 4TB internal).
-    apfsContainer = "disk3";
-    apfsVolumes = [
-      "HuggingFace"
-      "ContainerData"
-    ];
-  };
 }

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -66,42 +66,32 @@
 
   mac-studio =
     let
-      # ---- Serving groups (single source for values shared across models) ----
-      # A value repeated across models means they belong to a FAMILY (same
-      # model lineage → same parser stack) or a CLASS (same serving role →
-      # same lifecycle/sizing). Set shared values here, never per-model.
+      # Serving groups: shared values live here, never per-model (FAMILY =
+      # lineage → parser stack; CLASS = role → lifecycle/sizing).
       #
-      # Family: Qwen3.6/Next MoE general lineage. The XML tool format needs
-      # the hermes parser (qwen3_coder mis-parses it → empty function.name
-      # repair storms) + qwen3 reasoning extraction.
+      # Qwen3.6/Next MoE lineage: XML tool format needs hermes (qwen3_coder
+      # mis-parses it → empty function.name repair storms) + qwen3 reasoning.
       qwenMoeGeneralParser = [
         "--tool-call-parser"
         "hermes"
         "--reasoning-parser"
         "qwen3"
       ];
-      # Class: agentic backends on the timeout guard chain. 3600 lifts the
-      # 300 s disconnect_guard; keeps the chain strict:
-      # server 3600 > router 2400 > client 1800.
+      # Guard chain: server 3600 > router 2400 > client 1800 (lifts the
+      # 300 s disconnect_guard).
       agentTimeout = [
         "--timeout"
         "3600"
       ];
-      # Class: resident brains (preloaded, long-lived). 256-token paged-cache
-      # blocks (up from the 64 default): a long agentic session near the
-      # 65536-token ceiling shatters into ~1000 blocks/seq × layers × K/V
-      # Metal buffers and trips MLX's buffer-COUNT limit ("[metal::malloc]
-      # Resource limit (499000) exceeded" at ~66 GB active — not a byte OOM),
-      # aborting the request mid-stream (litellm.MidStreamFallbackError).
-      # 256-token blocks cut the count 4× while keeping paged cache + prefix
-      # reuse. Validated 2026-07-09 on OptiQ solo: the repro prompt that
-      # reliably tripped block-size 64 completes clean at 256.
+      # Residents: 256-token paged-cache blocks (default 64) — long sessions
+      # shattered the KV into enough per-block Metal buffers to trip MLX's
+      # buffer-count limit ("Resource limit (499000) exceeded", not a
+      # byte OOM). Validated 2026-07-09 (#1609).
       residentBrainArgs = agentTimeout ++ [
         "--paged-cache-block-size"
         "256"
       ];
-      # Class: swap tier (on-demand, idle-unloaded after 900 s so it never
-      # crowds the residents; small footprint caps).
+      # Swap tier: on-demand, idle-unloaded; small caps.
       swapTierTtl = 900;
       swapTierFlags = {
         autoUnloadIdleSeconds = swapTierTtl;
@@ -239,10 +229,8 @@
         # Swap-tier serve flags go on extraArgs HERE (modelExtraArgs only reaches
         # role-registry models). The tool-call parser is required — the global
         # --enable-auto-tool-choice makes vllm-mlx exit at argparse without it.
-        # NOTE: parser anomaly — this stock sibling still runs qwen3_coder while
-        # the family group uses hermes (which the OptiQ bench showed is required
-        # for the general XML tool format). Predates the 2026-07-08 bench; flip
-        # to qwenMoeGeneralParser only with a bench validating this variant.
+        # Parser anomaly: still qwen3_coder (predates the 2026-07-08 bench);
+        # flip to qwenMoeGeneralParser only with a bench on this variant.
         "mlx-community/Qwen3.6-35B-A3B-4bit" = {
           ttl = swapTierTtl;
           extraArgs = [


### PR DESCRIPTION
## Problem

Long agentic sessions on the resident brains abort mid-stream once accumulated
context nears the 65536-token ceiling. Server side:

```text
[Metal memory] active=65.9GB peak=75.4GB cache=0.0GB running=1 waiting=0
ERROR:vllm_mlx.scheduler: Error in batch generation step: [metal::malloc] Resource limit (499000) exceeded.
WARNING: [generation_error_recovery] aborted 1 running requests
```

Clients see `litellm.MidStreamFallbackError` after 3 retries. Reproduced 4x on
2026-07-09 (single request, `running=1 waiting=0` — not concurrency, and
`active` well under the ~92 GB byte limit).

## Root cause

`--paged-cache-block-size` defaults to **64 tokens**. A 65K-token session
shatters into ~1000 blocks per sequence, and each block is a separate Metal
buffer per layer per K/V — exhausting MLX's Metal buffer-**count** ceiling
(499000) while byte usage is fine. Disabling paged cache would dodge the count
but sacrifice paging + prefix reuse (and nix-ai asserts prefix caching
requires it); the proportionate fix is coarser blocks.

## Fix

`--paged-cache-block-size 256` on the two resident brains: 4x fewer buffers,
paged cache + prefix reuse kept, worst-case waste 255 token-slots per sequence
tail.

**Validation**: solo OptiQ instance, production args + the flag. A
**113,401-token** prompt (1.7x the context where production tripped) completed
end-to-end (`finish_reason=length`, 186.6 s, full 2048-token generation) with
**0** Metal errors; a ~340K-token prefill stress also ran 15 min clean. The
64-token default tripped within minutes on the same harness.

Incidental finding for a follow-up: `--max-request-tokens 65536` did not
reject the 113K-token prompt — the ceiling is apparently not enforced on
input length.

## DRY refactor (same diff)

Shared serving values are now single-sourced as named groups in the
`mac-studio` `let`:

| Group | Kind | Members |
| --- | --- | --- |
| `qwenMoeGeneralParser` | family | OptiQ-35B, Next-80B |
| `agentTimeout` | class | residents + Next-80B |
| `residentBrainArgs` | class | Coder-30B, OptiQ-35B |
| `swapTierTtl` / `swapTierFlags` | class | stock-35B, Next-80B, gpt-oss (ttl) |

A nix-eval JSON diff of old vs new `lib/hosts.nix` proves the refactor is
value-preserving — the only semantic change is the block-size flag on the two
residents. One deliberate non-change is flagged in a comment: stock-35B still
runs the `qwen3_coder` parser (family anomaly; flip only with a bench).

## Follow-ups (separate issues)

- 8-bit KV-cache quantization (`--kv-cache-quantization`) as a bench-window
  candidate — 2x context-byte headroom, needs a quality gate first.
- nix-ai: first-class typed options for paged-cache block size (currently a
  raw extraArg) and model group/profile support so hosts only tag membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr

