### PR TITLE
chore(deps): bump nix-ai to carry through advisorModel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -465,32 +465,16 @@
     "fabric-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777933126,
-        "narHash": "sha256-2O/g0DC0ptxzEzXA1NYZWfdnUeIVFuLWNyw1uct2XyM=",
+        "lastModified": 1781042236,
+        "narHash": "sha256-folZ+Y5l76SKo65RJAK7kZX6DJ/AL+iLkcV8NX+1DTA=",
         "owner": "danielmiessler",
         "repo": "fabric",
-        "rev": "6a9b55a096361d368368fa8119f7dd3b8bf2673b",
+        "rev": "a420eaf63c532094eb12bc90c91a227401e96c31",
         "type": "github"
       },
       "original": {
         "owner": "danielmiessler",
-        "ref": "v1.4.452",
-        "repo": "fabric",
-        "type": "github"
-      }
-    },
-    "fabric-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1777933126,
-        "narHash": "sha256-2O/g0DC0ptxzEzXA1NYZWfdnUeIVFuLWNyw1uct2XyM=",
-        "owner": "danielmiessler",
-        "repo": "fabric",
-        "rev": "6a9b55a096361d368368fa8119f7dd3b8bf2673b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "danielmiessler",
+        "ref": "v1.4.455",
         "repo": "fabric",
         "type": "github"
       }
@@ -928,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783597202,
-        "narHash": "sha256-8fQzEUNooHH81+DMk1P8op4DGunTCrIHzCP41xXZyHg=",
+        "lastModified": 1783631924,
+        "narHash": "sha256-T49pCVf6C2RDTtv0ok7squhPetLGHMb+oC3BtXrB7yc=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "e6a2c8756f8f9dfb8bc56207762810cb2db6fe22",
+        "rev": "a9ed4ee9394307f9dee0c907089eb61d1e5dc7c9",
         "type": "github"
       },
       "original": {
@@ -1016,7 +1000,10 @@
         "claude-plugins-official": "claude-plugins-official",
         "claude-skills": "claude-skills",
         "dryvist-github": "dryvist-github",
-        "fabric-src": "fabric-src_2",
+        "fabric-src": [
+          "nix-ai",
+          "fabric-src"
+        ],
         "flake-parts": "flake-parts_2",
         "home-manager": [
           "nix-ai",
@@ -1038,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783271602,
-        "narHash": "sha256-OiWFfUJ+tQhwfXxUnsdxY9E2xQd2NAOg0quSkMZ1sdg=",
+        "lastModified": 1783622041,
+        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "e058e7451002e90c49ed12e51dcdf4ab0cfc6492",
+        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `nix-ai` to `a9ed4ee`, propagating the released `advisorModel` setting to
this host's generated `~/.claude/settings.json`. The bump pulls in, transitively:

- nix-ai's `advisorModel = "fable"` setting (#1149)
- nix-claude-code **v0.7.0** typed `advisorModel` option (#1155)
- fabric-ai `proxyVendor` build fix (#1156)
- fabric-src `follows` dedup fix (#1159)

The last two were required for the host to build at all — nix-ai `main` had a
broken/​skewed fabric-ai that blocked `darwin-rebuild`.

## Changes

- `flake.lock`: `nix-ai` → `a9ed4ee`; transitive `nix-claude-code` → v0.7.0;
  `fabric-src` deduped to a single node.

## Test Plan

- `darwin-rebuild build` (no `--override-input`) succeeds.
- `darwin-rebuild switch` applied on the host; `~/.claude/settings.json` now
  contains `"advisorModel": "fable"`.