### PR TITLE
feat(cluster): host wiring, worker quiesce, gated cluster endpoint, runbook

### DIFF
--- a/docs/NIGHT_CLUSTER.md
+++ b/docs/NIGHT_CLUSTER.md
@@ -1,0 +1,112 @@
+# Night Cluster — two-Mac Thunderbolt 5 distributed brain
+
+Every night, one Thunderbolt 5 cable turns the two M4 Max / 128 GB Macs into a
+single 256 GB inference cluster running a frontier-class model neither machine
+can hold alone — and the rest of the fabric never notices the seam. Plugging
+in is the entire ceremony; unplugging in the morning reverses everything
+unattended.
+
+Component map (all IaC):
+
+| Piece | Where |
+| --- | --- |
+| `programs.mlx.nightCluster` (ranks, link watcher, prefetch) | nix-ai `modules/mlx/night-cluster.nix` |
+| Host roles (coordinator = server, worker = workstation) | `lib/hosts/*.nix` |
+| Worker quiesce/restore (GUI quit + agent allowlist sweep) | `hosts/common/night-quiesce.nix` + `scripts/` |
+| Gated night endpoint (`:11440`, same bearer token) | `modules/darwin/llm-gate.nix` `nightUpstreamPort` |
+| Router: night brain in the large phase + solo fallback | ansible-proxmox-apps `roles/llm_router` (`ai_night_brain_enabled`) |
+| Log shipping (`in_night_logs`, `night-access.*`) | `hosts/common/cribl.nix` |
+
+Serving stack: first-party **mlx-lm** — `mlx_lm.server --pipeline` on both
+ranks (rank 0 binds the OpenAI-compatible endpoint; both ranks join every
+generation). Distributed init uses the documented env contract
+(`MLX_RANK` / `MLX_JACCL_COORDINATOR` / `MLX_IBV_DEVICES`,
+`MLX_METAL_FAST_SYNCH=1`), so each Mac starts its own rank from launchd — no
+SSH orchestration. `--pipeline` is required: the pinned mlx-lm ships
+`PipelineMixin` for `glm4_moe` but not tensor-parallel `shard()`; revisit TP
+on an mlx-lm bump.
+
+**Night model**: `GLM-4.7-4bit` (352.8B, 198 GB — `glm4_moe`). It is the only
+frontier-class (>128 GB) architecture with distributed support in the pinned
+mlx-lm. Qwen3-235B (`qwen3_moe`) and Qwen3.5-397B (`qwen3_5_moe`) have **no**
+shard/pipeline support upstream yet (ml-explore/mlx-lm#1138 stale since
+April 2026) — recheck before every bench night; either landing would make a
+strong head-to-head candidate.
+
+## One-time prep (BEFORE the first plug night — no cable needed)
+
+1. **Enable RDMA on BOTH Macs** (physical presence required): boot into macOS
+   Recovery → Utilities → Terminal → `rdma_ctl enable` → reboot. Verify from
+   normal boot: `ibv_devices` lists `rdma_enX` devices.
+2. **Confirm weights on both Macs**: the `dev.mlx-night.prefetch` agent
+   downloads the night model into `$HF_HOME` on each host (retry-until-
+   complete). `hf download mlx-community/GLM-4.7-4bit` resumes manually if
+   needed; mirroring the workstation's cache over the second TB cable beats
+   re-downloading 198 GB.
+3. **Dry-run the worker quiesce WITHOUT a cable**: run `night-quiesce`, then
+   assert the agent table matches the allowlist
+   (`launchctl list | grep -v com.apple`), then `night-restore` and confirm
+   the recorded agents return.
+4. **Check the fabric config is live**: rebuild both Macs; confirm
+   `launchctl print gui/$UID/dev.mlx-night.watcher` exists on both and the
+   rank agent is idle (link down → watcher no-ops).
+
+## Plug night checklist (execution only — zero code)
+
+1. Assign the link IPs once (System Settings or `networksetup -setmanual` on
+   the Thunderbolt interface; the module defaults are
+   `programs.mlx.nightCluster.linkIps`). Make sure the RDMA interface is NOT
+   a member of the Thunderbolt bridge (remove it from bridge0 in System
+   Settings; RDMA requires the bridge disabled on that link).
+2. Cable #1 in (the RDMA rail). Verify: `ibv_devices` shows the device on
+   both; note the real device name and correct
+   `programs.mlx.nightCluster.rdmaDevice` if it differs from `rdma_en2` —
+   the `MLX_IBV_DEVICES` matrix ships UNVALIDATED until this step. Optionally
+   run `mlx.distributed_config --over thunderbolt --backend jaccl --hosts …`
+   to cross-check the generated hostfile against the module's env contract.
+3. JACCL hello-world: `mlx.launch --backend jaccl --hostfile <generated> --
+   python -c 'import mlx.core as mx; print(mx.distributed.init().rank())'`
+   (or watch the two rank logs — the watcher will have started the ranks
+   as soon as the peer ping succeeded).
+4. Watch the seam: `night-watcher.log` on both Macs shows
+   `down -> up` → day models unload (coordinator) / quiesce sweep (worker) →
+   rank kickstart. First token can take minutes (198 GB load).
+5. Smoke the endpoint through the gate:
+   `curl -H "Authorization: Bearer $TOKEN" https://<serving-host>:11440/v1/models`.
+6. Flip the router: set `ai_night_brain_enabled: true` (+ `ai_night_model`,
+   `ai_night_context_window`, and the `llm_night_api` port constant in the
+   tofu registry), converge the routers. Large phase now serves `ai-default`
+   on the night brain with the solo 80B as automatic fallback.
+7. Bench: two runs on the night model (verdict-maturity rule: results stay
+   PROVISIONAL until ≥4 runs / ≥5 days). Then let Hermes's overnight digest
+   run on it.
+8. **Unplug test before bed is optional but recommended**: yank the cable —
+   in-flight generations abort, LiteLLM falls back to the solo brain, the
+   watcher stops the rank and re-warms day serving. Surprise-yank and
+   graceful shutdown converge on the same code path; there is no hardware or
+   filesystem risk (each Mac's memory is its own).
+
+## Morning
+
+Pull the cable (glance that no generation is mid-stream if you care about
+it finishing). Everything reverses unattended: ranks exit, day workers
+restart and re-warm, the worker's booted-out agents bootstrap back, the
+12:00 UTC flip proceeds as always. GUI apps stay closed.
+
+## Second cable
+
+A 2-node JACCL cluster is fully connected with ONE cable. Cable #2 is the
+control/mirror rail (plain TB bridge IP link: HF-cache sync, health checks,
+monitoring) and the tested spare — the cable is the single physical failure
+point of the whole design. Whether JACCL uses a second link between the same
+pair is expected to be "no"; test once and record the result here.
+
+## Observability
+
+- `in_night_logs` ships rank/watcher/prefetch logs; the gate's
+  `night-access.json` rides the existing gate input (both → index=llm).
+- Saved searches (ansible-splunk): night-rank crash/JACCL-error detector;
+  "night mode active but no night-brain tokens in 30 min"; worker
+  quiesce-violation (unexpected agent during the night window).
+- The memory-headroom alert and verdict-maturity benchmarking extend to the
+  night brain unchanged.

--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783647242,
-        "narHash": "sha256-uLU7aWzRWJVN0qo/+u/xZcZndScxKHRdZFtgLnn3zao=",
+        "lastModified": 1783684882,
+        "narHash": "sha256-tUuqgHtL1pBEGmDbq9yYKs4rGHH0Ez0Iw3M5IPLBgoc=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "9579083f65f01e8293867d0b40a8cb15f5a7315a",
+        "rev": "b8eb6c3e78e5fcaaaedb1c235171d214fc7634c9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783684882,
-        "narHash": "sha256-tUuqgHtL1pBEGmDbq9yYKs4rGHH0Ez0Iw3M5IPLBgoc=",
+        "lastModified": 1783686749,
+        "narHash": "sha256-Rq6DCPHw5ZYpYVsZokOvOSsL7yoJwiF73UD64QbF2Oc=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "b8eb6c3e78e5fcaaaedb1c235171d214fc7634c9",
+        "rev": "0f39059775a4a8b4978d664f4e48f838808a4358",
         "type": "github"
       },
       "original": {

--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -69,6 +69,22 @@ in
               connections:
                 - pipeline: llm_logs
                   output: cribl_stream
+            # Night-cluster logs (rank + link watcher + prefetch, both Macs).
+            # Same proven path and pipeline as in_llm_logs above; the "*/"
+            # lead on every pattern is the #1623 lesson.
+            in_night_logs:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/Library/Logs/mlx-night/
+              filenames:
+                - "*/night-*.log"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - pipeline: llm_logs
+                  output: cribl_stream
             in_system_metrics:
               type: system_metrics
               disabled: false
@@ -195,6 +211,8 @@ in
               path: ${config.programs.llm-gate.logDir}/
               filenames:
                 - "*/access.*"
+                # Night-cluster site's own access log (llm-gate nightSite).
+                - "*/night-access.*"
               tailOnly: false
               sendToRoutes: false
               connections:

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -27,6 +27,8 @@
     ./git-global-excludes.nix
     # Ghostty terminfo (package + ~/.terminfo) — split out for the byte cap.
     ./ghostty-terminfo.nix
+    # Worker-side night-cluster quiesce/restore hooks (byte cap split).
+    ./night-quiesce.nix
   ];
 
   # Share system-level Homebrew taps with nix-ai's trust.json.

--- a/hosts/common/night-quiesce.nix
+++ b/hosts/common/night-quiesce.nix
@@ -1,0 +1,42 @@
+# Worker-side night-cluster hooks (split out for the per-file byte cap).
+#
+# Wires the night-quiesce/restore scripts into nix-ai's
+# programs.mlx.nightCluster link watcher on the worker Mac: link-up quits
+# GUI apps and boots out non-allowlisted user agents before the rank starts;
+# link-down bootstraps the recorded set back. Coordinator hosts get their
+# quiesce natively from the watcher (llama-swap unload + warmup re-warm),
+# so this module is worker-only.
+{
+  lib,
+  pkgs,
+  hostConfig,
+  ...
+}:
+let
+  nightRole = hostConfig.mlx.nightCluster.role or null;
+
+  quiescePkg = pkgs.writeShellApplication {
+    name = "night-quiesce";
+    text = builtins.readFile ./scripts/night-quiesce.sh;
+  };
+
+  restorePkg = pkgs.writeShellApplication {
+    name = "night-restore";
+    text = builtins.readFile ./scripts/night-restore.sh;
+  };
+in
+{
+  config = lib.mkIf (nightRole == "worker") {
+    programs.mlx.nightCluster = {
+      quiesceCommand = lib.getExe quiescePkg;
+      restoreCommand = lib.getExe restorePkg;
+    };
+
+    # On PATH for the pre-plug verification: run the pair manually WITHOUT a
+    # cable and assert the post-quiesce agent table matches the allowlist.
+    home.packages = [
+      quiescePkg
+      restorePkg
+    ];
+  };
+}

--- a/hosts/common/scripts/night-quiesce.sh
+++ b/hosts/common/scripts/night-quiesce.sh
@@ -25,7 +25,7 @@ tell application "System Events"
 end tell
 repeat with appName in appNames
     set appText to appName as text
-    if appText is not in {"Finder", "Ghostty", "Terminal", "iTerm2"} then
+    if appText is not in {"Finder", "Ghostty", "Terminal", "iTerm2", "WezTerm", "Alacritty", "kitty"} then
         try
             with timeout of 15 seconds
                 tell application appText to quit
@@ -42,7 +42,7 @@ keep='^(com\.apple\.|org\.nix-community\.|com\.nix-darwin\.|dev\.mlx-night\.|org
 for plist in "$HOME/Library/LaunchAgents/"*.plist; do
   [ -f "$plist" ] || continue
   label="$(basename "$plist" .plist)"
-  if printf '%s' "$label" | grep -qE "$keep"; then
+  if [[ "$label" =~ $keep ]]; then
     continue
   fi
   if launchctl bootout "gui/$uid/$label" 2> /dev/null; then

--- a/hosts/common/scripts/night-quiesce.sh
+++ b/hosts/common/scripts/night-quiesce.sh
@@ -1,0 +1,53 @@
+# Night-quiesce (worker Mac) — free memory/GPU for the night rank.
+#
+# Explicit KEEP allowlist: every user LaunchAgent whose label does not match
+# the reviewed patterns below is booted out, and every visible GUI app is
+# quit. What was booted out is recorded to a state file so night-restore.sh
+# brings back exactly that set. The allowlist (not a kill list) keeps
+# machine-specific agent names out of this public file and means a newly
+# installed memory hog is quiesced by default instead of silently surviving.
+#
+# KEEP: nix-managed plumbing (com.nix-darwin.* — includes the log shippers),
+# home-manager agents (org.nix-community.*), the night cluster itself
+# (dev.mlx-night.*), day-log rotation (harmless, avoids a restore step),
+# ssh/gpg agents, and git background maintenance.
+
+uid="$(id -u)"
+state_file="$HOME/Library/Application Support/mlx-night/quiesced-agents"
+mkdir -p "$(dirname "$state_file")"
+: > "$state_file"
+
+# 1. Quit every visible GUI app, honoring save prompts. Terminals are
+#    excluded so a plug-night test session cannot saw off its own branch.
+/usr/bin/osascript <<'EOF' || true
+tell application "System Events"
+    set appNames to name of every application process whose background only is false
+end tell
+repeat with appName in appNames
+    set appText to appName as text
+    if appText is not in {"Finder", "Ghostty", "Terminal", "iTerm2"} then
+        try
+            with timeout of 15 seconds
+                tell application appText to quit
+            end timeout
+        end try
+    end if
+end repeat
+EOF
+
+# 2. Boot out every user agent not on the KEEP allowlist, recording each
+#    label for restore. Only agents with a plist under ~/Library/LaunchAgents
+#    are swept — those are the ones night-restore.sh can bootstrap back.
+keep='^(com\.apple\.|org\.nix-community\.|com\.nix-darwin\.|dev\.mlx-night\.|org\.git-scm\.|com\.openssh\.)|^dev\.vllm-mlx\.logrotate$'
+for plist in "$HOME/Library/LaunchAgents/"*.plist; do
+  [ -f "$plist" ] || continue
+  label="$(basename "$plist" .plist)"
+  if printf '%s' "$label" | grep -qE "$keep"; then
+    continue
+  fi
+  if launchctl bootout "gui/$uid/$label" 2> /dev/null; then
+    printf '%s\n' "$label" >> "$state_file"
+  fi
+done
+
+echo "night-quiesce: GUI apps quit; booted out $(wc -l < "$state_file" | tr -d ' ') agents"

--- a/hosts/common/scripts/night-restore.sh
+++ b/hosts/common/scripts/night-restore.sh
@@ -1,0 +1,25 @@
+# Night-restore (worker Mac) — undo night-quiesce.sh after the cable is out.
+#
+# Bootstraps back exactly the agents the quiesce recorded (labels whose
+# plists have since disappeared are skipped silently). GUI apps deliberately
+# stay closed — it is morning, the user reopens what they want.
+
+uid="$(id -u)"
+state_file="$HOME/Library/Application Support/mlx-night/quiesced-agents"
+
+[ -f "$state_file" ] || {
+  echo "night-restore: nothing recorded, nothing to do"
+  exit 0
+}
+
+restored=0
+while IFS= read -r label; do
+  [ -n "$label" ] || continue
+  plist="$HOME/Library/LaunchAgents/$label.plist"
+  if [ -f "$plist" ] && launchctl bootstrap "gui/$uid" "$plist" 2> /dev/null; then
+    restored=$((restored + 1))
+  fi
+done < "$state_file"
+
+rm -f "$state_file"
+echo "night-restore: bootstrapped $restored agents back"

--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -80,6 +80,10 @@ in
       # the public zone issues cleanly, same as the host FQDN. (A future
       # public-facing capability name is tracked separately.)
       extraHostnames = [ "llm-large.${userConfig.baseDomain}" ];
+      # Night-cluster endpoint (mlx-lm rank 0 on loopback :11440, see
+      # lib/hosts/mac-studio.nix nightCluster): second gated site, same
+      # bearer token and cert, mirrored external:loopback port convention.
+      nightUpstreamPort = 11440;
     };
 
     # ========================================================================

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -62,6 +62,16 @@
     ];
     # Global parser off; every backend's parser comes from its catalog entry.
     toolCallParser = null;
+
+    # Night cluster: this Mac is rank 0 (coordinator) of the two-Mac JACCL
+    # brain when the Thunderbolt cable is in — it binds the night endpoint on
+    # loopback :11440, gated by llm-gate (hosts/mac-studio/default.nix). The
+    # link watcher quiesces day serving at link-up and re-warms the preload
+    # list on unplug.
+    nightCluster = {
+      enable = true;
+      role = "coordinator";
+    };
   };
 
   # OrbStack stays OFF — this host uses the Apple `container` runtime, not

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -30,6 +30,15 @@
   mlx = {
     cacheMemoryMb = 16384;
     prefillBatchSize = 2048;
+
+    # Night cluster: this Mac is rank 1 (worker) of the two-Mac JACCL brain
+    # when the Thunderbolt cable is in. The worker-side quiesce/restore hooks
+    # (GUI quit + agent bootout allowlist sweep) are wired by
+    # hosts/common/night-quiesce.nix. Day config above is untouched.
+    nightCluster = {
+      enable = true;
+      role = "worker";
+    };
   };
 
   # OrbStack container runtime. The ContainerData volume is created by

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -81,6 +81,26 @@ let
     lib.unique ([ cfg.domain ] ++ cfg.extraHostnames)
   );
 
+  # Optional second gated site for the night-cluster endpoint (same bearer
+  # token, same cert, own port + access log). Rendered only when a night
+  # upstream is configured.
+  nightSite = lib.optionalString (cfg.nightUpstreamPort != null) ''
+    ${
+      lib.concatMapStringsSep " " (host: "https://${host}:${toString cfg.nightPort}") (
+        lib.unique ([ cfg.domain ] ++ cfg.extraHostnames)
+      )
+    } {
+      ${tlsDirective}
+      log {
+        output file ${cfg.logDir}/night-access.json
+        format json
+      }
+      @unauthorized not header Authorization "Bearer {env.LLM_LARGE_BEARER_TOKEN}"
+      respond @unauthorized 401
+      reverse_proxy 127.0.0.1:${toString cfg.nightUpstreamPort}
+    }
+  '';
+
   # The whole Caddyfile is a plain, secret-free nix store file: every sensitive
   # value is an {env.VAR} placeholder resolved by Caddy at parse time from the
   # Doppler-injected environment. Safe to be world-readable — it contains no
@@ -108,6 +128,8 @@ let
       respond @unauthorized 401
       reverse_proxy 127.0.0.1:${toString cfg.apiUpstreamPort}
     }
+
+    ${nightSite}
   '';
 in
 {
@@ -153,6 +175,18 @@ in
       type = lib.types.port;
       default = 11434;
       description = "Loopback llama-swap port the API site proxies to.";
+    };
+
+    nightPort = lib.mkOption {
+      type = lib.types.port;
+      default = 11440;
+      description = "Gated night-cluster API port on the LAN bind address (mirrors the loopback night port, same convention as apiPort).";
+    };
+
+    nightUpstreamPort = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
+      default = null;
+      description = "Loopback night-cluster (mlx-lm rank 0) port to gate; null renders no night site.";
     };
 
     user = lib.mkOption {


### PR DESCRIPTION
## Summary

nix-darwin half of the two-Mac Thunderbolt 5 cluster brain (module: dryvist/nix-ai#1173, bumped here; router: dryvist/ansible-proxmox-apps#838; searches: dryvist/ansible-splunk#329; port constant: dryvist/terraform-proxmox#622).

- **Host roles** (`lib/hosts`): mac-studio = coordinator (rank 0, binds the cluster endpoint on loopback), macbook-m4 = worker (rank 1). Day serving untouched on both.
- **Worker quiesce/restore** (the worker quiesce module under `hosts/common/` + scripts): link-up quits visible GUI apps (terminals excluded so a plugged-in session can't saw off its own branch) and boots out every user agent not on the reviewed **KEEP allowlist**, recording the set to a state file; link-down bootstraps exactly that set back. Allowlist semantics keep machine-specific agent names out of this public repo and quiesce newly-installed memory hogs by default. Both commands are on PATH for the pre-plug dry-run.
- **Gate** (`modules/darwin/llm-gate.nix`): optional second gated site — its own port/upstream-port options, same bearer token and certificate, own dedicated access log. mac-studio sets the cluster upstream port to 11440.
- **Log shipping** (`hosts/common/cribl.nix`): a dedicated Cribl input for the rank/watcher/prefetch logs on both Macs + the cluster access log on the existing gate input (`*/` lead per the #1623 lesson).
- **Runbook** (the cluster runbook under `docs/`): one-time prep — including the Recovery-mode `rdma_ctl enable` on BOTH Macs that cannot be automated — plug-in checklist, morning unplug, second-cable rail, observability map.

## Verification

Evaled from this branch:

- `jevans-ms` rank LaunchAgent: `MLX_RANK=0`, `MLX_JACCL_COORDINATOR=192.168.208.1:11441`, args = `uvx --from mlx-lm==0.31.3 --with transformers==5.12.1 mlx_lm.server --model mlx-community/GLM-4.7-4bit --pipeline --host 127.0.0.1 --port 11440`.
- `jevans-mbp`: `MLX_RANK=1`, watcher peer = coordinator link ip, quiesce/restore command envs wired to the nix-built scripts (writeShellApplication ⇒ shellcheck-clean).
- nixfmt/statix/deadnix clean; markdownlint 0 errors on the runbook.
- Post-merge: promote to main, rebuild both Macs — agents idle correctly with the link down (watcher no-ops), so deploying pre-cable is safe by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLeWAhEN9MsTchNU4n1nGY
