### PR TITLE
feat: enable macOS Screen Sharing by default on all Macs

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -38,6 +38,11 @@ in
   # SSH/Remote Login — macOS Remote Login via launchd (Settings > General > Sharing).
   services.openssh.enable = true;
 
+  # Screen Sharing (VNC) — macOS Remote Login's GUI counterpart, enabled on
+  # every host so a reboot always leaves remote recovery available without a
+  # trip to the physical console. See modules/darwin/apps/screen-sharing.nix.
+  programs.screenSharing.enable = true;
+
   # Application firewall on every host. The MBP had this enabled by hand; the
   # Studio shipped disabled, which left the firewall-log-shipping feed with
   # nothing to say (its `log stream` daemon was alive but the ALF subsystem

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -21,6 +21,7 @@ _:
     ./openbao-keychain.nix
     ./orbstack.nix
     ./raycast.nix
+    ./screen-sharing.nix
     ./streamline-login.nix
   ];
 

--- a/modules/darwin/apps/screen-sharing.nix
+++ b/modules/darwin/apps/screen-sharing.nix
@@ -1,0 +1,36 @@
+# macOS Screen Sharing (VNC), enabled by default so remote recovery after a
+# reboot doesn't need physical console access.
+#
+# nix-darwin has no first-class `services.screenSharing`-style option (checked
+# the nix-darwin-26.05 module tree — nothing references
+# `com.apple.screensharing`), so this follows the same shape as
+# programs.gitApfsVolume: a writeShellApplication invoked from
+# system.activationScripts.postActivation runs `launchctl enable` +
+# `launchctl kickstart` against the system's built-in
+# com.apple.screensharing launchd daemon. Plain Screen Sharing only — this
+# does not turn on Remote Management (ARD) or set a control password.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.screenSharing;
+  enablePkg = pkgs.writeShellApplication {
+    name = "screen-sharing-enable";
+    text = builtins.readFile ./scripts/screen-sharing.sh;
+  };
+in
+{
+  options.programs.screenSharing.enable = lib.mkEnableOption "macOS Screen Sharing (VNC) launchd service";
+
+  config = lib.mkIf cfg.enable {
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Enabling macOS Screen Sharing..."
+      ${lib.getExe enablePkg}
+    '';
+  };
+}

--- a/modules/darwin/apps/scripts/screen-sharing.sh
+++ b/modules/darwin/apps/scripts/screen-sharing.sh
@@ -1,0 +1,27 @@
+# Enable the macOS Screen Sharing (VNC) launchd service and start it if it
+# is not already running.
+#
+# nix-darwin ships no first-class option for this (not one of its services.*
+# modules), so this goes through `launchctl enable` + `launchctl kickstart`
+# directly — the standard command-line equivalent of toggling Screen Sharing
+# on in System Settings > General > Sharing. macOS system binaries
+# (launchctl, grep) are called by absolute path — writeShellApplication
+# restricts PATH to runtimeInputs, and launchctl is a macOS-only tool not in
+# nixpkgs.
+#
+# Guarded: `enable` is a harmless no-op when already enabled. `kickstart` is
+# only called when the service isn't already running, so a re-run (every
+# darwin-rebuild) never drops an active Screen Sharing session by force
+# restarting it.
+
+service="system/com.apple.screensharing"
+
+echo "[screen-sharing] enabling ${service}..."
+/bin/launchctl enable "$service"
+
+if /bin/launchctl print "$service" 2>/dev/null | /usr/bin/grep -q "state = running"; then
+  echo "[screen-sharing] ${service} already running; nothing to do"
+else
+  echo "[screen-sharing] starting ${service}..."
+  /bin/launchctl kickstart "$service"
+fi


### PR DESCRIPTION
## Summary

Enables macOS Screen Sharing (VNC) by default on every host (`jevans-mbp`, `jevans-ms`) so it survives every `darwin-rebuild` and is available for remote recovery after a reboot, without needing physical console access.

## Mechanism

nix-darwin has **no first-class option** for this — I checked the `nix-darwin-26.05` module tree (the pinned input in `flake.nix`) directly for any `com.apple.screensharing` / `services.screenSharing`-style option; there is none. `services.openssh.enable` (SSH/Remote Login) is a real shipped module option, but Screen Sharing is not.

The accepted local idiom for "macOS feature with no nix-darwin primitive" is already established by `programs.gitApfsVolume` (`modules/darwin/apps/git-apfs-volume.nix`, PR #1674): a `pkgs.writeShellApplication` invoked from `system.activationScripts.postActivation`. This PR follows that shape exactly:

- New module: `modules/darwin/apps/screen-sharing.nix` — `programs.screenSharing.enable` (a `lib.mkEnableOption`), gated `config` block that appends to `postActivation`.
- New script: `modules/darwin/apps/scripts/screen-sharing.sh` — calls `/bin/launchctl enable system/com.apple.screensharing`, then `/bin/launchctl kickstart` **only if the service isn't already running** (checked via `launchctl print ... | grep "state = running"`). This is deliberately guarded: `enable` is idempotent, but an unguarded `kickstart -k` would force-restart (and drop) an active Screen Sharing session on every `darwin-rebuild switch`. All macOS binaries are called by absolute path since `writeShellApplication` restricts `PATH` to `runtimeInputs`.
- Registered in `modules/darwin/apps/default.nix`'s `imports`.
- Wired on for **both** hosts via the shared module: `hosts/common/default.nix` now sets `programs.screenSharing.enable = true;` right next to the existing `services.openssh.enable = true;` — no per-host split.

This is plain Screen Sharing (VNC) only. It does **not** enable Remote Management (ARD) or set a control password — no `kickstart -activate -configure ...` against `ARDAgent`.

## Validation

Run from `.worktrees/screen-share`:

- `nix fmt` — clean (0 files changed; already conformant).
- `statix check` — clean, no output.
- `deadnix` — clean, no output.
- `nix flake check` — passes, including eval of both `darwinConfigurations.jevans-mbp` and `darwinConfigurations.jevans-ms` (build-skipped mode).
- `nix build .#darwinConfigurations.jevans-mbp.system --dry-run` — passes, derivation list includes `screen-sharing-enable.drv`.
- `nix build .#darwinConfigurations.jevans-ms.system --dry-run` — passes, derivation list includes `screen-sharing-enable.drv`.
- Additionally built the `screen-sharing-enable` derivation itself for real (not just eval) to force `writeShellApplication`'s built-in `shellcheck` + `bash -n` checks to run: builds clean, zero warnings, output at `bin/screen-sharing-enable`.

## What the human needs to do

On **each** Mac, after merge:

```bash
sudo darwin-rebuild switch --flake .
```

Then verify:

1. **System Settings > General > Sharing** — "Screen Sharing" should show as On.
2. **Port listening**: `lsof -iTCP:5900 -sTCP:LISTEN` should show `launchd` (or `screensharingd`) bound to port 5900.
3. From another Mac on the LAN: `open vnc://<hostname>.local` (or Finder > Go > Connect to Server) should reach a login prompt.

## Known limitation

macOS gates the **first actual screen-capture connection** behind a one-time interactive TCC/Privacy consent (Screen Recording permission for `screensharingd` / the incoming session), and on some macOS versions a first-time VNC connection also needs local-user approval at the console. Nix/launchd can enable and start the *service* declaratively, but it cannot pre-grant that OS-level privacy consent — the very first remote connection after this ships may need one manual grant at the physical console (or via an already-approved Apple ID / Remote Management enrollment) before subsequent unattended remote-recovery connections work cleanly. This is a macOS TCC restriction, not a gap in this module.

## Test plan

- [ ] `sudo darwin-rebuild switch --flake .` on `jevans-mbp`, confirm Screen Sharing on + port 5900 listening
- [ ] `sudo darwin-rebuild switch --flake .` on `jevans-ms`, confirm Screen Sharing on + port 5900 listening
- [ ] Connect via VNC from the other Mac to confirm end-to-end reachability
- [ ] Reboot one Mac and confirm Screen Sharing comes back up without manual intervention (beyond the one-time TCC grant noted above, if not already granted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3