### PR TITLE
chore(deps): bump nix-ai for resident block-512 + Next-80B block-256

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783633416,
-        "narHash": "sha256-hR0dyVkzLVR0KaQZdRPKWBKbkeWAIVdS+NTJldsxnBc=",
+        "lastModified": 1783647242,
+        "narHash": "sha256-uLU7aWzRWJVN0qo/+u/xZcZndScxKHRdZFtgLnn3zao=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "9a9a6986bef736e469ce3ba1dcc70d5715564968",
+        "rev": "9579083f65f01e8293867d0b40a8cb15f5a7315a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls [nix-ai#1168](https://github.com/dryvist/nix-ai/pull/1168) and [nix-ai#1172](https://github.com/dryvist/nix-ai/pull/1172) (both merged to nix-ai develop). Re-lands #1627's intent on **develop** — the default-branch migration landed that bump on main, which `darwin-rebuild --flake github:dryvist/nix-darwin` no longer follows.

Post-merge: rebuild jevans-ms → running residents pick up block 512 on next load (12:00 UTC warm), the 80B block 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr