### PR TITLE
fix(cribl): file-source filenames must be globs — literal names match nothing

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -40,6 +40,11 @@ in
         # fails validation ("should have required property 'path'") and takes
         # the whole config load down with it. Shape mirrors the stock
         # in_file_varlog entry in default/edge/inputs.yml.
+        # `filenames` entries MUST contain a glob character: a literal
+        # filename ("vllm-mlx.log") silently matches NOTHING — the input
+        # reports health Green with zero files tracked (verified empirically
+        # both ways via the local API, 4.18.0; root cause of #1623's "ships
+        # nothing").
         "inputs.yml" = ''
           inputs:
             in_llm_logs:
@@ -49,8 +54,7 @@ in
               interval: 10
               path: ${userConfig.user.homeDir}/Library/Logs/vllm-mlx/
               filenames:
-                - vllm-mlx.log
-                - vllm-mlx.error.log
+                - "vllm-mlx*.log"
               tailOnly: false
               sendToRoutes: false
               # Ship through cribl_stream (:10300 in_cribl_s2s), the ONLY live
@@ -182,6 +186,7 @@ in
         # module): other mlx hosts get no input for a path that never exists.
         + lib.optionalString config.programs.llm-gate.enable ''
           # llm-gate JSON access log (Caddy `log` directive, llm-gate.nix).
+          # Glob required — a literal filename matches nothing (see above).
             in_gate_access:
               type: file
               disabled: false
@@ -189,7 +194,7 @@ in
               interval: 10
               path: ${config.programs.llm-gate.logDir}/
               filenames:
-                - access.json
+                - "access.*"
               tailOnly: false
               sendToRoutes: false
               connections:


### PR DESCRIPTION
## Summary
Root cause of #1623 (vllm-mlx logs never reach Splunk): **Cribl Edge 4.18's file source silently matches zero files when a `filenames` entry is a literal filename** — the input reports health Green with an empty tracked-file set. Entries must contain a glob character.

Empirically proven both directions on a live Edge node via its local API:
- `filenames: [vllm-mlx.log, vllm-mlx.error.log]` → 0 files tracked after 2+ min of active file growth (fresh input recreation included, ruling out stale monitor state)
- `filenames: ["*.log"]` on the same path → collector added within seconds, 3 files tracked

This also explains why the serving host's Edge appeared to have a dead FileMonitor: its only actively-growing monitored file was the vllm-mlx log, matched by the broken input.

## Changes
- `in_llm_logs`: literal filenames → `vllm-mlx*.log` (matches the main, error, and warmup logs)
- `in_gate_access`: literal `access.json` → `access.*`
- Comment documents the glob requirement at the schema note

fixes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Way2of9zrhrqx1G1DtHHTS