### PR TITLE
fix(hosts): codify application firewall on (Studio drift closes firewall.log gap)

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -36,6 +36,19 @@ in
   # SSH/Remote Login — macOS Remote Login via launchd (Settings > General > Sharing).
   services.openssh.enable = true;
 
+  # Application firewall on every host. The MBP had this enabled by hand; the
+  # Studio shipped disabled, which left the firewall-log-shipping feed with
+  # nothing to say (its `log stream` daemon was alive but the ALF subsystem
+  # was silent). allowSigned/allowSignedApp match the working MBP posture so
+  # LAN services (sshd, llama-swap via signed python) keep accepting inbound.
+  networking.applicationFirewall = {
+    enable = true;
+    allowSigned = true;
+    allowSignedApp = true;
+    blockAllIncoming = false;
+    enableStealthMode = false;
+  };
+
   programs = {
     # Custom file extensions recognized as tar.gz archives (Finder auto-extract
     # + shell autocomplete).


### PR DESCRIPTION
**Root cause of the stale Studio `firewall.log`** (quiet since Jul 8): the log-shipping daemon was alive and streaming, but the Studio's application firewall was **disabled**, so the ALF subsystem emitted nothing. The MBP's firewall was enabled by hand — unmanaged drift.

Fix: manage `networking.applicationFirewall` declaratively in `hosts/common` for every host. `allowSigned`/`allowSignedApp` mirror the working MBP posture so LAN inbound (sshd, router→llama-swap) keeps accepting connections.

**Post-rebuild verify (Studio):** `socketfilterfw --getglobalstate` → enabled; router → `:11434` still reachable; a firewall event eventually lands in `index=firewall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaGpLAzZMKYa6QE5PHSKCu