### PR TITLE
refactor(mac-studio): slim host to nix-ai catalog selections + bump nix-ai

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783633334,
-        "narHash": "sha256-1sWR0qB6XDgK6PpT/dw/KntLHO8Qe9Tg8Tx5umX43ns=",
+        "lastModified": 1783633416,
+        "narHash": "sha256-hR0dyVkzLVR0KaQZdRPKWBKbkeWAIVdS+NTJldsxnBc=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "fe5109c283f1dff7fb708340277fb20aa1e20570",
+        "rev": "9a9a6986bef736e469ce3ba1dcc70d5715564968",
         "type": "github"
       },
       "original": {

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -1,38 +1,9 @@
 # mac-studio — M4 Max / 128 GB headless network server for the homelab.
-let
-  # Serving groups: shared values live here, never per-model (FAMILY =
-  # lineage → parser stack; CLASS = role → lifecycle/sizing).
-  #
-  # Qwen3.6/Next MoE lineage: XML tool format needs hermes (qwen3_coder
-  # mis-parses it → empty function.name repair storms) + qwen3 reasoning.
-  qwenMoeGeneralParser = [
-    "--tool-call-parser"
-    "hermes"
-    "--reasoning-parser"
-    "qwen3"
-  ];
-  # Guard chain: server 3600 > router 2400 > client 1800 (lifts the
-  # 300 s disconnect_guard).
-  agentTimeout = [
-    "--timeout"
-    "3600"
-  ];
-  # Residents: 256-token paged-cache blocks (default 64) — long sessions
-  # shattered the KV into enough per-block Metal buffers to trip MLX's
-  # buffer-count limit ("Resource limit (499000) exceeded", not a
-  # byte OOM). Validated 2026-07-09 (#1609).
-  residentBrainArgs = agentTimeout ++ [
-    "--paged-cache-block-size"
-    "256"
-  ];
-  # Swap tier: on-demand, idle-unloaded; small caps.
-  swapTierTtl = 900;
-  swapTierFlags = {
-    autoUnloadIdleSeconds = swapTierTtl;
-    maxNumSeqs = 2;
-    maxRequestTokens = 32768;
-  };
-in
+#
+# Serving detail lives in nix-ai's validated model catalog
+# (modules/mlx/catalog-data.nix): parser stacks, chat-template kwargs, and
+# per-class flag profiles. This host only picks entries + classes and sets
+# host-scoped runtime posture. Add or fix serve args in the catalog, not here.
 {
   # Network identity. `system` omitted (mkHost defaults to aarch64-darwin).
   hostName = "jevans-ms";
@@ -41,31 +12,39 @@ in
   # defaults (hosts/common/default.nix) and nix-home's server preset.
   class = "server";
 
-  # Resident brains (2026-07-08 agentic tool-calling bench; verdicts + capacity
-  # in HF JacobPEvans/mlx-benchmarks + apps docs/BRAIN_ROTATION.md):
-  #   tool-calling — Qwen3.6-35B-A3B OptiQ-4bit (~19.5 GB, qwen3_5_moe): bench
-  #     winner, the brain Hermes routes to by physical id. glm47 + stock 8-bit
-  #     degraded, left unregistered.
-  #   coding — Qwen3-Coder-30B-A3B 4-bit (17.1 GB, qwen3_moe).
-  # gpt-oss-120b (63.3 GB, default/oss) is NOT preloaded — 0% on the agentic
-  # gate, so on-demand + idle-unload. Resident weights ≈ 36.6 GB.
+  # Roles (2026-07-08 agentic tool-calling bench; verdicts + capacity in
+  # HF JacobPEvans/mlx-benchmarks + apps docs/BRAIN_ROTATION.md):
+  #   tool-calling — Qwen3.6-35B-A3B OptiQ-4bit: bench winner, the brain
+  #     Hermes routes to by physical id.
+  #   coding — Qwen3-Coder-30B-A3B 4-bit.
+  # gpt-oss-120b (63.3 GB, default/oss role) is swap-class: 0% on the agentic
+  # gate, so on-demand + idle-unload, never preloaded.
   defaultLocalModelId = "mlx-community/gpt-oss-120b-MXFP4-Q8";
   roleModelOverrides = {
     tool-calling = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
     coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
   };
 
-  # MLX sizing (per-worker cacheMemoryMb; derivations in mlx-benchmarks
-  # docs/RUNBOOK.md): residents ≈ 58.6 GB (coder + OptiQ weights + 6 + 16 GB
-  # caches), far under the ~109 GB cache-clear trip (gpuMemoryUtilization 0.80
-  # on 128 GB, never > 0.85). An on-demand gpt-oss swap-in transiently exceeds
-  # the trip — pre-existing; it idle-unloads back to baseline.
   mlx = {
+    # Validated catalog selections (profiles in nix-ai catalog-data.nix).
+    # Residents ≈ 58.6 GB with caches, far under the ~109 GB cache-clear trip
+    # (gpuMemoryUtilization 0.80 on 128 GB); an on-demand gpt-oss swap-in
+    # transiently exceeds the trip — pre-existing; it idle-unloads.
+    catalog = {
+      qwen36-optiq.class = "resident";
+      qwen3-coder-30b.class = "resident";
+      gpt-oss-120b.class = "swap";
+      qwen36-35b.class = "swap";
+      # LARGE daily-rotation brain (apps ai_default_model_large;
+      # docs/BRAIN_ROTATION.md).
+      qwen3-next-80b.class = "swap";
+    };
+
     cacheMemoryMb = 6144;
     prefillBatchSize = 2048;
-    # Server host: no group swap, no global idle eviction (per-model unloads
-    # are set below). A blanket TTL would make each resident brain pay a
-    # 60-120 s cold start after any quiet period.
+    # Server host: no group swap, no global idle eviction (per-class unloads
+    # come from the catalog). A blanket TTL would make each resident brain pay
+    # a 60-120 s cold start after any quiet period.
     proxy = {
       groupSwap = false;
       idleTtl = 0;
@@ -76,116 +55,13 @@ in
     };
     autoUnloadIdleSeconds = 0;
     # Resident brains warmed at boot: coder (coding) + OptiQ (tool-calling).
-    # gpt-oss (default) is deliberately omitted — see the composition note.
+    # gpt-oss (default) deliberately omitted — swap-class above.
     preload = [
       "coding"
       "tool-calling"
     ];
-    # Global parser off; each backend pins its own below (harmony needs
-    # vllm-mlx >= 0.4.0). gpt-oss MUST set --reasoning-parser gpt_oss — unset,
-    # its harmony channel markers ("analysis"/"assistantfinal") leak into
-    # streamed message.content (root-caused 2026-07-06; nix-ai#1083).
+    # Global parser off; every backend's parser comes from its catalog entry.
     toolCallParser = null;
-    modelExtraArgs = {
-      "mlx-community/gpt-oss-120b-MXFP4-Q8" = [
-        "--tool-call-parser"
-        "harmony"
-        "--reasoning-parser"
-        "gpt_oss"
-        # Server defaults keep request-level chat_template_kwargs overrideable.
-        "--default-chat-template-kwargs"
-        (builtins.toJSON {
-          reasoning_effort = "low";
-        })
-      ];
-      "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = [
-        "--tool-call-parser"
-        "qwen3_coder"
-      ]
-      ++ residentBrainArgs;
-      # tool-calling role (resident agent brain): family parser stack;
-      # thinking ON (bench winner).
-      "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" =
-        qwenMoeGeneralParser
-        ++ [
-          "--default-chat-template-kwargs"
-          (builtins.toJSON {
-            enable_thinking = true;
-          })
-        ]
-        ++ residentBrainArgs;
-      # Swap-tier (mlx.models) args go on those entries below; keys here
-      # only reach role-registry models and are otherwise silently ignored.
-    };
-    # gpt-oss needs pagedKvCache + prefix caching OFF: its sliding-window
-    # attention hits a [broadcast_shapes] failure with vllm-mlx 0.4.0's paged
-    # cache. The Qwen models keep prefix caching for agentic reuse.
-    modelFlagOverrides = {
-      # gpt-oss: demoted from preload. The global autoUnloadIdleSeconds = 0
-      # would pin it resident-forever once loaded on demand, so re-arm a 15-min
-      # idle unload to free its 63 GB back to the two-brain baseline.
-      "mlx-community/gpt-oss-120b-MXFP4-Q8" = {
-        pagedKvCache = false;
-        enablePrefixCaching = false;
-        autoUnloadIdleSeconds = swapTierTtl;
-      };
-      # coding: resident, unchanged. The global maxRequestTokens (8192, modules/
-      # mlx in nix-ai) is too low for agentic multi-turn, so keep 32768.
-      "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit" = {
-        maxRequestTokens = 32768;
-      };
-      # tool-calling (resident brain): HIGH KV budget for 40-58K-token contexts;
-      # maxNumSeqs 8 = one continuous batch. The 65536 ceiling replaces the 32768
-      # cap that fed the truncation/retry death-loop.
-      "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit" = {
-        cacheMemoryMb = 16384;
-        maxNumSeqs = 8;
-        maxRequestTokens = 65536;
-      };
-      "mlx-community/Qwen3.6-35B-A3B-4bit" = swapTierFlags // {
-        cacheMemoryMb = 3072;
-      };
-      # Qwen3-Next-80B swap brain (mlx.models entry below). Small 4096 MB cache
-      # keeps the on-demand swap-in under the ~109 GB trip (≈104.6 GB with
-      # residents; derivation in mlx-benchmarks docs/RUNBOOK.md); idle-unload
-      # frees it. prefixCaching off — unsupported for the qwen3_next
-      # hybrid-attention family (mlx-benchmarks model-notes).
-      "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = swapTierFlags // {
-        cacheMemoryMb = 4096;
-        enablePrefixCaching = false;
-      };
-    };
-  };
-
-  # Non-resident swap tier: router loads on demand, idle-unloads so it never
-  # crowds the resident pair. (Dense 27B retired 2026-07-07: 4x slower.)
-  mlx.models = {
-    # Swap-tier serve flags go on extraArgs HERE (modelExtraArgs only reaches
-    # role-registry models). The tool-call parser is required — the global
-    # --enable-auto-tool-choice makes vllm-mlx exit at argparse without it.
-    # Parser anomaly: still qwen3_coder (predates the 2026-07-08 bench);
-    # flip to qwenMoeGeneralParser only with a bench on this variant.
-    "mlx-community/Qwen3.6-35B-A3B-4bit" = {
-      ttl = swapTierTtl;
-      extraArgs = [
-        "--tool-call-parser"
-        "qwen3_coder"
-        "--reasoning-parser"
-        "qwen3"
-        # Thinking off by default (requests can opt back in). extraArgs are
-        # raw-concatenated + shell-parsed, so the JSON quotes itself (#1557).
-        "--default-chat-template-kwargs"
-        "'{\"enable_thinking\":false}'"
-      ];
-    };
-    # Qwen3-Next-80B-A3B Thinking 4-bit — the LARGE daily-rotation brain (apps
-    # ai_default_model_large; rotation + capacity in apps docs/BRAIN_ROTATION.md
-    # and mlx-benchmarks docs/RUNBOOK.md). No enable_thinking kwarg: the
-    # dedicated Thinking variant is always-on (no chat-template switch).
-    "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit" = {
-      ttl = swapTierTtl;
-      extraArgs = qwenMoeGeneralParser ++ agentTimeout;
-    };
   };
 
   # OrbStack stays OFF — this host uses the Apple `container` runtime, not


### PR DESCRIPTION
## Why

Architecture decision (nix-ai#1153): detailed vllm-mlx serve args do not belong in nix-darwin — nix-ai owns the serving domain via the validated model catalog (merged in [nix-ai#1158](https://github.com/dryvist/nix-ai/pull/1158)). Hosts only pick WHICH entries run, in which class.

## What

- `lib/hosts/mac-studio.nix`: 8.2 KB of per-model args → 3.2 KB of `programs.mlx.catalog` selections (2 residents, 3 swap) + host posture (proxy, preload, sizing).
- `flake.lock`: nix-ai bump pulls in the catalog module, the transformers 5.13.0 regression block + mlx 0.32.0 ([nix-ai#1157](https://github.com/dryvist/nix-ai/pull/1157)), and the per-worker `MLX_BUFFER_CACHE_LIMIT` concurrency fix ([nix-ai#1160](https://github.com/dryvist/nix-ai/pull/1160)).

## Equivalence proof

`nix eval` of the compiled per-model surfaces (`modelExtraArgs` / `modelFlagOverrides` / `models` / `preload`) before vs after is identical except three intended deltas:
1. `--paged-cache-block-size 256` moves from raw extraArgs to the typed `pagedCacheBlockSize` flag on both residents (same cmd semantics);
2. the stock-35B swap entry gains the validated block-256;
3. every backend env gains `MLX_BUFFER_CACHE_LIMIT=12 GB` (the nix-ai#1160 fix riding this bump).

Both `darwinConfigurations` toplevels eval clean.

## Post-merge

Rebuild both machines; verify the Studio log line `buffer_cache_limit=12.9GB (MLX_BUFFER_CACHE_LIMIT)` and run the 4-way concurrency harness (nix-ai#1153 acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr