### PR TITLE
ci: widen main-only CI triggers to include develop

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["Nix Build", "Nix Validate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
 ---
 

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI Gate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   actions: read

--- a/.github/workflows/ci-file-length.yml
+++ b/.github/workflows/ci-file-length.yml
@@ -7,7 +7,7 @@ name: File Size Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**.md'
       - '**.nix'

--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -7,7 +7,7 @@ name: Markdown Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**.md'
       - '.markdownlint.json'

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -7,7 +7,7 @@ name: Nix Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - '**.nix'
       - 'flake.lock'

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -7,7 +7,7 @@ name: Nix Validate
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '17 11 * * 1'  # Weekly Monday 11:17 UTC (off-peak minute)
 


### PR DESCRIPTION
## What

Ahead of the git-flow-next pilot flip, widens hardcoded `main`-only triggers to also cover `develop`:

**Push-triggered standalone lint/build/validate wrappers** (`push: branches: [main]` -> `[main, develop]`):

- `ci-file-length.yml` ("File Size Check")
- `ci-markdownlint.yml` ("Markdown Lint")
- `ci-nix.yml` ("Nix Build")
- `ci-validate.yml` ("Nix Validate")
- `osv-scan.yml` ("OSV Scan" — security gate, not release/deploy)

**CI-completion consumers** (`workflow_run: branches: [main]` -> `[main, develop]`):

- `ci-fail-issue.yml` (listens for "CI Gate" completions)
- `ci-doctor.md` (gh-aw agentic CI triage source, listens for "Nix Build"/"Nix Validate" completions) — see lock-file note below

## Why

Each of the push-triggered workflows documents itself as "Runs on push to main for visibility. PRs use ci-gate.yml instead." — a post-merge safety net duplicating the PR-time checks. Once `develop` is a long-lived branch with direct pushes allowed, that safety net needs to cover it too. Same for the CI-Gate-completion auto-issue/auto-doctor flows.

## Scope notes

- `release-please.yml` stays `main`-only by design.
- `ci-fix.yml`'s `workflow_run` trigger is currently disabled (commented out, `workflow_dispatch`-only) — nothing to widen.
- `ai-merge-gate.yml`, `ai-pr-care.yml`, `ci-gate.yml`, `ci-package-staleness.yml`, `review-thread-resolver.yml` have no `branches` restriction on their `pull_request` triggers, so PR-time checks already run against develop-targeted PRs unchanged.
- `copilot-setup-steps.yml`'s bare `on: push` has no branch filter at all, so it already covers `develop`.
- `release-please-config.json` / `.release-please-manifest.json` / `release-please.yml` verified present and following the org-standard pattern — no gap.
- Other gh-aw `.md`/`.lock.yml` pairs (`daily-malicious-code-scan`, `link-checker`, `sub-issue-closer`, `repo-health-audit`) are schedule/workflow_dispatch only — no changes needed.

## Known gap — `ci-doctor.lock.yml` not regenerated

Same caveat as the sibling pilot-repo PRs: the only `gh aw` CLI available locally is a "dev" build newer than this repo's pinned version. Compiling with it silently upgrades the entire toolchain (schema version, action SHAs, container images) as a side effect of what should be a one-line trigger change — out of scope here. **Follow-up needed:** regenerate `ci-doctor.lock.yml` with the pinned toolchain so only the `branches` list changes.

## Open PRs targeting main (not retargeted here, per instructions — retarget happens at flip time)

- #1617 `fix(chatgpt): install via greedy homebrew cask, mirroring claude` (JacobPEvans-personal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ