### PR TITLE
chore: promote develop to main

### DIFF
--- a/docs/TB5-RDMA-CLUSTER.md
+++ b/docs/TB5-RDMA-CLUSTER.md
@@ -1,0 +1,67 @@
+# Thunderbolt 5 RDMA two-Mac cluster runbook
+
+Pool the MacBook Pro + Mac Studio (M4 Max, 128GB each) over a direct
+Thunderbolt 5 cable into a 256GB MLX cluster using Apple's first-party RDMA
+over Thunderbolt (macOS 26.2+, Apple TN3205) and the JACCL collective
+library (TB5-only, max 4 nodes, fully-connected mesh; ~50-60 Gb/s,
+single-digit-µs latency).
+
+This file is the committed record of the physical/Recovery steps that code
+cannot apply. Everything software-side (bridge networking, SSH pairing,
+wired-memory limits, EXO/JACCL install) lives in nix-darwin/nix-ai modules,
+not here.
+
+## One-time RDMA enable (per Mac, physical)
+
+`rdma_ctl status` reports `disabled` on a fresh install. Enabling requires
+Recovery mode and a reboot — it cannot be scripted or remoted:
+
+1. Shut the Mac down fully.
+2. Hold the power button ~10 s until "Loading startup options", choose
+   **Options** → Recovery.
+3. If the enable command in step 4 is refused, first open **Utilities →
+   Startup Security Utility** and set **Reduced Security** (reported as
+   required by some TN3205 readings; if step 4 succeeds under Full
+   Security, record that here and skip this).
+4. **Utilities → Terminal**: `rdma_ctl enable`
+5. Restart normally.
+6. Verify from a shell: `rdma_ctl status` → `enabled`.
+
+Repeat on the second Mac. Record the actual observed sequence (with/without
+Reduced Security) in this file after the first run.
+
+## Physical topology
+
+- One TB5 cable, port-to-port, **no daisy-chain, no dock/hub** in the path.
+- Both machines must be TB5 (M4 Max ✓); JACCL does not support TB4.
+
+## Network substrate (two-track — do NOT bridge the RDMA path)
+
+The RDMA transport is point-to-point and is NOT IP-over-Thunderbolt-Bridge.
+EXO's own `set_rdma_network_config.sh` *disables* Thunderbolt Bridge and
+sets DHCP on the RDMA ports.
+
+- Keep an IP path (Thunderbolt Bridge or regular LAN) only for out-of-band
+  bootstrap/SSH between the nodes.
+- Never hardcode the `bridgeN` interface name — the index is dynamic per
+  plug order and VPN state. Resolve dynamically or use link-local
+  addressing.
+- Assert the RDMA transport is actually active before benchmarking:
+  `ibv_devices` lists the RDMA device, and EXO's startup log reports the
+  transport. A working `ping` between the nodes proves only the TCP
+  fallback.
+
+## Memory sizing (per node, not per model)
+
+`iogpu.wired_limit_mb` is sized for the node's **shard** (~66GB weights +
+KV headroom → ~80-90GB ceiling on a 128GB node), never the whole pooled
+model. A ~130GB wired limit on a 128GB node starves macOS and the RDMA
+stack itself.
+
+## Verification checklist
+
+- [ ] `rdma_ctl status` → `enabled` on both Macs
+- [ ] `ibv_devices` shows the TB RDMA device on both
+- [ ] JACCL smoke: `mlx.launch --backend jaccl` with a small model across
+      both nodes completes
+- [ ] Big-model target answers a chat completion end-to-end from the MBP

--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783696096,
-        "narHash": "sha256-YbMkduX2FBMcYCrO+3VqB4PQItS31BM0klKLnta6UuA=",
+        "lastModified": 1783700602,
+        "narHash": "sha256-+Jii/Ww7XDKh7lo90k/6ZRfSfjH7NnY8Jr/MwoaeWV8=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "ba4659fc1631378d4a5858d7dd8fddb1f7c13b74",
+        "rev": "b40d6742e9e9ae664d41d42ef9431dea182f138a",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783656288,
-        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
+        "lastModified": 1783699561,
+        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
+        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783686749,
-        "narHash": "sha256-Rq6DCPHw5ZYpYVsZokOvOSsL7yoJwiF73UD64QbF2Oc=",
+        "lastModified": 1783696096,
+        "narHash": "sha256-YbMkduX2FBMcYCrO+3VqB4PQItS31BM0klKLnta6UuA=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "0f39059775a4a8b4978d664f4e48f838808a4358",
+        "rev": "ba4659fc1631378d4a5858d7dd8fddb1f7c13b74",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783622041,
-        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
+        "lastModified": 1783656288,
+        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
+        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
         "type": "github"
       },
       "original": {

--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -85,6 +85,22 @@ in
               connections:
                 - pipeline: llm_logs
                   output: cribl_stream
+            # Benchmark result events (mlx-benchmarks#119): mlx-bench-publish
+            # appends one flat JSON line per result row; derived state,
+            # replayable from the HF dataset via `mlx-bench-events replay`.
+            in_bench_events:
+              type: file
+              disabled: false
+              mode: manual
+              interval: 10
+              path: ${userConfig.user.homeDir}/.local/state/mlx-benchmarks/
+              filenames:
+                - "*/bench-events.jsonl"
+              tailOnly: false
+              sendToRoutes: false
+              connections:
+                - pipeline: bench_events
+                  output: cribl_stream
             in_system_metrics:
               type: system_metrics
               disabled: false
@@ -285,6 +301,18 @@ in
                     value: "'llm'"
                   - name: sourcetype
                     value: "_raw.match(/^(INFO|DEBUG|WARNING|ERROR|CRITICAL):/) ? 'vllm:mlx' : 'llamaswap'"
+        '';
+        "pipelines/bench_events/conf.yml" = ''
+          output: default
+          functions:
+            - id: eval
+              filter: "true"
+              conf:
+                add:
+                  - name: index
+                    value: "'llm'"
+                  - name: sourcetype
+                    value: "'mlx:bench'"
         '';
         "pipelines/llm_metrics/conf.yml" = ''
           output: default

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -36,6 +36,19 @@ in
   # SSH/Remote Login — macOS Remote Login via launchd (Settings > General > Sharing).
   services.openssh.enable = true;
 
+  # Application firewall on every host. The MBP had this enabled by hand; the
+  # Studio shipped disabled, which left the firewall-log-shipping feed with
+  # nothing to say (its `log stream` daemon was alive but the ALF subsystem
+  # was silent). allowSigned/allowSignedApp match the working MBP posture so
+  # LAN services (sshd, llama-swap via signed python) keep accepting inbound.
+  networking.applicationFirewall = {
+    enable = true;
+    allowSigned = true;
+    allowSignedApp = true;
+    blockAllIncoming = false;
+    enableStealthMode = false;
+  };
+
   programs = {
     # Custom file extensions recognized as tar.gz archives (Finder auto-extract
     # + shell autocomplete).


### PR DESCRIPTION
Promotes this week's develop work to main per git-flow:

- mlx warmup-after-restart fix via the nix-ai bump (#1639) — deployed and verified on both hosts
- mlx bench-events Cribl feed to Splunk (#1640)
- application firewall codified on all hosts (#1643)
- TB5 RDMA two-Mac cluster runbook (#1642)
- nix-ai synthetic-marketplace directory bump (#1637)

Merge with a merge commit (no squash) per repo policy; release-please cuts the release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXJ9SYFfh1AWhjPztVqa1K