### PR TITLE
fix: server timezone GMT + pull marketplace settings-merge fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1783719204,
-        "narHash": "sha256-qvHMwcc+XhuJ1FZi7Bn2MrjQmQAqujzS/E11hOhr12k=",
+        "lastModified": 1783723550,
+        "narHash": "sha256-BJIzD5Lk8Qn6+nsXn0bsQIUtaSbh4igsIJ8RRxRZ1QQ=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "9cd0e3f6d478690cbade0a7bcf37cc7bc50ef150",
+        "rev": "4e6174ede09dc68188d7c1e72925d652a7ae1245",
         "type": "github"
       },
       "original": {
@@ -1025,11 +1025,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783699561,
-        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
+        "lastModified": 1783723192,
+        "narHash": "sha256-xclX8LzvWAmNWSFEisfaJWUg3f2emUJMUZ/zGlJQZMs=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
+        "rev": "d63a213af4f2c90ce3d576a2aab0c3a3ff2e4b12",
         "type": "github"
       },
       "original": {

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -29,9 +29,11 @@ in
   # Network hostname from the per-host registry.
   networking.hostName = hostConfig.hostName;
 
-  # Workstations keep macOS' automatic timezone behavior. Server hosts pin UTC
-  # so the Friday 00:00 launchd schedule lands at Friday 00:00 UTC there.
-  time.timeZone = if hostConfig.isServer then "UTC" else null;
+  # Workstations keep macOS' automatic timezone behavior. Server hosts pin GMT
+  # (UTC-equivalent, no DST) so the Friday 00:00 launchd schedule lands at 00:00
+  # there. macOS `systemsetup -settimezone` rejects bare "UTC" (not in its
+  # listtimezones); "GMT" is the accepted +00:00 value.
+  time.timeZone = if hostConfig.isServer then "GMT" else null;
 
   # SSH/Remote Login — macOS Remote Login via launchd (Settings > General > Sharing).
   services.openssh.enable = true;


### PR DESCRIPTION
Two fixes for a zero-warning `darwin-rebuild`, surfaced by a full clean rebuild of a server host:

**1. Server timezone (#1649).** `time.timeZone = "UTC"` for servers → macOS `systemsetup` rejects bare "UTC", so the timezone was silently never applied. Change to "GMT" (UTC-equivalent, the value macOS accepts).

**2. Marketplace settings-merge (#1186).** Bumps nix-ai → `4e6174e`, which pulls nix-claude-code → `d63a213` (dryvist/nix-claude-code#101). That makes the home-manager settings.json merge strip `extraKnownMarketplaces` before the deep merge, clearing the stale `directory`-source fossil that fails Claude Code settings schema validation every rebuild. This is the top of the nix-claude-code → nix-ai → nix-darwin chain.

After merge, a rebuild of both Macs should be free of `not a valid timezone` and `Schema validation errors`.

Closes #1649. Refs #1186.