### PR TITLE
feat(security): grant passwordless reboot for unattended cluster recovery

### DIFF
--- a/modules/darwin/security.nix
+++ b/modules/darwin/security.nix
@@ -114,8 +114,13 @@ in
   #   RDMA port is auto-detected at runtime — see cluster-link.nix — so its index
   #   cannot be pinned in a static pattern), but up/down on those is recoverable
   #   and non-destructive.
-  # - reboot/shutdown are deliberately NOT granted here; those stay
-  #   interactive pending explicit user approval.
+  # - reboot is granted (added 2026-07-12 with explicit user approval) so the
+  #   autonomous agent can clear a reboot-only RDMA/Protection-Domain wedge and
+  #   let the reboot-continuity agent (claude-continuity.nix) resume the session
+  #   unattended. Only the two restart verbs are granted — `/sbin/reboot` and
+  #   `/sbin/shutdown -r now` — never a bare `/sbin/shutdown` (which could halt
+  #   or power the host off). Both always restart, so the Mac returns to a login
+  #   where FileVault auto-unlock + auto-login fire and continuity resumes.
   #
   # To disable: comment out or remove the environment.etc block
   environment.etc."sudoers.d/cluster-ops".text = ''
@@ -125,5 +130,7 @@ in
     ${userConfig.user.name} ALL=(ALL) NOPASSWD: /sbin/ifconfig bridge0 deletem en[0-9]*
     ${userConfig.user.name} ALL=(ALL) NOPASSWD: /sbin/ifconfig en[0-9]* up
     ${userConfig.user.name} ALL=(ALL) NOPASSWD: /sbin/ifconfig en[0-9]* down
+    ${userConfig.user.name} ALL=(ALL) NOPASSWD: /sbin/reboot
+    ${userConfig.user.name} ALL=(ALL) NOPASSWD: /sbin/shutdown -r now
   '';
 }


### PR DESCRIPTION
## What

Grants passwordless sudo for the two restart verbs — `/sbin/reboot` and `/sbin/shutdown -r now` — in the existing cluster-ops sudoers block in `modules/darwin/security.nix`.

## Why

The two-Mac Thunderbolt-RDMA cluster hits a reboot-only Protection-Domain / `errno=60` exhaustion after repeated bring-up/teardown cycles; recovery requires a full reboot. Paired with the reboot-continuity agent (`claude-continuity.nix`), this lets an unattended run clear the wedge and resume itself: reboot → FileVault auto-unlock + auto-login → the RunAtLoad continuity agent resumes the session in tmux.

## Security scoping

- Only the two restart verbs are granted — never a bare `/sbin/shutdown`, which could halt or power the host off and strand it.
- Both verbs only ever restart, so the host always returns to a login where auto-login fires.
- Consistent with the file's already-disclosed posture (passwordless `darwin-rebuild`/`activate` + cluster-ops for the same autonomous-recovery goal).
- Previously deferred pending explicit user approval (comment updated accordingly); approved 2026-07-12.

## Validation

- `nix fmt` clean; single-file diff.
- Being applied to live `jevans-mbp` via NOPASSWD `sudo darwin-rebuild switch`.
- CI runs `nix flake check` + `darwin-rebuild switch` on macOS runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3