### PR TITLE
chore(deps): bump nix-ai for synthetic-marketplace directory source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783686749,
-        "narHash": "sha256-Rq6DCPHw5ZYpYVsZokOvOSsL7yoJwiF73UD64QbF2Oc=",
+        "lastModified": 1783696096,
+        "narHash": "sha256-YbMkduX2FBMcYCrO+3VqB4PQItS31BM0klKLnta6UuA=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "0f39059775a4a8b4978d664f4e48f838808a4358",
+        "rev": "ba4659fc1631378d4a5858d7dd8fddb1f7c13b74",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783622041,
-        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
+        "lastModified": 1783656288,
+        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
+        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bumps the `nix-ai` input to develop `ba4659f`, which carries its bumped `nix-claude-code` `1ab41d1`. Together these register the three synthetic marketplaces — `fabric-patterns`, `browser-use-skills`, `vct-cribl-pack-validator-skills` — as Claude `directory` sources instead of `github`.

## Why

Synthetic marketplaces have no upstream `.claude-plugin/marketplace.json` (Nix synthesizes it). A `github` source makes Claude 2.x clone raw upstream over the Nix content on every `darwin-rebuild switch`, wiping the synthesized `marketplace.json` and breaking plugin load. A `directory` source is read in place, so it survives switches and the sessionStart refresh hook.

Upstream chain: nix-claude-code [#95](https://github.com/dryvist/nix-claude-code/pull/95) → nix-ai [#1177](https://github.com/dryvist/nix-ai/pull/1177) → this bump.

## Verification

Applied live on jevans-mbp (`darwin-rebuild switch`, committed lock, no override-input):
- `/run/current-system` == the built `darwin-system` path.
- Deployed `known_marketplaces.json` shows all three as `{"source": "directory", "path": ...}`.
- Each target dir contains a valid synthesized `marketplace.json` (1 plugin each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)