### PR TITLE
chore(deps): bump nix-ai for mlx warmup-after-restart fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783696096,
-        "narHash": "sha256-YbMkduX2FBMcYCrO+3VqB4PQItS31BM0klKLnta6UuA=",
+        "lastModified": 1783700602,
+        "narHash": "sha256-+Jii/Ww7XDKh7lo90k/6ZRfSfjH7NnY8Jr/MwoaeWV8=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ba4659fc1631378d4a5858d7dd8fddb1f7c13b74",
+        "rev": "b40d6742e9e9ae664d41d42ef9431dea182f138a",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783656288,
-        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
+        "lastModified": 1783699561,
+        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
+        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls [dryvist/nix-ai#1180](https://github.com/dryvist/nix-ai/pull/1180): residents warm via the warmup agent after every proxy restart; llama-swap's broken `on_startup.preload` hook dropped (nix-ai#1175).

Lock pins nix-ai `b40d674` (the #1180 squash-merge) + its transitive nix-claude-code follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaGpLAzZMKYa6QE5PHSKCu