### PR TITLE
chore(deps): bump nix-ai for marketplace-refresh retry fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783696096,
-        "narHash": "sha256-YbMkduX2FBMcYCrO+3VqB4PQItS31BM0klKLnta6UuA=",
+        "lastModified": 1783699993,
+        "narHash": "sha256-HQP06bGbwjVsu1P2kFn7heojxL3GcjbLC5uLhoMFtq8=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ba4659fc1631378d4a5858d7dd8fddb1f7c13b74",
+        "rev": "cd3486830803bca28ff0e7e05c16fe33baf0e3f6",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783656288,
-        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
+        "lastModified": 1783699561,
+        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
+        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `nix-ai` to develop `cd34868`, carrying `nix-claude-code cc52344` ([#99](https://github.com/dryvist/nix-claude-code/pull/99)).

## What / why

After a `darwin-rebuild switch` bumps nix-managed marketplace store paths, the SessionStart hook `marketplace-refresh.sh` re-clones marketplace indexes and reinstalls affected plugins. Previously it cleared its `.nix-refresh-needed` marker on `marketplace update` success **without** verifying the enabled plugins actually re-resolved — so a transient reinstall failure could strand an enabled plugin with no retry. The hook now re-queues the marker when any enabled plugin is left unresolved (or the re-scan itself errors), making post-switch plugin recovery self-correcting across sessions.

## Verification

Applied live on jevans-mbp (committed lock, no override-input):
- `/run/current-system` == the built `darwin-system` path.
- Deployed `~/.claude/hooks/session-start.sh` contains the retry logic (`if still_missing=…`, `Re-scan failed for …`).
- Post-switch: 0 enabled plugins with a missing installPath; 24/24 marketplaces valid; no stuck refresh marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)