### PR TITLE
chore(ci): extend file-size ceiling for cribl module; exclude gh-aw files from whitespace fixers

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -6,6 +6,9 @@ extended:
     - AGENTS
     - ANTHROPIC-ECOSYSTEM
     - TROUBLESHOOTING
+    # cribl.nix crossed the 12KB error limit on develop, failing every PR's
+    # merge-ref file-size check; split the module if it approaches this ceiling
+    - cribl
 
 exempt:
   - RUNBOOK

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,11 @@ repos:
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+        # gh-aw generated artifacts are regenerated verbatim; hand-fixing
+        # whitespace in them just churns against the generator
+        exclude: ^\.github/(workflows/.*\.lock\.yml|aw/imports/)
       - id: end-of-file-fixer
+        exclude: ^\.github/(workflows/.*\.lock\.yml|aw/imports/)
       - id: check-yaml
       - id: check-json
       - id: check-added-large-files


### PR DESCRIPTION
## Summary
- Grant `hosts/common/cribl.nix` the extended (32KB) file-size ceiling — it crossed the 12KB error limit on develop, failing every PR's merge-ref File Size check (root cause of #1617's red gate).
- Exclude gh-aw generated artifacts (`.lock.yml` workflows, `.github/aw/imports/`) from the whitespace pre-commit fixers so hooks stop churning against the generator.

## Test Plan
- Pre-commit + pre-push hooks pass locally on both commits.
- File Size check on this PR's merge-ref should go green (it was failing on all PRs before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKFbnb4ekCsypxzGZvqUeA