### PR TITLE
feat(hosts): auto-login on both Macs; disable cluster auto-bring-up

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -89,7 +89,6 @@ in
     # disk unlock and zero prompts after.
     defaults.loginwindow.autoLoginUser = userConfig.user.name;
 
-
     # --- Apple Silicon Tunables ---
     # Wired-memory ceiling, pmset perf flags, App Nap, Spotlight + TM excludes,
     # Metal debug-env guard. See modules/darwin/apple-silicon-tunables.nix.

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -81,6 +81,15 @@ in
   # System-Level Tuning (inference performance, power, limits, network)
   # ==========================================================================
   system = {
+    # --- Auto-login ---
+    # Land in the user session on every restart so login-time agents (the
+    # claude-continuity auto-resume, the MLX user agents) come up unattended.
+    # With FileVault on, macOS defers this to the pre-boot unlock: the unlock
+    # user proceeds straight to the desktop, so the effect is one password at
+    # disk unlock and zero prompts after.
+    defaults.loginwindow.autoLoginUser = userConfig.user.name;
+
+
     # --- Apple Silicon Tunables ---
     # Wired-memory ceiling, pmset perf flags, App Nap, Spotlight + TM excludes,
     # Metal debug-env guard. See modules/darwin/apple-silicon-tunables.nix.

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -72,7 +72,10 @@
     # link watcher quiesces normal serving at link-up and re-warms the preload
     # list on unplug.
     clusterMode = {
-      enable = true;
+      # DISABLED 2026-07-12: boot-time auto-bring-up panicked both hosts
+      # (WindowServer starvation under the shard's wired load). Re-enable
+      # together with the worker once the wired-headroom mitigation lands.
+      enable = false;
       role = "coordinator";
     };
   };

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -31,7 +31,11 @@
     # (GUI quit + agent bootout allowlist sweep) are wired by
     # hosts/common/cluster-quiesce.nix. Day config above is untouched.
     clusterMode = {
-      enable = true;
+      # DISABLED 2026-07-12: the boot-time watcher auto-started a rank whose
+      # ~99 GB wired shard starved WindowServer into a watchdog kernel panic
+      # on both hosts. Re-enable only with a wired-headroom mitigation that
+      # provably leaves the GUI working set unwirable.
+      enable = false;
       role = "worker";
     };
   };


### PR DESCRIPTION
Per direct user order after tonight's double kernel panic.

## Auto-login (both Macs)

`defaults.loginwindow.autoLoginUser` (parameterized from `user-config`) now set on **macbook-m4** too, matching the Studio. Every restart lands in the user session, so login-time agents — the `claude-continuity` auto-resume above all — come up unattended. With FileVault on, macOS folds this into pre-boot unlock: one password at disk unlock, zero prompts after. Combined with `claude-continuity` (merged in #1664, armed at runtime), a reboot on either Mac now auto-resumes the in-flight Claude session in tmux.

## Cluster auto-bring-up DISABLED (both hosts)

`programs.mlx.clusterMode.enable = false`. Root cause, twice tonight (2026-07-12): reboot → launchd loads the link watcher (RunAtLoad) → cable present → watcher auto-starts the rank → the ~99 GB GLM shard wires past the GUI's working set → WindowServer misses watchdog check-ins for 120 s → **kernel panic** (`AppleARMWatchdogTimer`, panic log captured). This hit the MBP while in active use and re-crashed the freshly-booted Studio. Re-enable only together with a wired-headroom mitigation that provably leaves the GUI unwirable.

## Validation

`nix eval` both `darwinConfigurations.*.system.drvPath` clean; `darwin-rebuild switch` applied to BOTH hosts as part of this change (per repo policy: flake check + switch are required testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3