### PR TITLE
feat(continuity): login-time auto-resume of an armed Claude mission

### DIFF
--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -155,6 +155,14 @@ in
     # this always-on host is a first-class autonomous OpenBao consumer too.
     # See modules/darwin/apps/openbao-keychain.nix.
     openbao-keychain.enable = true;
+
+    # --- Reboot-continuity auto-resume ---
+    # Same login-time armed-mission resume as the laptop; no-op unless armed
+    # at runtime. See modules/darwin/apps/claude-continuity.nix.
+    claude-continuity = {
+      enable = true;
+      user = userConfig.user.name;
+    };
   };
 
   # nix-prebuild: warm the darwin closure nightly so the morning

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -22,57 +22,59 @@ in
   imports = [ ../common/default.nix ];
 
   # --- Streamline Login Items ---
-  # Persistently disable unwanted updaters and remove junk plists.
-  # Edit these lists to add/remove services — enforced on every rebuild.
-  programs.streamline-login = {
-    enable = true;
+  programs = {
+    # Persistently disable unwanted updaters and remove junk plists.
+    # Edit these lists to add/remove services — enforced on every rebuild.
+    streamline-login = {
+      enable = true;
 
-    # Junk/dead plists to delete from ~/Library/LaunchAgents/
-    removePlists = [
-      "com.google.keystone.agent.plist" # Legacy Google Keystone (empty, replaced by GoogleUpdater)
-      "com.google.keystone.xpcservice.plist" # Legacy Google Keystone (empty)
-    ];
+      # Junk/dead plists to delete from ~/Library/LaunchAgents/
+      removePlists = [
+        "com.google.keystone.agent.plist" # Legacy Google Keystone (empty, replaced by GoogleUpdater)
+        "com.google.keystone.xpcservice.plist" # Legacy Google Keystone (empty)
+      ];
 
-    # User-domain services to disable (updaters, redundant apps, broken daemons)
-    disableUserServices = [
-      "com.google.GoogleUpdater.wake" # Google hourly updater
-      "us.zoom.updater" # Zoom hourly updater
-      "us.zoom.updater.login.check" # Zoom login check at login
-      # Boot-time race condition daemons — crash-loop before dependencies ready,
-      # corrupt WindowServer client dispatch table, cause sustained UI lag/freezes
-      "com.apple.universalaccessd" # No accessibility features enabled
-      "com.apple.macos.studentd" # Classroom daemon, no MDM enrollment
-      "com.apple.passd" # Apple Wallet not used
-    ];
+      # User-domain services to disable (updaters, redundant apps, broken daemons)
+      disableUserServices = [
+        "com.google.GoogleUpdater.wake" # Google hourly updater
+        "us.zoom.updater" # Zoom hourly updater
+        "us.zoom.updater.login.check" # Zoom login check at login
+        # Boot-time race condition daemons — crash-loop before dependencies ready,
+        # corrupt WindowServer client dispatch table, cause sustained UI lag/freezes
+        "com.apple.universalaccessd" # No accessibility features enabled
+        "com.apple.macos.studentd" # Classroom daemon, no MDM enrollment
+        "com.apple.passd" # Apple Wallet not used
+      ];
 
-    # System-domain services to disable
-    disableSystemServices = [
-      "com.google.GoogleUpdater.wake.system" # Google system updater (hourly)
-      "com.duosecurity.duoappupdater" # Duo updater (every 10 minutes)
-      "us.zoom.ZoomDaemon" # Zoom privileged helper daemon
-    ];
+      # System-domain services to disable
+      disableSystemServices = [
+        "com.google.GoogleUpdater.wake.system" # Google system updater (hourly)
+        "com.duosecurity.duoappupdater" # Duo updater (every 10 minutes)
+        "us.zoom.ZoomDaemon" # Zoom privileged helper daemon
+      ];
 
-    # Dangling zsh completion symlinks to prune on every rebuild. nix-homebrew
-    # leaves a dead `_brew` here (its /opt/homebrew/completions target is never
-    # materialized), which makes compinit warn on every new login shell.
-    pruneCompletionDirs = [
-      "/opt/homebrew/share/zsh/site-functions"
-    ];
-  };
+      # Dangling zsh completion symlinks to prune on every rebuild. nix-homebrew
+      # leaves a dead `_brew` here (its /opt/homebrew/completions target is never
+      # materialized), which makes compinit warn on every new login shell.
+      pruneCompletionDirs = [
+        "/opt/homebrew/share/zsh/site-functions"
+      ];
+    };
 
-  # --- OpenBao keychain-backed secret-zero ---
-  # Dedicated 72h-auto-lock keychain + resolver agent for OpenBao AppRole
-  # credentials. See modules/darwin/apps/openbao-keychain.nix.
-  programs.openbao-keychain.enable = true;
+    # --- OpenBao keychain-backed secret-zero ---
+    # Dedicated 72h-auto-lock keychain + resolver agent for OpenBao AppRole
+    # credentials. See modules/darwin/apps/openbao-keychain.nix.
+    openbao-keychain.enable = true;
 
-  # --- Reboot-continuity auto-resume ---
-  # Login-time LaunchAgent that resumes an armed Claude Code mission in tmux,
-  # so a planned reboot (e.g. clearing leaked RDMA Protection Domains during
-  # cluster work) doesn't lose the in-flight session. No-op unless armed at
-  # runtime. See modules/darwin/apps/claude-continuity.nix.
-  programs.claude-continuity = {
-    enable = true;
-    user = userConfig.user.name;
+    # --- Reboot-continuity auto-resume ---
+    # Login-time LaunchAgent that resumes an armed Claude Code mission in tmux,
+    # so a planned reboot (e.g. clearing leaked RDMA Protection Domains during
+    # cluster work) doesn't lose the in-flight session. No-op unless armed at
+    # runtime. See modules/darwin/apps/claude-continuity.nix.
+    claude-continuity = {
+      enable = true;
+      user = userConfig.user.name;
+    };
   };
 
   # ==========================================================================

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -65,6 +65,16 @@ in
   # credentials. See modules/darwin/apps/openbao-keychain.nix.
   programs.openbao-keychain.enable = true;
 
+  # --- Reboot-continuity auto-resume ---
+  # Login-time LaunchAgent that resumes an armed Claude Code mission in tmux,
+  # so a planned reboot (e.g. clearing leaked RDMA Protection Domains during
+  # cluster work) doesn't lose the in-flight session. No-op unless armed at
+  # runtime. See modules/darwin/apps/claude-continuity.nix.
+  programs.claude-continuity = {
+    enable = true;
+    user = userConfig.user.name;
+  };
+
   # ==========================================================================
   # System-Level Tuning (inference performance, power, limits, network)
   # ==========================================================================

--- a/modules/darwin/apps/claude-continuity.nix
+++ b/modules/darwin/apps/claude-continuity.nix
@@ -1,0 +1,82 @@
+# Reboot-Continuity Auto-Resume for Claude Code
+#
+# A RunAtLoad launchd user agent that, on login, resumes an "armed" Claude
+# Code session inside a dedicated detached tmux session. Purpose: a planned
+# reboot (e.g. clearing leaked RDMA Protection Domains during cluster work)
+# must not lose an in-flight autonomous mission — the mission auto-continues
+# the moment the user logs back in.
+#
+# Human dependency: with FileVault on and auto-login off, NOTHING runs until
+# the user unlocks and logs in. This agent makes the continuation instant
+# after that unavoidable step; it cannot remove the step.
+#
+# Arming is runtime state, never nix (see the script header for the file
+# format under ~/.claude/run/continuity/). No armed file = permanent no-op.
+# The script consumes the armed file after one successful launch and only
+# fires when the machine has rebooted since arming, so darwin-rebuild's
+# apply-time RunAtLoad fire is safe while the original session still runs.
+#
+# Auth follows the claude-scheduled-jobs model: the claude CLI's own login
+# session (macOS Keychain), no token on disk. The login keychain is unlocked
+# by the login itself, so a RunAtLoad agent can authenticate.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude-continuity;
+  homeDir = "/Users/${cfg.user}";
+  logDir = "${homeDir}/Library/Logs/claude-continuity";
+
+  # Same resolution order as claude-scheduled-jobs: vendor claude install
+  # first, then the per-user nix profile (tmux), system profile, base system.
+  agentPath = lib.concatStringsSep ":" [
+    "${homeDir}/.local/bin"
+    "/etc/profiles/per-user/${cfg.user}/bin"
+    "/run/current-system/sw/bin"
+    "/usr/bin"
+    "/bin"
+  ];
+
+  # No runtimeInputs: tmux must come from the user's own profile via PATH so
+  # the client matches the version of any tmux server already running for
+  # this user (a nixpkgs-pinned client can refuse an older server).
+  resumeScript = pkgs.writeShellApplication {
+    name = "claude-continuity-resume";
+    text = builtins.readFile ./scripts/claude-continuity-resume.sh;
+  };
+in
+{
+  options.programs.claude-continuity = {
+    enable = lib.mkEnableOption "login-time auto-resume of an armed Claude Code mission (reboot continuity)";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      description = "macOS login user whose armed Claude session is resumed at login.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.user.agents.claude-continuity.serviceConfig = {
+      Label = "com.nix-darwin.claude-continuity";
+      ProgramArguments = [ "${resumeScript}/bin/claude-continuity-resume" ];
+      RunAtLoad = true;
+      ProcessType = "Background";
+      StandardOutPath = "${logDir}/resume.log";
+      StandardErrorPath = "${logDir}/resume.error.log";
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = agentPath;
+      };
+    };
+
+    # Log dir with user ownership so the user agent can write its logs.
+    system.activationScripts.postActivation.text = ''
+      /usr/bin/install -d -o ${cfg.user} -g staff "${logDir}"
+    '';
+  };
+}

--- a/modules/darwin/apps/claude-continuity.nix
+++ b/modules/darwin/apps/claude-continuity.nix
@@ -38,6 +38,7 @@ let
     "${homeDir}/.local/bin"
     "/etc/profiles/per-user/${cfg.user}/bin"
     "/run/current-system/sw/bin"
+    "/opt/homebrew/bin"
     "/usr/bin"
     "/bin"
   ];

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -13,6 +13,7 @@ _:
     ./apfs-volumes.nix
     ./apple-container-runtime.nix
     ./auto-update-prevention.nix
+    ./claude-continuity.nix
     ./claude-scheduled-jobs.nix
     ./cribl-edge.nix
     ./cribl-stream.nix

--- a/modules/darwin/apps/scripts/claude-continuity-resume.sh
+++ b/modules/darwin/apps/scripts/claude-continuity-resume.sh
@@ -11,7 +11,8 @@
 #   2. No reboot since arming (boottime)   -> no-op. Makes arming safe while
 #      the original session is still alive, including the RunAtLoad fire that
 #      darwin-rebuild triggers at apply time.
-#   3. Cadence gate (durable marker)       -> a storming launchd no-ops.
+#   3. Cadence gate (durable marker)       -> repeated launchd fires within
+#      the min interval do nothing.
 #   4. Dedicated tmux session exists       -> no-op (already resumed).
 #   5. Armed file is CONSUMED (renamed) only after a successful launch —
 #      one-shot per arming, marker written after the work (loop-cadence).
@@ -27,6 +28,13 @@ CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 
 # Fire only on the first login of a boot that happened AFTER arming.
 boot_sec=$(/usr/sbin/sysctl -n kern.boottime | sed -E 's/^\{ sec = ([0-9]+).*/\1/')
+case "$boot_sec" in
+'' | *[!0-9]*)
+  # kern.boottime format changed or the regex missed — fail safe, stay armed.
+  echo "claude-continuity: could not parse boot time ('$boot_sec'); standing by" >&2
+  exit 0
+  ;;
+esac
 armed_sec=$(/usr/bin/stat -f %m "$ARMED")
 if [ "$boot_sec" -lt "$armed_sec" ]; then
   echo "claude-continuity: armed but no reboot since arming; standing by"

--- a/modules/darwin/apps/scripts/claude-continuity-resume.sh
+++ b/modules/darwin/apps/scripts/claude-continuity-resume.sh
@@ -1,4 +1,6 @@
+# shellcheck shell=bash
 # Reboot-continuity resume: relaunch an armed Claude Code mission at login.
+# (Fragment for writeShellApplication — it supplies the shebang and strict mode.)
 #
 # Armed state lives in ~/.claude/run/continuity/ (runtime state, never nix):
 #   armed-session-id  line 1 = Claude Code session id to resume

--- a/modules/darwin/apps/scripts/claude-continuity-resume.sh
+++ b/modules/darwin/apps/scripts/claude-continuity-resume.sh
@@ -52,10 +52,12 @@ fi
 work_dir=$(sed -n '2p' "$ARMED")
 work_dir="${work_dir:-$HOME/git}"
 
+host=$(/bin/hostname -s)
+attach_hint="ssh $host then: tmux attach -t $TMUX_SESSION"
 if [ -f "$STATE_DIR/resume-prompt.md" ]; then
   prompt=$(cat "$STATE_DIR/resume-prompt.md")
 else
-  prompt="You were auto-resumed after a planned reboot. Read $STATE_DIR/RESUME-CONTINUITY.md and the mission plan it points at, verify current state, then continue the mission."
+  prompt="You were auto-resumed after a planned reboot. FIRST post a Slack status to the user's channel confirming the resume and your remote-control handle ($attach_hint) so the user can reach and steer you. Then read $STATE_DIR/RESUME-CONTINUITY.md and the mission plan it points at, verify current state, and continue the mission."
 fi
 
 # tmux execs a multi-argument command directly — no shell quoting layer, so
@@ -66,3 +68,4 @@ tmux new-session -d -s "$TMUX_SESSION" -c "$work_dir" \
 mv "$ARMED" "$STATE_DIR/fired-$now"
 printf '%s\n' "$now" >"$MARKER"
 echo "claude-continuity: resumed session $session_id in tmux session $TMUX_SESSION (cwd $work_dir)"
+echo "claude-continuity: remote control: $attach_hint"

--- a/modules/darwin/apps/scripts/claude-continuity-resume.sh
+++ b/modules/darwin/apps/scripts/claude-continuity-resume.sh
@@ -1,0 +1,68 @@
+# Reboot-continuity resume: relaunch an armed Claude Code mission at login.
+#
+# Armed state lives in ~/.claude/run/continuity/ (runtime state, never nix):
+#   armed-session-id  line 1 = Claude Code session id to resume
+#                     line 2 = optional working directory (default: ~/git)
+#   resume-prompt.md  optional continuation prompt (default points at
+#                     RESUME-CONTINUITY.md in the state dir)
+#
+# Safety layers, in order:
+#   1. Disarmed (no armed file)            -> no-op.
+#   2. No reboot since arming (boottime)   -> no-op. Makes arming safe while
+#      the original session is still alive, including the RunAtLoad fire that
+#      darwin-rebuild triggers at apply time.
+#   3. Cadence gate (durable marker)       -> a storming launchd no-ops.
+#   4. Dedicated tmux session exists       -> no-op (already resumed).
+#   5. Armed file is CONSUMED (renamed) only after a successful launch —
+#      one-shot per arming, marker written after the work (loop-cadence).
+
+STATE_DIR="$HOME/.claude/run/continuity"
+ARMED="$STATE_DIR/armed-session-id"
+MARKER="$STATE_DIR/last-fire"
+MIN_INTERVAL=300
+TMUX_SESSION="claude-continuity"
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+
+[ -f "$ARMED" ] || exit 0
+
+# Fire only on the first login of a boot that happened AFTER arming.
+boot_sec=$(/usr/sbin/sysctl -n kern.boottime | sed -E 's/^\{ sec = ([0-9]+).*/\1/')
+armed_sec=$(/usr/bin/stat -f %m "$ARMED")
+if [ "$boot_sec" -lt "$armed_sec" ]; then
+  echo "claude-continuity: armed but no reboot since arming; standing by"
+  exit 0
+fi
+
+now=$(date +%s)
+last=$(cat "$MARKER" 2>/dev/null || echo 0)
+if [ $((now - last)) -lt "$MIN_INTERVAL" ]; then
+  exit 0
+fi
+
+if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+  exit 0
+fi
+
+session_id=$(head -n 1 "$ARMED" | tr -d '[:space:]')
+if [ -z "$session_id" ]; then
+  echo "claude-continuity: armed file is empty: $ARMED" >&2
+  exit 1
+fi
+
+work_dir=$(sed -n '2p' "$ARMED")
+work_dir="${work_dir:-$HOME/git}"
+
+if [ -f "$STATE_DIR/resume-prompt.md" ]; then
+  prompt=$(cat "$STATE_DIR/resume-prompt.md")
+else
+  prompt="You were auto-resumed after a planned reboot. Read $STATE_DIR/RESUME-CONTINUITY.md and the mission plan it points at, verify current state, then continue the mission."
+fi
+
+# tmux execs a multi-argument command directly — no shell quoting layer, so
+# the prompt and session id never transit a shell string.
+tmux new-session -d -s "$TMUX_SESSION" -c "$work_dir" \
+  "$CLAUDE_BIN" --resume "$session_id" --dangerously-skip-permissions "$prompt"
+
+mv "$ARMED" "$STATE_DIR/fired-$now"
+printf '%s\n' "$now" >"$MARKER"
+echo "claude-continuity: resumed session $session_id in tmux session $TMUX_SESSION (cwd $work_dir)"


### PR DESCRIPTION
## What

A `RunAtLoad` launchd user agent (`programs.claude-continuity`, enabled on both hosts) that resumes an **armed** Claude Code session inside a dedicated detached tmux session at the first login after a reboot. Purpose: a planned reboot — e.g. clearing leaked RDMA Protection Domains during cluster work — no longer loses an in-flight autonomous mission; it auto-continues the moment the user logs back in.

## How it stays safe

Arming is **runtime state**, never nix: `~/.claude/run/continuity/armed-session-id` (session id + optional cwd). No armed file → permanent no-op on every login. Safety layers, in order:

1. Disarmed → no-op.
2. **Boot-time gate**: fires only when the machine rebooted *after* arming — so arming while the original session is alive is safe, including the RunAtLoad fire darwin-rebuild triggers at apply time.
3. Durable min-interval cadence marker (storming launchd no-ops).
4. Existing tmux session → no-op (already resumed).
5. Armed file is **consumed** (renamed) only after a successful launch — one-shot per arming.

Auth follows the `claude-scheduled-jobs` model: the claude CLI's own login-keychain session, no token on disk.

## Human dependency (stated plainly)

With FileVault on and auto-login off, nothing runs until the user unlocks and logs in. This makes continuation instant *after* that unavoidable step; it cannot remove the step. Relaxing FileVault/auto-login is a security decision this PR deliberately does not make.

## Validation

- `nix eval` of both `darwinConfigurations.{jevans-mbp,jevans-ms}.system.drvPath` — clean.
- shellcheck clean under the `writeShellApplication` prelude (`set -euo pipefail`).
- Pre-commit hooks (nixfmt, statix, deadnix, gitleaks, markdownlint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3