### PR TITLE
refactor(mlx): pin one shared default local model, drop per-host defaults

### DIFF
--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -16,9 +16,9 @@
 
 {
   imports = [
-    # services.aiStack.defaultLocalModelId — supplied from the committed
-    # lib/hosts.nix (non-secret model id). Extracted to keep files under the
-    # per-file size cap.
+    # services.aiStack.defaultLocalModelId — supplied shared (non-secret model
+    # id) from services-ai-stack.nix, pinned once for every host. Extracted to
+    # keep files under the per-file size cap.
     ./services-ai-stack.nix
     # Disables nix-ai's auto-discovery of locally-cached HF models so the
     # registry stays at the single defaultLocalModelId entry.

--- a/hosts/common/services-ai-stack.nix
+++ b/hosts/common/services-ai-stack.nix
@@ -1,23 +1,26 @@
-# AI Stack — local model id supplier
+# AI Stack — shared local model id supplier
 #
 # Required option since dryvist/nix-ai#878 collapsed the role registry to one
 # configurable physical model id. nix-ai keeps the option generic ("never
-# hardcoded in this repo"); the consumer supplies the value.
+# hardcoded in this repo"); this consumer pins the value.
 #
-# The value is a non-secret public model name consumed at Nix EVAL time, so it
-# lives committed in lib/hosts.nix (per-host) alongside every other eval-time
-# identifier. Keeping it in-tree means evaluation stays pure — no `--impure`,
-# no keychain/env/file sourcing. Change the model via a reviewed commit.
+# The default local model is SHARED across every host and pinned here — not per
+# host. There is deliberately no per-host `defaultLocalModelId`: every host
+# resolves the `default` role to the one id below, so hosts cannot drift to
+# different defaults. It is a non-secret public model name consumed at Nix EVAL
+# time, so keeping it in-tree keeps evaluation pure (no `--impure`, no
+# keychain/env/file sourcing). Change the model via a reviewed commit.
 #
-# roleModelOverrides (optional per-host registry field) pins selected roles to
-# a different physical model — e.g. the Studio's `coding` role on a dedicated
-# coder model — while every other role keeps following defaultLocalModelId.
+# roleModelOverrides (optional per-host registry field) still pins selected
+# NON-default roles to a different physical model — e.g. the Studio's
+# tool-calling role on OptiQ — so other models stay available on demand. Only
+# the default role is locked to the shared id below.
 
 { hostConfig, ... }:
 
 {
   services.aiStack = {
-    inherit (hostConfig) defaultLocalModelId;
+    defaultLocalModelId = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
     roleOverrides = hostConfig.roleModelOverrides or { };
   };
 }

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -12,14 +12,17 @@
   # defaults (hosts/common/default.nix) and nix-home's server preset.
   class = "server";
 
-  # Roles (2026-07-08 agentic tool-calling bench; verdicts + capacity in
-  # HF JacobPEvans/mlx-benchmarks + apps docs/BRAIN_ROTATION.md):
+  # The default local model id is SHARED and pinned in
+  # hosts/common/services-ai-stack.nix (no per-host default). This host pins its
+  # two warm brains via roleModelOverrides (2026-07-08 agentic tool-calling
+  # bench; verdicts + capacity in HF JacobPEvans/mlx-benchmarks + apps
+  # docs/BRAIN_ROTATION.md):
   #   tool-calling — Qwen3.6-35B-A3B OptiQ-4bit: bench winner, the brain
   #     Hermes routes to by physical id.
   #   coding — Qwen3-Coder-30B-A3B 4-bit.
-  # gpt-oss-120b (63.3 GB, default/oss role) is swap-class: 0% on the agentic
-  # gate, so on-demand + idle-unload, never preloaded.
-  defaultLocalModelId = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+  # gpt-oss-120b (63.3 GB) stays in the catalog as swap-class (on-demand,
+  # idle-unload, never preloaded); reach it by physical id or add a role
+  # override if a role should target it.
   roleModelOverrides = {
     tool-calling = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
     coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -13,15 +13,10 @@
   # CI hmActivationPackage output. Exactly one host should set this.
   primary = true;
 
-  # Local MLX physical model id, consumed at Nix eval time by
-  # services.aiStack.defaultLocalModelId (hosts/*/services-ai-stack.nix, shared).
-  # Non-secret public Hugging Face name; committed so evaluation stays pure (no
-  # --impure, no keychain/env/file sourcing). Change via a reviewed commit.
-  # 2026-06-09: Qwen3-30B-A3B-Instruct-2507, a standard-attention MoE
-  # (qwen3_moe), ~85 tok/s at 4-way concurrency, hermes tool calling
-  # (dryvist/nix-ai#915). The retired "qwen3_5_moe batching crash" claim was
-  # disproven by the 2026-07-08 agentic bench (HF JacobPEvans/mlx-benchmarks).
-  defaultLocalModelId = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
+  # The default local model id is SHARED and pinned in
+  # hosts/common/services-ai-stack.nix — this host deliberately sets no
+  # per-host `defaultLocalModelId`. With no roleModelOverrides here, every role
+  # (incl. the preloaded default) resolves to that shared id.
 
   # Local MLX inference server sizing (programs.mlx). Multi-turn agent clients
   # re-prefill 5-40K-token contexts; the 8192 MB default left no paged-cache


### PR DESCRIPTION
## What

The default local model was set **per host** — `macbook-m4` → Qwen3-30B-2507, `mac-studio` → gpt-oss-120b — so the two Macs resolved the `default` role to different models. This collapses it to a **single shared, code-pinned default** in `hosts/common/services-ai-stack.nix` and removes both per-host `defaultLocalModelId` entries. Hosts can no longer drift to different defaults.

Shared default is now **`mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`** (coding-oriented; the local API's primary consumers are coding agents).

## Other models stay available

`roleModelOverrides` is retained — the Studio keeps `tool-calling` → OptiQ, so non-default models are still selectable per role. `gpt-oss-120b` stays in the Studio catalog as swap-class (reachable by physical id, or a future role override); it just no longer backs the default role.

## Verified (eval)

| Host | default | coding | tool-calling |
| --- | --- | --- | --- |
| jevans-mbp | Coder-30B | Coder-30B | Coder-30B |
| jevans-ms | Coder-30B | Coder-30B | OptiQ |

Warm residents on both Macs are unchanged (Studio still preloads coding=Coder + tool-calling=OptiQ).