### PR TITLE
chore(ci): retire deps-update-flake custom nix-update target

### DIFF
--- a/.claude/rules/nix-deps-sync.md
+++ b/.claude/rules/nix-deps-sync.md
@@ -20,8 +20,9 @@
 
 - **Renovate** — Daily at 7am ET, polls for new versions. JacobPEvans inputs are in
   GROUP 1 (critical infrastructure) and GROUP 2 (AI tools) in `renovate.json5`.
-- **`deps-update-flake.yml`** — Weekly Monday, updates custom packages (claudebar via nix-update).
-  Flake input updates are handled by Renovate, not this workflow.
+- **`deps-update-flake.yml`** — Manual dispatch only (see *Immediate* below); bumps
+  JacobPEvans flake inputs on demand. Third-party flake input updates are handled by
+  Renovate, not this workflow.
 
 ### Immediate (after shipping upstream changes)
 
@@ -29,10 +30,10 @@ When you've just merged changes in nix-home, nix-ai, or another JacobPEvans repo
 need nix-darwin to pick them up immediately — don't wait for Renovate:
 
 ```bash
-gh workflow run deps-update-flake.yml -f target=jacobpevans --repo JacobPEvans/nix-darwin
+gh workflow run deps-update-flake.yml --repo JacobPEvans/nix-darwin
 ```
 
-This triggers `.github/workflows/deps-update-flake.yml` (target=jacobpevans) which:
+This triggers `.github/workflows/deps-update-flake.yml` which:
 1. Runs `nix flake update nix-home nix-ai ai-assistant-instructions claude-code-plugins`
 2. Opens a PR with the updated `flake.lock`
 3. CI validates, then auto-merge (via org Renovate preset) handles the rest
@@ -65,7 +66,7 @@ the build, the CI gate catches it before merge.
 
 ## Related Files
 
-- `.github/workflows/deps-update-flake.yml` — Parameterized: `target=jacobpevans` for immediate input bump, `target=custom` (default/scheduled) for nix-update packages
+- `.github/workflows/deps-update-flake.yml` — Manual dispatch: bumps JacobPEvans flake inputs on demand
 - `renovate.json5` — Renovate config with package groups and schedules
 - `flake.nix` — Input declarations
 - `flake.lock` — Current pinned versions (auto-updated)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -152,7 +152,7 @@ jobs:
 | --- | --- |
 | `review-code.yml` | Claude Code PR review |
 | `review-deps.yml` | Dependency update reviews |
-| `deps-update-flake.yml` | Unified flake.lock updates (schedule + instant sync) |
+| `deps-update-flake.yml` | JacobPEvans flake.lock updates (manual dispatch) |
 
 ## Configuration
 

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -1,39 +1,22 @@
-# Flake dependency updates (on-demand and scheduled)
+# Flake dependency updates (manual, on-demand)
 #
-# Two modes controlled by the `target` input:
+# Bumps all JacobPEvans-owned flake inputs to latest. Use after shipping
+# changes in upstream repos (nix-home, nix-ai, etc.) to pull them into
+# nix-darwin immediately instead of waiting for Renovate.
+#   CLI: gh workflow run deps-update-flake.yml
 #
-#   jacobpevans  — Bump all JacobPEvans-owned flake inputs to latest.
-#                  Use after shipping changes in upstream repos (nix-home,
-#                  nix-ai, etc.) to pull them into nix-darwin immediately.
-#                  CLI: gh workflow run deps-update-flake.yml -f target=jacobpevans
-#
-#   custom       — Update custom packages with pinned source hashes that
-#                  Renovate cannot manage (currently: claudebar via nix-update).
-#                  Runs weekly on Monday at noon UTC and on manual dispatch.
-#
-# Flake input updates for third-party inputs (nixpkgs, home-manager, etc.)
-# are handled by Renovate's nix manager — see renovate.json5.
+# Third-party inputs (nixpkgs, home-manager, etc.) are handled by Renovate's
+# nix manager — see renovate.json5.
 name: Update flake dependencies
 
 on:
-  schedule:
-    - cron: "0 12 * * 1"
   workflow_dispatch:
-    inputs:
-      target:
-        description: "What to update"
-        required: true
-        default: "custom"
-        type: choice
-        options:
-          - custom
-          - jacobpevans
 
 jobs:
   update:
-    name: Update (${{ inputs.target || 'custom' }})
-    # Always macOS: claudebar requires aarch64-darwin for nix-update prefetch,
-    # and nix flake update works fine on Darwin too.
+    name: Update JacobPEvans flake inputs
+    # Runs on macOS to match the primary target platform; `nix flake update`
+    # itself is platform-agnostic.
     runs-on: macos-latest
     environment: automation
     permissions:
@@ -59,12 +42,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
 
-      - name: Update custom packages
-        if: inputs.target != 'jacobpevans'
-        run: nix run nixpkgs#nix-update -- --flake --system aarch64-darwin claudebar
-
       - name: Update JacobPEvans flake inputs
-        if: inputs.target == 'jacobpevans'
         run: nix flake update nix-home nix-ai ai-assistant-instructions jacobpevans-cc-plugins
 
       - name: Validate flake
@@ -75,12 +53,12 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
-          branch: chore/update-${{ inputs.target || 'custom' }}-packages
+          branch: chore/update-jacobpevans-inputs
           delete-branch: true
-          commit-message: "chore(deps): update ${{ inputs.target || 'custom' }} packages"
-          title: "chore(deps): update ${{ inputs.target || 'custom' }} packages"
+          commit-message: "chore(deps): update JacobPEvans flake inputs"
+          title: "chore(deps): update JacobPEvans flake inputs"
           body: |
-            Automated dependency update (${{ inputs.target || 'custom' }}).
+            Automated JacobPEvans flake-input update.
 
             Triggered via `${{ github.event_name }}` on `deps-update-flake.yml`.
           labels: dependencies

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -592,10 +592,11 @@ gh issue list --search "Dependency Dashboard in:title"
 
 Renovate has a 3 concurrent PR limit. Merge some PRs to allow new ones.
 
-**Custom workflow conflicts with Renovate:**
+**`deps-update-flake.yml` and Renovate:**
 
-The custom workflow (`.github/workflows/deps-update-flake.yml`) automatically skips
-if a Renovate PR exists. No manual intervention needed.
+`deps-update-flake.yml` runs only on manual dispatch — it never fires on a schedule,
+so it cannot collide with Renovate on its own. Trigger it only when you need an
+immediate JacobPEvans flake-input bump.
 
 ---
 


### PR DESCRIPTION
**Stacked on #1617** (base = `fix/chatgpt-cask`). GitHub will retarget this to `main` once #1617 merges.

## Why

`claudebar` was the **only** package the `deps-update-flake.yml` `custom` target updated via `nix-update`. #1617 removes claudebar, orphaning that target. This PR retires it.

## Changes

- `.github/workflows/deps-update-flake.yml` — remove the weekly `schedule`, the `target` input, and the `Update custom packages` (nix-update) step. The workflow becomes a single **manual-dispatch** job that bumps JacobPEvans flake inputs. **No custom package is auto-updated now**; `cribl-edge` stays manually pinned, unchanged.
- `.claude/rules/nix-deps-sync.md`, `.github/workflows/README.md`, `RUNBOOK.md` — reconcile the descriptions that referenced the removed schedule/target.

## Deliberately NOT in this PR

`docs/DEPENDENCY-MONITORING.md` and `docs/FLAKE_UPDATE_STRATEGY.md` describe an entirely different, **phantom** workflow (daily day-of-week schedules, a `repository_dispatch` `ai-instructions-updated` event, an `update_all` input) that does **not** exist in the YAML and predates even the pre-#1617 state. That is long-standing doc drift unrelated to the custom target, and rewriting it here would over-scope this PR. Tracked separately.

## Verification

- Workflow YAML parses; `markdownlint-cli2` on touched docs — clean
- No `claudebar` / `target=` / `inputs.target` references remain in the workflow or the three reconciled docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)