### PR TITLE
chore(deps): bump nix-ai for resident block-512 + Next-80B block-256

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783633334,
-        "narHash": "sha256-1sWR0qB6XDgK6PpT/dw/KntLHO8Qe9Tg8Tx5umX43ns=",
+        "lastModified": 1783647242,
+        "narHash": "sha256-uLU7aWzRWJVN0qo/+u/xZcZndScxKHRdZFtgLnn3zao=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "fe5109c283f1dff7fb708340277fb20aa1e20570",
+        "rev": "9579083f65f01e8293867d0b40a8cb15f5a7315a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls [nix-ai#1168](https://github.com/dryvist/nix-ai/pull/1168) (resident paged blocks 256→512 — residual buffer-count trip under 2×50K-token concurrency) and [nix-ai#1172](https://github.com/dryvist/nix-ai/pull/1172) (Qwen3-Next-80B to 256 — the engine-default 64 tripped mid-digest at step 250880). Post-merge: rebuild jevans-ms, then re-run the concurrency harness + a long 80B thinking request → 0 resource-limit lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr