### PR TITLE
feat(cluster): pin static Thunderbolt RDMA link IPs at activation

### DIFF
--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -41,6 +41,16 @@ in
     # Raise kern.maxfiles* + launchctl maxfiles to 524288 for large mmap'd models.
     resourceLimits.enable = true;
 
+    # --- Thunderbolt RDMA link (night cluster) ---
+    # Coordinator (rank 0); its TB cable landed on en3 → rdma_en3 (en2/en4/en5
+    # idle). Pin this end so the watcher and JACCL rendezvous bind 192.168.208.1.
+    # See modules/darwin/night-link.nix.
+    rdmaLink = {
+      enable = true;
+      interface = "en3";
+      address = "192.168.208.1";
+    };
+
     # --- Energy & Sleep ---
     # Always-on: never idle-sleep on AC (module sleep.ac default = 0). Wake-on-LAN,
     # network tuning, and energyMode come from the server class in ../common.

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -105,6 +105,16 @@ in
     # measured bottleneck. Loopback inference does not need it.
     networkTuning.enable = false;
 
+    # --- Thunderbolt RDMA link (night cluster) ---
+    # Worker (rank 1); its TB cable is on en2 → rdma_en2. Pin this end of the
+    # point-to-point link so the night-cluster watcher can reach the coordinator
+    # at 192.168.208.1. See modules/darwin/night-link.nix.
+    rdmaLink = {
+      enable = true;
+      interface = "en2";
+      address = "192.168.208.2";
+    };
+
     # --- Energy & Sleep Configuration ---
     energy = {
       enable = true;

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -74,6 +74,9 @@
     nightCluster = {
       enable = true;
       role = "coordinator";
+      # Studio's TB cable landed on en3 (en2/en4/en5 idle) → its RDMA device is
+      # rdma_en3; the module default rdma_en2 is the MBP worker's port.
+      rdmaDevice = "rdma_en3";
     };
   };
 

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -39,6 +39,7 @@ in
     ./apple-silicon-tunables.nix
     ./system-limits.nix
     ./network-tuning.nix
+    ./night-link.nix # Static IP on the unbridged Thunderbolt RDMA link
   ];
 
   # --- Nixpkgs Configuration ---

--- a/modules/darwin/night-link.nix
+++ b/modules/darwin/night-link.nix
@@ -33,14 +33,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # Runs as root at activation. Detach the cabled port from the auto
-    # Thunderbolt bridge (Apple RDMA needs exclusive L2 on the link), then pin
-    # the static point-to-point address. Idempotent + non-fatal: no cable, or a
-    # port already detached, must never fail the rebuild.
-    system.activationScripts.rdmaLink.text = ''
+    # Runs as root at the end of system activation. `rdmaLink` is NOT a
+    # recognized activation-script phase — nix-darwin only emits the named
+    # phases (pre/extra/postActivation), so a custom key type-checks but its
+    # text is silently dropped. Hook postActivation instead. Detach the cabled
+    # port from the auto Thunderbolt bridge (Apple RDMA needs exclusive L2 on
+    # the link), then pin the static point-to-point address. Idempotent +
+    # non-fatal: no cable, or a port already detached, must never fail rebuild.
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "rdmaLink: pinning ${cfg.interface} -> ${cfg.address}/24 (detach from bridge0)"
       /sbin/ifconfig bridge0 deletem ${cfg.interface} 2>/dev/null || true
       /sbin/ifconfig ${cfg.interface} inet ${cfg.address} netmask 255.255.255.0 2>/dev/null || true
-      echo "rdmaLink: pinned ${cfg.interface} -> ${cfg.address}/24 (detached from bridge0)"
     '';
   };
 }

--- a/modules/darwin/night-link.nix
+++ b/modules/darwin/night-link.nix
@@ -1,0 +1,46 @@
+# Thunderbolt RDMA link — static point-to-point IP on the cabled port.
+#
+# The two-Mac night cluster (nix-ai `programs.mlx.nightCluster`) serves one
+# ~353B model split over a direct Thunderbolt cable with Apple RDMA. macOS
+# auto-enslaves every Thunderbolt port into the "Thunderbolt Bridge" (bridge0)
+# with a link-local address, but Apple RDMA needs the cabled port OUT of that
+# bridge, holding its own static IP on the synthetic /24 that matches
+# `programs.mlx.nightCluster.linkIps`. This assigns that at activation.
+#
+# `interface` and `address` are per-Mac physical facts (which Thunderbolt port
+# the cable is in, this Mac's end of the link) and are set per host in
+# hosts/<label>/default.nix. ponytail: restated here rather than derived across
+# the home-manager boundary; a morning refactor could read nightCluster directly.
+{ lib, config, ... }:
+let
+  cfg = config.system.rdmaLink;
+in
+{
+  options.system.rdmaLink = {
+    enable = lib.mkEnableOption "static IP on the unbridged Thunderbolt RDMA link";
+
+    interface = lib.mkOption {
+      type = lib.types.str;
+      example = "en2";
+      description = "Cabled Thunderbolt interface (the ibv device name minus its rdma_ prefix).";
+    };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      example = "192.168.208.2";
+      description = "This Mac's IPv4 on the link (its role's entry in nightCluster.linkIps).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Runs as root at activation. Detach the cabled port from the auto
+    # Thunderbolt bridge (Apple RDMA needs exclusive L2 on the link), then pin
+    # the static point-to-point address. Idempotent + non-fatal: no cable, or a
+    # port already detached, must never fail the rebuild.
+    system.activationScripts.rdmaLink.text = ''
+      /sbin/ifconfig bridge0 deletem ${cfg.interface} 2>/dev/null || true
+      /sbin/ifconfig ${cfg.interface} inet ${cfg.address} netmask 255.255.255.0 2>/dev/null || true
+      echo "rdmaLink: pinned ${cfg.interface} -> ${cfg.address}/24 (detached from bridge0)"
+    '';
+  };
+}


### PR DESCRIPTION
## What
Adds a `system.rdmaLink` darwin module that pins a static point-to-point IPv4 on the cabled Thunderbolt port at activation, and detaches that port from the auto Thunderbolt bridge so Apple RDMA holds exclusive L2 on the link. This lets the two-node MLX pipeline (the `programs.mlx` cluster module) rendezvous over RDMA instead of the bridged link-local fallback.

## Changes
- New link module under `modules/darwin/` (`system.rdmaLink.{enable,interface,address}`); idempotent, non-fatal activation script (no cable, or an already-detached port, must never fail a rebuild).
- `hosts/mac-studio/default.nix`, `hosts/macbook-m4/default.nix` — enable per host with the correct cabled interface and link address.
- `lib/hosts/mac-studio.nix` — set the cluster module's `rdmaDevice` to the coordinator port actually cabled.
- `modules/darwin/common.nix` — import the module.

## Testing
- `nix flake check` — pass; both host configs evaluate.
- `sudo darwin-rebuild switch --flake .` on jevans-mbp — pass; activation pinned the link and it persists (sub-ms point-to-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaCWk2Xzb6p19T6YXfE6V8
