### PR TITLE
feat(energy): AC-power display sleep via displaysleepAc

### DIFF
--- a/modules/darwin/energy.nix
+++ b/modules/darwin/energy.nix
@@ -30,7 +30,13 @@ in
     displaysleep = lib.mkOption {
       type = lib.types.int;
       default = 10;
-      description = "Display sleep timer in minutes (0 = never). Applies to all power sources.";
+      description = "Display sleep timer in minutes (0 = never). Base for all power sources; AC is overridden by displaysleepAc.";
+    };
+
+    displaysleepAc = lib.mkOption {
+      type = lib.types.int;
+      default = 60;
+      description = "Display sleep timer when on AC power (minutes, 0 = never). Overrides displaysleep while plugged in.";
     };
 
     sleep = {
@@ -82,10 +88,10 @@ in
         failures=$((failures + 1))
       fi
 
-      if sudo pmset -c sleep ${toString cfg.sleep.ac}; then
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] AC power settings applied (sleep: ${toString cfg.sleep.ac} min)"
+      if sudo pmset -c sleep ${toString cfg.sleep.ac} displaysleep ${toString cfg.displaysleepAc}; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] AC power settings applied (sleep: ${toString cfg.sleep.ac} min, display: ${toString cfg.displaysleepAc} min)"
       else
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to apply AC power settings (attempted: ${toString cfg.sleep.ac} min)" >&2
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to apply AC power settings (attempted: sleep ${toString cfg.sleep.ac} min, display ${toString cfg.displaysleepAc} min)" >&2
         failures=$((failures + 1))
       fi
 


### PR DESCRIPTION
## What

Adds `system.energy.displaysleepAc` (default `60`) to control the display-sleep
timer while on AC power, separate from the battery timer.

- `displaysleep` is now the base/battery value.
- `displaysleepAc` overrides it when plugged in, folded into the existing
  `pmset -c` activation line.

Result: a plugged-in machine sleeps its display after 1 hour of no activity;
on battery it keeps the shorter timeout.

## Why

The display previously used one timer for every power source. This splits AC
from battery so a plugged-in machine holds the display on longer (1 h) without
lengthening the battery timeout.

## Verification

- `nix flake check` — pass
- `darwin-rebuild switch` on the M4 Max laptop — pass
- Live `pmset -g custom` after activation:
  - AC: `displaysleep 60`, `sleep 0`
  - Battery: `displaysleep 30`, `sleep 60`

## Notes

- No per-host change needed — the default of `60` applies on every host that
  enables the module (the headless desktop also gets AC display-sleep 60).
- The headless desktop host needs its own `darwin-rebuild` to pick up the
  change; the laptop is already applied.
