### PR TITLE
fix(cluster-link): address review findings from promotion #1660

### DIFF
--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -46,11 +46,13 @@ in
     # network tuning, and energyMode come from the server class in ../common.
     energy.enable = true;
 
-    # --- Thunderbolt RDMA link (night cluster, coordinator / rank 0) ---
-    # Auto-detects the cabled TB port and detaches it from bridge0; no IP is
-    # written (IPv6 link-local is the link identity). See
-    # modules/darwin/night-link.nix for the JACCL link-local gate + fallback.
-    rdmaLink.enable = true;
+    # --- Thunderbolt RDMA link (cluster mode, coordinator / rank 0) ---
+    # Disabled: conflicts with the deployed nightLinkPrep converge daemon
+    # (hosts/common), which owns the TB link (bridge0 sweep + static IPv4) and
+    # is the mechanism the cluster rendezvous was proven on. Re-enable only
+    # when the zero-IP rework in modules/darwin/night-link.nix replaces
+    # nightLinkPrep in the same change.
+    rdmaLink.enable = false;
 
     # --- Auto-login ---
     # The MLX stack and the gh-runner lifecycle are launchd USER agents — a

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -105,11 +105,13 @@ in
     # measured bottleneck. Loopback inference does not need it.
     networkTuning.enable = false;
 
-    # --- Thunderbolt RDMA link (night cluster, worker / rank 1) ---
-    # Auto-detects the cabled TB port and detaches it from bridge0; no IP is
-    # written (IPv6 link-local is the link identity). See
-    # modules/darwin/night-link.nix for the JACCL link-local gate + fallback.
-    rdmaLink.enable = true;
+    # --- Thunderbolt RDMA link (cluster mode, worker / rank 1) ---
+    # Disabled: conflicts with the deployed nightLinkPrep converge daemon
+    # (hosts/common), which owns the TB link (bridge0 sweep + static IPv4) and
+    # is the mechanism the cluster rendezvous was proven on. Re-enable only
+    # when the zero-IP rework in modules/darwin/night-link.nix replaces
+    # nightLinkPrep in the same change.
+    rdmaLink.enable = false;
 
     # --- Energy & Sleep Configuration ---
     energy = {

--- a/modules/darwin/night-link-prep.nix
+++ b/modules/darwin/night-link-prep.nix
@@ -26,7 +26,10 @@ let
   cfg = config.system.nightLinkPrep;
   convergePkg = pkgs.writeShellApplication {
     name = "night-link-converge";
-    runtimeInputs = [ pkgs.gawk ];
+    runtimeInputs = [
+      pkgs.gawk
+      pkgs.gnugrep
+    ];
     text = builtins.readFile ./scripts/night-link-converge.sh;
   };
 in
@@ -70,10 +73,10 @@ in
     system.activationScripts.postActivation.text = lib.mkAfter ''
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Preparing RDMA-capable Thunderbolt interfaces..."
       if [ -x /usr/bin/ibv_devices ]; then
-        /usr/bin/ibv_devices 2>/dev/null | awk 'NR>2 {print $1}' | while read -r rdma_dev; do
+        /usr/bin/ibv_devices 2>/dev/null | /usr/bin/awk 'NR>2 {print $1}' | while read -r rdma_dev; do
           iface="''${rdma_dev#rdma_}"
           /sbin/ifconfig "$iface" > /dev/null 2>&1 || continue
-          if /sbin/ifconfig bridge0 2>/dev/null | grep -q "member: $iface "; then
+          if /sbin/ifconfig bridge0 2>/dev/null | /usr/bin/grep -q "member: $iface "; then
             if /sbin/ifconfig bridge0 deletem "$iface"; then
               echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed $iface from bridge0"
             else

--- a/modules/darwin/scripts/night-link-converge.sh
+++ b/modules/darwin/scripts/night-link-converge.sh
@@ -42,6 +42,6 @@ if ! /sbin/ifconfig "$iface" 2>/dev/null | grep -q "inet $NIGHT_LINK_IP "; then
       echo "night-link: cleared $NIGHT_LINK_IP from $other"
     fi
   done
-  /sbin/ifconfig "$iface" inet "$NIGHT_LINK_IP/24" alias
+  /sbin/ifconfig "$iface" inet "$NIGHT_LINK_IP" netmask 255.255.255.0 alias
   echo "night-link: assigned $NIGHT_LINK_IP to $iface"
 fi


### PR DESCRIPTION
Addresses all four Gemini review threads on #1660 (the develop→main promotion), so the promotion carries the fixes rather than resolving the threads away.

- **critical — ifconfig CIDR**: the deployed script demonstrably works (tonight's cluster rendezvous ran over addresses it assigned), so this was not a live failure — but the explicit `netmask 255.255.255.0` form is portable across macOS ifconfig variants and removes the doubt. Switched.
- **high — nightLinkPrep + rdmaLink both enabled**: confirmed real. `system.rdmaLink` disabled on both hosts; the deployed `nightLinkPrep` converge daemon owns the Thunderbolt link (bridge0 sweep + static IPv4) and is the mechanism the cluster rendezvous was proven on. The zero-IP rework re-enables `rdmaLink` only when it replaces `nightLinkPrep` in the same change.
- **medium ×2 — unpathed awk/grep**: `gnugrep` added to the converge script's `writeShellApplication` runtimeInputs (matching how awk was already provided); absolute `/usr/bin/awk` + `/usr/bin/grep` in the activation script, where runtimeInputs isn't available and every neighboring utility is fully pathed.

Validation: `nix eval` of both `darwinConfigurations.{jevans-mbp,jevans-ms}.system.drvPath` clean; pre-commit hooks (nixfmt, statix, deadnix, shellcheck-via-writeShellApplication at build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3