### PR TITLE
fix: address promotion review findings

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -42,6 +42,30 @@
     touch $out
   '';
 
+  # Lint standalone shell scripts. Scripts wrapped by writeShellApplication are
+  # already checked during their builds, but repository helpers under scripts/
+  # otherwise have no ShellCheck coverage.
+  shellcheck = pkgs.runCommand "check-shellcheck" { } ''
+    cd ${src}
+    find ./scripts -name "*.sh" -print0 | \
+    xargs -0 bash -c '
+      failed=0
+      for script in "$@"; do
+        # ShellCheck does not support zsh.
+        if head -1 "$script" | grep -q "zsh"; then
+          echo "Skipping zsh script: $script"
+        else
+          echo "Checking $script..."
+          if ! ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"; then
+            failed=1
+          fi
+        fi
+      done
+      exit "$failed"
+    ' bash
+    touch $out
+  '';
+
   # Run the BATS (Bash Automated Testing System) test suite
   # Runs specific shell integration tests from tests/shell/
   shell-tests =

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -46,13 +46,15 @@
   # already checked during their builds, but repository helpers under scripts/
   # otherwise have no ShellCheck coverage.
   shellcheck = pkgs.runCommand "check-shellcheck" { } ''
+    set -o pipefail
     cd ${src}
     find ./scripts -name "*.sh" -print0 | \
     xargs -0 bash -c '
       failed=0
       for script in "$@"; do
         # ShellCheck does not support zsh.
-        if head -1 "$script" | grep -q "zsh"; then
+        read -r shebang < "$script" || true
+        if [[ "$shebang" == *zsh* ]]; then
           echo "Skipping zsh script: $script"
         else
           echo "Checking $script..."

--- a/modules/darwin/apps/scripts/git-apfs-volume.sh
+++ b/modules/darwin/apps/scripts/git-apfs-volume.sh
@@ -12,18 +12,19 @@
 volume_name="git"
 quota="100g"
 
-# Guard: a volume named "git" already exists -> nothing to do. APFS volume names
-# are case-insensitive, so match case-insensitively on the "Name:" line.
-if /usr/sbin/diskutil apfs list | /usr/bin/grep -qiE "Name:[[:space:]]+${volume_name} \("; then
-  echo "[git-apfs-volume] volume '${volume_name}' already exists; nothing to do"
-  exit 0
-fi
-
 # Resolve the internal APFS container from the booted root volume.
 container="$(/usr/sbin/diskutil info -plist / | /usr/bin/plutil -extract APFSContainerReference raw -)"
 if [ -z "$container" ]; then
   echo "[git-apfs-volume] could not resolve internal APFS container from /" >&2
   exit 1
+fi
+
+# Guard: a volume named "git" already exists on the target container -> nothing
+# to do. APFS volume names are case-insensitive, so match case-insensitively on
+# the complete "Name:" field without depending on a parenthetical suffix.
+if /usr/sbin/diskutil apfs list "$container" | /usr/bin/grep -qiE "Name:[[:space:]]+${volume_name}([[:space:]]+\(|$)"; then
+  echo "[git-apfs-volume] volume '${volume_name}' already exists on container ${container}; nothing to do"
+  exit 0
 fi
 
 echo "[git-apfs-volume] creating volume '${volume_name}' (quota ${quota}) on container ${container}"

--- a/scripts/validate-package-freshness.sh
+++ b/scripts/validate-package-freshness.sh
@@ -74,6 +74,7 @@ matches_exemption_pattern() {
   for pattern in "${array[@]}"; do
     # Use glob pattern matching (supports wildcards like "prefix*"); $pattern is
     # deliberately unquoted so the glob applies.
+    # shellcheck disable=SC2053
     [[ "$element" == $pattern ]] && return 0
   done
   return 1


### PR DESCRIPTION
## Summary

- scope the git APFS volume existence check to the boot container
- restore ShellCheck coverage for standalone repository scripts
- preserve build-time ShellCheck for writeShellApplication-managed scripts

## Validation

- `nix fmt`
- ShellCheck on every `scripts/**/*.sh` file
- ShellCheck on `git-apfs-volume.sh` as Bash
- `nix flake check`
- evaluated `checks.x86_64-linux.shellcheck.drvPath`
- `git diff --check`

Refs: dryvist/nix-darwin#1678