### PR TITLE
feat(cribl): ship mlx bench-events feed to Splunk (mlx:bench)

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -85,6 +85,22 @@ in
               connections:
                 - pipeline: llm_logs
                   output: cribl_stream
+            # Benchmark result events (mlx-benchmarks#119): mlx-bench-publish
+            # appends one flat JSON line per result row; derived state,
+            # replayable from the HF dataset via `mlx-bench-events replay`.
+            in_bench_events:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/.local/state/mlx-benchmarks/
+              filenames:
+                - "*/bench-events.jsonl"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - pipeline: bench_events
+                  output: cribl_stream
             in_system_metrics:
               type: system_metrics
               disabled: false
@@ -285,6 +301,18 @@ in
                     value: "'llm'"
                   - name: sourcetype
                     value: "_raw.match(/^(INFO|DEBUG|WARNING|ERROR|CRITICAL):/) ? 'vllm:mlx' : 'llamaswap'"
+        '';
+        "pipelines/bench_events/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "'mlx:bench'"
         '';
         "pipelines/llm_metrics/conf.yml" = ''
           output: default


### PR DESCRIPTION
New `in_bench_events` Edge file source tailing `~/.local/state/mlx-benchmarks/bench-events.jsonl` — the [dryvist/mlx-benchmarks#121](https://github.com/dryvist/mlx-benchmarks/pull/121) publisher feed (one flat JSON line per benchmark result row, issue mlx-benchmarks#119).

- Dedicated `bench_events` pipeline stamps `index=llm` + `sourcetype=mlx:bench`
- Ships via the proven `cribl_stream` (:10300) path like `in_llm_logs`
- Leading `*/` glob per the #1623 full-path-match lesson
- Derived state: the feed is replayable from the HF dataset (`mlx-bench-events replay`), so no PQ-loss anxiety

Verify after rebuild: `index=llm sourcetype=mlx:bench` shows events after the next `mlx-bench-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaGpLAzZMKYa6QE5PHSKCu