### PR TITLE
feat(cluster-link): RDMA link prep — bridge detach, IPv6, role-IP converge daemon

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -112,6 +112,14 @@ in
     # value still wins. `mkIf isServer` gates each: a workstation needs nothing —
     # the module defaults already match the laptop.
     nixDarwinAutoUpgrade.enable = true; # Friday 00:00 local-time launchd target; server hosts are pinned to UTC above.
+    # Both hosts are night-cluster nodes: keep every RDMA-capable Thunderbolt
+    # port out of bridge0 and converge the role link address onto whichever
+    # port the cable is in. Role follows machine class: the headless desktop
+    # is the coordinator (rank 0), the laptop the worker.
+    nightLinkPrep = {
+      enable = true;
+      role = if hostConfig.isServer then "coordinator" else "worker";
+    };
     energy.wakeOnMagicPacket = lib.mkIf hostConfig.isServer (lib.mkDefault true); # Wake-on-LAN for a headless box
     networkTuning.enable = lib.mkIf hostConfig.isServer (lib.mkDefault true); # socket buffers for LAN serving
     appleSiliconTunables.energyMode = lib.mkIf hostConfig.isServer (lib.mkDefault "unmanaged"); # no High Power Mode on a desktop

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -20,6 +20,7 @@ in
   ++ [
     ./energy.nix
     ./file-extensions.nix
+    ./night-link-prep.nix
     ./finder.nix
     ./homebrew.nix
     ./nix-homebrew.nix

--- a/modules/darwin/night-link-prep.nix
+++ b/modules/darwin/night-link-prep.nix
@@ -1,0 +1,94 @@
+# Night-Link Prep — RDMA Thunderbolt link preparation + address convergence
+#
+# The two-Mac night cluster runs Apple RDMA over a direct Thunderbolt cable.
+# JACCL's rendezvous parser is IPv4-only (verified 2026-07-11: every IPv6
+# form, including [::1]:port, fails with "Can't parse address"), so the link
+# uses role-derived synthetic IPv4 addresses. They are module-defined
+# defaults on a deliberately-non-LAN /24 — not site topology; the canonical
+# copy lives in nix-ai `programs.mlx.nightCluster.linkIps` and these defaults
+# must match it.
+#
+# Two root-side pieces (user-space cannot do either):
+#   1. Activation sweep: every RDMA-capable port (ibv_devices: rdma_enX ->
+#      enX) leaves bridge0 (RDMA needs exclusive L2) and gets AUTOMATIC-V6.
+#   2. Converge daemon (30s tick): finds the ACTIVE RDMA-capable port and
+#      moves this host's link address onto it. Moving the cable to another
+#      port converges within one tick — no config change, ever.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.system.nightLinkPrep;
+  convergePkg = pkgs.writeShellApplication {
+    name = "night-link-converge";
+    runtimeInputs = [ pkgs.gawk ];
+    text = builtins.readFile ./scripts/night-link-converge.sh;
+  };
+in
+{
+  options.system.nightLinkPrep = {
+    enable = lib.mkEnableOption "RDMA Thunderbolt link preparation (bridge detach, IPv6, role address convergence)";
+
+    role = lib.mkOption {
+      type = lib.types.enum [
+        "coordinator"
+        "worker"
+      ];
+      description = "Cluster role; selects which link address this host converges onto the cabled port.";
+    };
+
+    linkIps = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = {
+        # Synthetic point-to-point net for the Thunderbolt cable itself —
+        # must match the nix-ai nightCluster.linkIps defaults (canonical).
+        coordinator = "192.168.208.1";
+        worker = "192.168.208.2";
+      };
+      description = "Link addresses of the two ends of the Thunderbolt cable.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.daemons.night-link-converge = {
+      serviceConfig = {
+        Label = "dev.night-link.converge";
+        ProgramArguments = [ (lib.getExe convergePkg) ];
+        RunAtLoad = true;
+        StartInterval = 30;
+        EnvironmentVariables.NIGHT_LINK_IP = cfg.linkIps.${cfg.role};
+        StandardOutPath = "/var/log/night-link-converge.log";
+        StandardErrorPath = "/var/log/night-link-converge.error.log";
+      };
+    };
+
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Preparing RDMA-capable Thunderbolt interfaces..."
+      if [ -x /usr/bin/ibv_devices ]; then
+        /usr/bin/ibv_devices 2>/dev/null | awk 'NR>2 {print $1}' | while read -r rdma_dev; do
+          iface="''${rdma_dev#rdma_}"
+          /sbin/ifconfig "$iface" > /dev/null 2>&1 || continue
+          if /sbin/ifconfig bridge0 2>/dev/null | grep -q "member: $iface "; then
+            if /sbin/ifconfig bridge0 deletem "$iface"; then
+              echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed $iface from bridge0"
+            else
+              echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to remove $iface from bridge0" >&2
+            fi
+          fi
+          if /usr/sbin/ipconfig set "$iface" AUTOMATIC-V6 2>/dev/null; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] IPv6 link-local enabled on $iface"
+          else
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to enable IPv6 on $iface" >&2
+          fi
+        done
+      else
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] ibv_devices not present; skipping RDMA link prep"
+      fi
+    '';
+  };
+}

--- a/modules/darwin/scripts/night-link-converge.sh
+++ b/modules/darwin/scripts/night-link-converge.sh
@@ -8,6 +8,11 @@
 # Consumed environment (set declaratively by the LaunchDaemon):
 #   NIGHT_LINK_IP   this host's link address (role-derived synthetic)
 
+# Guard rails: RDMA tooling may be absent (non-RDMA host) and the link IP
+# comes from the plist — bail cleanly rather than erroring every 30s tick.
+[ -x /usr/bin/ibv_devices ] || exit 0
+: "${NIGHT_LINK_IP:?NIGHT_LINK_IP must be set}"
+
 iface=""
 for dev in $(/usr/bin/ibv_devices 2>/dev/null | awk 'NR>2 {print $1}'); do
   cand="${dev#rdma_}"
@@ -27,7 +32,7 @@ if /sbin/ifconfig bridge0 2>/dev/null | grep -q "member: $iface "; then
   /sbin/ifconfig bridge0 deletem "$iface" && echo "night-link: removed $iface from bridge0"
 fi
 
-if ! /sbin/ifconfig "$iface" | grep -q "inet $NIGHT_LINK_IP "; then
+if ! /sbin/ifconfig "$iface" 2>/dev/null | grep -q "inet $NIGHT_LINK_IP "; then
   # The cable moved (or first assignment): clear the address from any other
   # interface, then alias it onto the live port.
   for other in $(/sbin/ifconfig -l); do

--- a/modules/darwin/scripts/night-link-converge.sh
+++ b/modules/darwin/scripts/night-link-converge.sh
@@ -1,0 +1,42 @@
+# Night-link converge — one tick per launchd interval (root).
+#
+# Finds the active RDMA-capable Thunderbolt interface (the cabled port),
+# keeps it out of bridge0, and converges this host's role-derived link
+# address onto it. Moving the cable to another port converges within one
+# tick — no config change.
+#
+# Consumed environment (set declaratively by the LaunchDaemon):
+#   NIGHT_LINK_IP   this host's link address (role-derived synthetic)
+
+iface=""
+for dev in $(/usr/bin/ibv_devices 2>/dev/null | awk 'NR>2 {print $1}'); do
+  cand="${dev#rdma_}"
+  if /sbin/ifconfig "$cand" 2>/dev/null | grep -q "status: active"; then
+    # ponytail: first active RDMA-capable port wins; disambiguation only
+    # matters if an RDMA-capable TB device besides the peer Mac is attached.
+    iface="$cand"
+    break
+  fi
+done
+
+if [ -z "$iface" ]; then
+  exit 0 # no cable; nothing to converge
+fi
+
+if /sbin/ifconfig bridge0 2>/dev/null | grep -q "member: $iface "; then
+  /sbin/ifconfig bridge0 deletem "$iface" && echo "night-link: removed $iface from bridge0"
+fi
+
+if ! /sbin/ifconfig "$iface" | grep -q "inet $NIGHT_LINK_IP "; then
+  # The cable moved (or first assignment): clear the address from any other
+  # interface, then alias it onto the live port.
+  for other in $(/sbin/ifconfig -l); do
+    [ "$other" = "$iface" ] && continue
+    if /sbin/ifconfig "$other" 2>/dev/null | grep -q "inet $NIGHT_LINK_IP "; then
+      /sbin/ifconfig "$other" inet "$NIGHT_LINK_IP" -alias
+      echo "night-link: cleared $NIGHT_LINK_IP from $other"
+    fi
+  done
+  /sbin/ifconfig "$iface" inet "$NIGHT_LINK_IP/24" alias
+  echo "night-link: assigned $NIGHT_LINK_IP to $iface"
+fi


### PR DESCRIPTION
## What

Root-side preparation for the two-Mac RDMA cluster link, replacing the manual `networksetup` runbook step and the closed static-pinning approach (#1654):

- **Activation sweep:** every RDMA-capable Thunderbolt port (from `ibv_devices`) leaves bridge0 and gets `AUTOMATIC-V6`.
- **Converge daemon** (root, 30 s tick): finds the *active* RDMA-capable port and moves this host's role-derived link address onto it — clearing it from any other port first. Moving the cable converges within one tick, no config change.
- Role follows machine class (server = coordinator). Link addresses are module-defined synthetics on a non-LAN /24, matching the canonical nix-ai cluster module link-IP defaults.

Pairs with dryvist/nix-ai#1191 (rank-side runtime RDMA device detection).

## Why

JACCL rendezvous is IPv4-only (verified live: every IPv6 form including `[::1]:port` fails to parse), ruling out the link-local no-address design. This keeps the synthetic IPv4 approach but removes every hardcoded port/interface reference.

## Verification

- `nix flake check` pass; `darwin-rebuild switch` applied on BOTH hosts from this branch.
- Live: daemon converged both role addresses onto the cabled ports (which moved today!) with zero manual steps; bidirectional ping ~0.5 ms across the Thunderbolt link.

## Note

Both hosts are already running this branch's generation (applied pre-merge to unblock the supervised cluster session). Merging makes develop match deployed reality.
