### PR TITLE
feat(openbao-keychain): AWS credential_process wrapper for tf-proxmox

### DIFF
--- a/modules/darwin/apps/openbao-keychain.nix
+++ b/modules/darwin/apps/openbao-keychain.nix
@@ -17,6 +17,13 @@
 # one-time operator step performed once the live OpenBao cluster's RBAC
 # actually mints those AppRoles.
 #
+# Two different consumption patterns read this same keychain: the resolver
+# LaunchAgent above publishes each domain's role_id/secret_id ambiently via
+# `launchctl setenv` (for domains in its DOMAINS list); `openbao-aws-creds`
+# below reads `openbao/terraform-apply` directly, on demand, as an AWS
+# `credential_process` provider — it needs no ambient env var and is not one
+# of the resolver's published domains.
+#
 # Neither of the two existing keychains is Nix-managed today (both were
 # created by hand, passwords never stored anywhere) — this is the first
 # Nix-managed keychain in this repo. Its own unlock password IS sops-managed
@@ -59,6 +66,21 @@ let
     runtimeInputs = [ ];
     text = builtins.readFile ./../scripts/openbao-keychain-resolver.sh;
   };
+
+  # AWS `credential_process` provider (see modules/darwin/scripts/openbao-aws-creds.sh)
+  # — exposed system-wide via environment.systemPackages below so `aws` (invoked
+  # from any shell, any PATH) can find it by name in ~/.aws/config's
+  # `credential_process = openbao-aws-creds <role>` line. Needs jq + curl on
+  # PATH; `security`/`date` inside the script are hardcoded to their macOS
+  # system paths since neither is a nixpkgs package.
+  awsCredsScript = pkgs.writeShellApplication {
+    name = "openbao-aws-creds";
+    runtimeInputs = [
+      pkgs.jq
+      pkgs.curl
+    ];
+    text = builtins.readFile ./../scripts/openbao-aws-creds.sh;
+  };
 in
 {
   options.programs.openbao-keychain = {
@@ -76,6 +98,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ awsCredsScript ];
+
     # Create the log dir with user ownership up front (matches
     # claude-scheduled-jobs.nix's rationale: install -d would otherwise leave
     # missing parents root-owned, blocking the user agents' log writes). This

--- a/modules/darwin/scripts/openbao-aws-creds.sh
+++ b/modules/darwin/scripts/openbao-aws-creds.sh
@@ -60,6 +60,12 @@ if cache_is_fresh; then
   exit 0
 fi
 
+# The lock dir lives INSIDE the cache dir, so the cache dir must exist before
+# the first lock attempt (mkdir without -p fails on a missing parent, which
+# would spin the acquisition loop forever on a cold start).
+/bin/mkdir -p "${CACHE_DIR}"
+/bin/chmod 0700 "${CACHE_DIR}"
+
 # Cache miss/stale: acquire a short-lived atomic lock so concurrent
 # invocations (terraform issues many AWS calls in parallel) don't each
 # independently log in and mint a fresh STS lease. mkdir is atomic on a local
@@ -114,7 +120,6 @@ fi
 
 expiration="$(/bin/date -u -v+"${lease_seconds}"S +'%Y-%m-%dT%H:%M:%SZ')"
 
-/bin/mkdir -p "${CACHE_DIR}"
 umask 077
 jq -n \
   --arg akid "${access_key}" \

--- a/modules/darwin/scripts/openbao-aws-creds.sh
+++ b/modules/darwin/scripts/openbao-aws-creds.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# AWS `credential_process` provider — replaces a static aws-vault base key
+# with short-lived STS creds minted on demand by OpenBao's AWS secrets engine
+# (assumed_role). Reads the terraform-apply AppRole's role_id/secret_id from
+# the openbao.keychain-db keychain (same read pattern as
+# openbao-keychain-resolver.sh — keychain LOCK STATE is the access boundary).
+#
+# Usage (as an ~/.aws/config credential_process line):
+#   credential_process = openbao-aws-creds tf-proxmox
+#
+# Caches the emitted STS creds at 0600 under ~/.cache/openbao-aws/, keyed by
+# role name, and only re-authenticates + re-mints when the cached lease is
+# within SAFETY_MARGIN_SECONDS of expiry. `aws`/terraform invoke
+# credential_process on every API call, so without this cache a single
+# terraform run would hammer OpenBao with AppRole logins + fresh STS leases.
+# An mkdir-based atomic lock (no `flock` — not shipped on macOS) collapses
+# concurrent invocations racing on a cold/expired cache into one fetch.
+#
+# `pkgs.writeShellApplication` (used to build this script) wraps it in
+# `set -euo pipefail` and runs shellcheck regardless of this file's own
+# content (see openbao-keychain-resolver.sh for the same note).
+#
+# macOS-only: `/bin/date -v` below is BSD date syntax, not GNU.
+
+readonly KEYCHAIN="${HOME}/Library/Keychains/openbao.keychain-db"
+readonly CACHE_DIR="${HOME}/.cache/openbao-aws"
+readonly ROLE="${1:?usage: openbao-aws-creds <aws-role-name>}"
+readonly CACHE_FILE="${CACHE_DIR}/${ROLE}.json"
+readonly LOCK_DIR="${CACHE_FILE}.lock"
+# Refresh this far before actual STS expiry so a long-running command never
+# gets handed creds that expire mid-request.
+readonly SAFETY_MARGIN_SECONDS=600
+
+prefix="[openbao-aws-creds]"
+warn() { echo "$prefix WARN $*" >&2; }
+die() { echo "$prefix ERROR $*" >&2; exit 1; }
+
+read_item() {
+  local service="$1" account="$2"
+  # A missing keychain item (locked keychain, not-yet-seeded role) is an
+  # EXPECTED outcome here, not a script failure — see the resolver script's
+  # note on why `|| true` is required under set -e.
+  /usr/bin/security find-generic-password -s "${service}" -a "${account}" -w "${KEYCHAIN}" 2>/dev/null || true
+}
+
+# Fast path: a cached lease that's still comfortably valid — no network call.
+cache_is_fresh() {
+  [ -f "${CACHE_FILE}" ] || return 1
+  local expiration exp_epoch now_epoch
+  expiration="$(jq -r '.Expiration // empty' "${CACHE_FILE}" 2>/dev/null)" || return 1
+  [ -n "${expiration}" ] || return 1
+  exp_epoch="$(/bin/date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "${expiration}" +%s 2>/dev/null)" || return 1
+  now_epoch="$(/bin/date -u +%s)"
+  [ "$((exp_epoch - now_epoch))" -gt "${SAFETY_MARGIN_SECONDS}" ]
+}
+
+if cache_is_fresh; then
+  cat "${CACHE_FILE}"
+  exit 0
+fi
+
+# Cache miss/stale: acquire a short-lived atomic lock so concurrent
+# invocations (terraform issues many AWS calls in parallel) don't each
+# independently log in and mint a fresh STS lease. mkdir is atomic on a local
+# filesystem; whichever process wins does the fetch, the rest wait for it.
+attempt=0
+until /bin/mkdir "${LOCK_DIR}" 2>/dev/null; do
+  attempt=$((attempt + 1))
+  if [ "${attempt}" -ge 100 ]; then
+    warn "lock ${LOCK_DIR} held past ~10s, reclaiming (assuming a prior holder crashed)"
+    /bin/rm -rf "${LOCK_DIR}"
+    continue
+  fi
+  sleep 0.1
+  # Someone else may have refreshed the cache while we were waiting on it.
+  if cache_is_fresh; then
+    cat "${CACHE_FILE}"
+    exit 0
+  fi
+done
+trap '/bin/rm -rf "${LOCK_DIR}"' EXIT
+
+# Re-check after acquiring the lock — another process may have just won it
+# and refreshed the cache before we got here.
+if cache_is_fresh; then
+  cat "${CACHE_FILE}"
+  exit 0
+fi
+
+bao_addr="$(read_item "openbao" "bao_addr")"
+role_id="$(read_item "openbao/terraform-apply" "role_id")"
+secret_id="$(read_item "openbao/terraform-apply" "secret_id")"
+if [ -z "${bao_addr}" ] || [ -z "${role_id}" ] || [ -z "${secret_id}" ]; then
+  die "openbao/bao_addr or openbao/terraform-apply role_id/secret_id not found in ${KEYCHAIN} — keychain locked or not yet seeded"
+fi
+
+login_resp="$(curl -sf --max-time 10 -X POST \
+  -d "{\"role_id\":\"${role_id}\",\"secret_id\":\"${secret_id}\"}" \
+  "${bao_addr}/v1/auth/approle/login")" || die "AppRole login to ${bao_addr} failed"
+token="$(jq -r '.auth.client_token // empty' <<<"${login_resp}")"
+[ -n "${token}" ] || die "AppRole login returned no client_token"
+
+sts_resp="$(curl -sf --max-time 10 -H "X-Vault-Token: ${token}" \
+  "${bao_addr}/v1/aws/sts/${ROLE}")" || die "reading aws/sts/${ROLE} failed"
+
+access_key="$(jq -r '.data.access_key // empty' <<<"${sts_resp}")"
+secret_key="$(jq -r '.data.secret_key // empty' <<<"${sts_resp}")"
+session_token="$(jq -r '.data.security_token // empty' <<<"${sts_resp}")"
+lease_seconds="$(jq -r '.lease_duration // empty' <<<"${sts_resp}")"
+if [ -z "${access_key}" ] || [ -z "${secret_key}" ] || [ -z "${session_token}" ] || [ -z "${lease_seconds}" ]; then
+  die "aws/sts/${ROLE} response missing access_key/secret_key/security_token/lease_duration"
+fi
+
+expiration="$(/bin/date -u -v+"${lease_seconds}"S +'%Y-%m-%dT%H:%M:%SZ')"
+
+/bin/mkdir -p "${CACHE_DIR}"
+umask 077
+jq -n \
+  --arg akid "${access_key}" \
+  --arg sak "${secret_key}" \
+  --arg tok "${session_token}" \
+  --arg exp "${expiration}" \
+  '{Version: 1, AccessKeyId: $akid, SecretAccessKey: $sak, SessionToken: $tok, Expiration: $exp}' \
+  >"${CACHE_FILE}"
+/bin/chmod 0600 "${CACHE_FILE}"
+cat "${CACHE_FILE}"


### PR DESCRIPTION
## What

Add the workstation consumer for OpenBao-served AWS credentials: an
`openbao-aws-creds` wrapper that AWS's `credential_process` invokes to get
short-lived STS creds for the `tf-proxmox` profile. Replaces the static
aws-vault base key on this machine.

## Changes

- **`modules/darwin/scripts/openbao-aws-creds.sh`** (new) — reads the
  `terraform-apply` AppRole (`role_id`/`secret_id`) and `bao_addr` from
  `openbao.keychain-db`, logs in, fetches `aws/sts/<role>`, and emits the
  `credential_process` JSON contract (`Version:1`, keys, RFC3339 `Expiration`).
  Caches the result at `~/.cache/openbao-aws/<role>.json` (0600) behind an
  mkdir lock and refreshes ~10 min before expiry, so Terraform's repeated
  invocations don't flood AppRole/STS. Keychain lock state is the access
  boundary; a locked or unseeded keychain fails with a clear message.
- **`modules/darwin/apps/openbao-keychain.nix`** — package the wrapper via
  `writeShellApplication` (jq + curl) and add it to `environment.systemPackages`.

## Notes

- The `~/.aws/config` profile switch (`credential_process = openbao-aws-creds
  tf-proxmox`) is in the nix-home PR.
- Server-side engine + RBAC are in the ansible-proxmox-apps PR.
- Keychain seeding (bao_addr + AppRole role_id/secret_id) is a one-time operator
  step; the design lives on the docs site.

## Test

Cache logic exercised locally against cold-start, fresh, stale, and near-expiry
states plus lock cleanup. BSD `date` round-trip verified on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb6NwqwMGy3kW3Bf9kR13R
