### PR TITLE
feat(macbook-m4): enable tmux cc-session autostart

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1050,11 +1050,11 @@
         "orbstack-kubernetes": "orbstack-kubernetes"
       },
       "locked": {
-        "lastModified": 1783633305,
-        "narHash": "sha256-OBvT8GkdTXbJD8mJlI/nm30mMPb6CA7LGpjcS0MmT9Q=",
+        "lastModified": 1783734680,
+        "narHash": "sha256-mNdL9wmRaTw7WZ7UnybFfCp4rulTIIkq6zg5/M6tB3E=",
         "owner": "dryvist",
         "repo": "nix-home",
-        "rev": "71b52319bc88a7fa25eec0e329f6aa99c1e968d4",
+        "rev": "e90b0d9c3976669a087105e4e82bbf7af6dab3f3",
         "type": "github"
       },
       "original": {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -29,6 +29,12 @@
     # d-claude Doppler session (ai-ci-automation/prd); a bare `claude` lacks them
     # and the server logs a harmless startup error.
     aiMcp.servers.vikunja.disabled = lib.mkForce false;
+
+    # Recreates the tmux "cc" session at every login — a reboot always kills
+    # the tmux server, and Termius' "tmux attach -t cc" startup command needs
+    # the session to already exist. Workstation-only: this is the box reached
+    # over SSH from Termius, not the headless mac-studio.
+    tmux-session-autostart.enable = true;
   };
 
   # ==========================================================================


### PR DESCRIPTION
## What

Enables the LaunchAgent from [dryvist/nix-home#365](https://github.com/dryvist/nix-home/pull/365) (merged) on `macbook-m4`, so the tmux `cc` session used for Ghostty (desktop) + Termius (mobile) is always there after a reboot, instead of dying with the tmux server and needing to be recreated by hand.

- `nix flake update nix-home`: bumps the pin to pick up `modules/home-manager/darwin/tmux-session-autostart.nix`.
- `hosts/macbook-m4/home.nix`: `programs.tmux-session-autostart.enable = true;` — workstation-only (reached via SSH from Termius), not set on the headless `mac-studio`.

## Validation

- `nix fmt` clean, `nix flake check` green (`darwinConfigurations.jevans-mbp` evaluates).
- `sudo darwin-rebuild switch --flake .` applied cleanly on this machine.
- Confirmed live: `dev.local.tmux-cc-session` LaunchAgent loaded (`launchctl list` shows exit code 0), plist present at `~/Library/LaunchAgents/dev.local.tmux-cc-session.plist`.

## Not in scope

Not enabled on `mac-studio` (headless, not reached via Termius).