### PR TITLE
fix: cover nix-ai-open-harness in flake-update automation

### DIFF
--- a/.claude/rules/nix-deps-sync.md
+++ b/.claude/rules/nix-deps-sync.md
@@ -6,9 +6,10 @@
 
 **Current inputs**:
 - `nix-ai` — AI CLI ecosystem (Claude, Gemini, Copilot, MCP)
+- `nix-ai-open-harness` — Fallback harness for open/local-LLM agent CLIs
 - `nix-home` — Cross-platform home-manager modules (git, zsh, vscode, monitoring)
 - `ai-assistant-instructions` — Shared AI assistant configurations (rules, skills)
-- `claude-code-plugins` — Claude Code plugin marketplace
+- `jacobpevans-cc-plugins` — Claude Code plugin marketplace (non-flake input)
 
 **Private repos** (explicitly excluded from sync rule):
 - Any repositories marked as private in GitHub are completely ignored
@@ -30,11 +31,11 @@ When you've just merged changes in nix-home, nix-ai, or another JacobPEvans repo
 need nix-darwin to pick them up immediately — don't wait for Renovate:
 
 ```bash
-gh workflow run deps-update-flake.yml --repo JacobPEvans/nix-darwin
+gh workflow run deps-update-flake.yml --repo dryvist/nix-darwin
 ```
 
 This triggers `.github/workflows/deps-update-flake.yml` which:
-1. Runs `nix flake update nix-home nix-ai ai-assistant-instructions claude-code-plugins`
+1. Runs `nix flake update nix-home nix-ai nix-ai-open-harness ai-assistant-instructions jacobpevans-cc-plugins`
 2. Opens a PR with the updated `flake.lock`
 3. CI validates, then auto-merge (via org Renovate preset) handles the rest
 

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -43,7 +43,7 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Update JacobPEvans flake inputs
-        run: nix flake update nix-home nix-ai ai-assistant-instructions jacobpevans-cc-plugins
+        run: nix flake update nix-home nix-ai nix-ai-open-harness ai-assistant-instructions jacobpevans-cc-plugins
 
       - name: Validate flake
         run: nix flake check --no-build


### PR DESCRIPTION
## Summary
- `nix-ai-open-harness` is a dryvist-owned flake input (no explicit ref, tracks its default branch) that was missing from `deps-update-flake.yml`'s update command and from `nix-deps-sync.md`'s input list — it had no update path at all.
- Fixes stale references in `nix-deps-sync.md`: `JacobPEvans/nix-darwin` (pre-migration owner name) and `claude-code-plugins` (the real flake input is `jacobpevans-cc-plugins`; `claude-code-plugins` now points to an unrelated upstream repo).

## Test plan
- [x] Confirmed via `gh repo view` that nix-ai-open-harness's default branch (`main`) was ~5 days ahead of the locked rev.
- [ ] After merge, confirm the next `deps-update-flake.yml` run's PR includes a `nix-ai-open-harness` bump.