### PR TITLE
feat(launchd): self-heal penalty-boxed critical KeepAlive daemons

### DIFF
--- a/docs/LAUNCHD-SELF-HEAL.md
+++ b/docs/LAUNCHD-SELF-HEAL.md
@@ -1,0 +1,85 @@
+# LaunchDaemon self-heal
+
+Critical KeepAlive daemons (Cribl Edge, firewall-log-shipping) are kept running
+automatically after every activation. This document explains the failure mode
+it prevents and the manual recovery to use if you ever hit it before the fix is
+deployed.
+
+## The failure mode: launchd's penalty box
+
+launchd throttles a KeepAlive daemon that crashes repeatedly in quick
+succession. After enough fast failures it stops respawning the daemon and parks
+it in a "penalty box": `launchctl print system/<label>` still succeeds and shows
+
+```text
+state = spawn scheduled
+```
+
+with **no `pid` line** and a stale `runs` count. The daemon is *loaded but not
+running*, and launchd will not restart it on its own.
+
+nix-darwin only (re)starts a daemon when its plist **content** changes. A
+penalty-boxed daemon keeps its unchanged plist, so `darwin-rebuild switch` walks
+right past it — the daemon stays dead and whatever it ships (here: all
+Mac-origin Splunk telemetry) goes dark silently, for days if unnoticed.
+
+`launchd-bootstrap.nix` does not cover this case either. It only bootstraps
+daemons whose `launchctl print` **fails** (never-loaded); a penalty-boxed daemon
+is loaded, so it is skipped. It also globs only `org.nixos.*` /
+`com.nix-darwin.*` plists, so a daemon labelled `com.<user>.*` (e.g.
+`com.jevans.firewall-log-shipping`) is invisible to it.
+
+## The automated fix
+
+`modules/darwin/launchd-self-heal.nix` runs in `postActivation` (after
+nix-darwin's launchd reconcile). For each registered critical daemon it checks
+whether the daemon is running and, if not, force-reloads it:
+
+```bash
+launchctl bootout   system/<label>          # clears the penalty box
+launchctl bootstrap system /Library/LaunchDaemons/<label>.plist   # starts fresh
+```
+
+Running daemons (those with a `pid` line) are left untouched, so the step is
+idempotent — it acts only on a dead daemon.
+
+### Registering a daemon
+
+A daemon opts in next to its own definition, so a rename can't silently drop
+coverage:
+
+```nix
+services.launchdSelfHeal.labels = [ "com.nix-darwin.cribl-edge" ];
+```
+
+Currently registered: `com.nix-darwin.cribl-edge` (Cribl Edge, in
+`apps/cribl-edge.nix`) and `com.<user>.firewall-log-shipping` (in `logging.nix`).
+Add a label only for a **KeepAlive** daemon that must always be running;
+registering a one-shot daemon would make every activation needlessly restart it.
+
+## Manual recovery
+
+If a daemon is wedged and you need it up before the next activation:
+
+```bash
+sudo launchctl bootout   system/<label>
+sudo launchctl bootstrap system /Library/LaunchDaemons/<label>.plist
+launchctl print system/<label> | grep -E 'state =|pid =|last exit'   # verify
+```
+
+A healthy result shows `state = running`, a numeric `pid`, and
+`last exit code = (never exited)`.
+
+### Do NOT use `launchctl kickstart`
+
+`launchctl kickstart -k system/<label>` **hangs indefinitely** on a
+penalty-boxed daemon — it blocks waiting on a spawn launchd will not perform,
+and `runs` never increments. Use `bootout` + `bootstrap` (which also kills any
+hung `kickstart` still waiting on that label), or reboot: a fresh launchd wipes
+the in-memory penalty box and `RunAtLoad` brings the daemon back.
+
+## See also
+
+- `modules/darwin/launchd-self-heal.nix` — the mechanism
+- `modules/darwin/launchd-bootstrap.nix` — bootstraps never-loaded nix daemons
+- `docs/ACTIVATION-SCRIPTS-RULES.md` — activation-script constraints this obeys

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,11 @@ them.
   - GitHub Actions templates
   - Troubleshooting and maintenance
 
+- **[LAUNCHD-SELF-HEAL.md](LAUNCHD-SELF-HEAL.md)** - Auto-reload of penalty-boxed critical KeepAlive daemons
+  - The launchd penalty-box failure mode (loaded-but-not-running)
+  - How the post-activation self-heal reloads dead daemons
+  - Manual recovery (bootout/bootstrap, never kickstart)
+
 - **[FILE-EXTENSIONS.md](FILE-EXTENSIONS.md)** - Custom file extension mappings for macOS
   - Configure non-standard archive extensions (e.g., .spl, .crbl)
   - Enable Finder auto-extract and shell autocomplete

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -229,5 +229,11 @@ in
         };
       };
     };
+
+    # Edge ships all Mac-origin telemetry; if it crash-loops into launchd's
+    # penalty box a config-unchanged `darwin-rebuild switch` won't restart it
+    # and ingestion goes dark silently. Self-heal it after every activation.
+    # See modules/darwin/launchd-self-heal.nix + docs/LAUNCHD-SELF-HEAL.md.
+    services.launchdSelfHeal.labels = [ "com.nix-darwin.cribl-edge" ];
   };
 }

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -26,6 +26,7 @@ in
     ./nix-homebrew.nix
     ./keyboard.nix
     ./launchd-bootstrap.nix
+    ./launchd-self-heal.nix # Reload penalty-boxed critical KeepAlive daemons
     ./logging.nix # Syslog forwarding to remote server
     ./boot-activation.nix # Creates /run/current-system at boot
     ./auto-recovery.nix

--- a/modules/darwin/launchd-self-heal.nix
+++ b/modules/darwin/launchd-self-heal.nix
@@ -1,0 +1,75 @@
+# Self-heal critical KeepAlive LaunchDaemons after every activation.
+#
+# nix-darwin only (re)starts a daemon when its plist CONTENT changes. A
+# KeepAlive daemon that has crash-looped into launchd's "penalty box"
+# (`launchctl print` shows `state = spawn scheduled`, no `pid`) keeps its
+# unchanged plist, so a plain `darwin-rebuild switch` leaves it dead and
+# telemetry silently goes dark for days.
+#
+# launchd-bootstrap.nix does not catch this: it only bootstraps daemons whose
+# `launchctl print` FAILS (never-loaded), and a penalty-boxed daemon is still
+# loaded. It also globs only `org.nixos.*` / `com.nix-darwin.*` plists, so a
+# daemon labelled `com.<user>.*` is invisible to it entirely.
+#
+# This module force-reloads (bootout + bootstrap) each listed daemon that is
+# not currently running. It NEVER uses `launchctl kickstart`, which HANGS
+# indefinitely on a penalty-boxed daemon (it blocks on a spawn launchd will
+# not perform).
+#
+# Runbook + rationale: docs/LAUNCHD-SELF-HEAL.md
+# Activation-script constraints obeyed here: docs/ACTIVATION-SCRIPTS-RULES.md
+
+{ config, lib, ... }:
+
+let
+  cfg = config.services.launchdSelfHeal;
+in
+{
+  options.services.launchdSelfHeal.labels = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    example = [ "com.nix-darwin.cribl-edge" ];
+    description = ''
+      LaunchDaemon labels that must always be running. After each activation,
+      any listed daemon that is loaded-but-not-running (penalty box) or absent
+      is force-reloaded via `launchctl bootout` + `bootstrap`. Only meaningful
+      for KeepAlive daemons. The plist is expected at
+      `/Library/LaunchDaemons/<label>.plist`. Each daemon module registers its
+      own label here, next to the daemon definition, so a rename can't silently
+      drop coverage.
+    '';
+  };
+
+  config = lib.mkIf (cfg.labels != [ ]) {
+    # postActivation + mkAfter: run after nix-darwin's own launchd reconcile so
+    # we observe the post-switch state. Follows docs/ACTIVATION-SCRIPTS-RULES.md
+    # — no `set -e`/early exit; every failure is a non-fatal warning so the
+    # critical /run/current-system symlink update is never blocked.
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: checking ${toString (builtins.length cfg.labels)} critical daemon(s)..."
+      for label in ${lib.escapeShellArgs cfg.labels}; do
+        plist="/Library/LaunchDaemons/$label.plist"
+        if [ ! -f "$plist" ]; then
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label plist missing, skipping" >&2
+          continue
+        fi
+        # A running daemon prints a numeric `pid = N`; a dead/penalty-boxed one
+        # (state = spawn scheduled) has no pid line even though it is loaded.
+        if /bin/launchctl print system/"$label" 2>/dev/null | grep -qE 'pid = [0-9]'; then
+          continue
+        fi
+        # Not running. Force a clean reload. NEVER `launchctl kickstart` here —
+        # it HANGS forever on a penalty-boxed daemon. bootout clears the wedged
+        # state; bootstrap starts it fresh (RunAtLoad). bootout is allowed to
+        # fail (daemon may be fully absent), hence `|| true`.
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label not running; reloading (bootout+bootstrap)" >&2
+        /bin/launchctl bootout system/"$label" 2>/dev/null || true
+        if /bin/launchctl bootstrap system "$plist" 2>/dev/null; then
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded" >&2
+        else
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label bootstrap failed" >&2
+        fi
+      done
+    '';
+  };
+}

--- a/modules/darwin/logging.nix
+++ b/modules/darwin/logging.nix
@@ -91,6 +91,12 @@ in
     };
   };
 
+  # This daemon's plist is labelled com.<user>.* so launchd-bootstrap.nix's
+  # org.nixos.*/com.nix-darwin.* glob never sees it; register it for self-heal
+  # so a penalty-boxed instance is reloaded after each activation.
+  # See modules/darwin/launchd-self-heal.nix + docs/LAUNCHD-SELF-HEAL.md.
+  services.launchdSelfHeal.labels = [ "com.${userConfig.user.name}.firewall-log-shipping" ];
+
   # User-owned log dir (same pattern as ai-cli-log-shipping.nix: install -d
   # so a root-created parent never blocks the user's writes).
   #


### PR DESCRIPTION
## Problem

nix-darwin only (re)starts a daemon when its plist **content** changes. A
KeepAlive daemon that crash-loops into launchd's *penalty box*
(`launchctl print` shows `state = spawn scheduled`, no `pid`) keeps its
unchanged plist, so `darwin-rebuild switch` walks past it — the daemon stays
dead and whatever it ships goes dark **silently**. This is how Mac-origin
Splunk telemetry (Cribl Edge) can stop for days before anyone notices.

`launchd-bootstrap.nix` does not catch this:
- it only bootstraps daemons whose `launchctl print` **fails** (never-loaded);
  a penalty-boxed daemon is loaded, so it's skipped.
- it globs only `org.nixos.*` / `com.nix-darwin.*` plists, so a `com.<user>.*`
  daemon (`firewall-log-shipping`) is invisible to it entirely.

## Change

- **`modules/darwin/launchd-self-heal.nix`** (new): a `postActivation` step that,
  for each registered critical daemon, force-reloads it (`launchctl bootout` +
  `bootstrap`) if it is not running. Idempotent — running daemons (those with a
  `pid` line) are left untouched. **Never** uses `launchctl kickstart`, which
  hangs indefinitely on a penalty-boxed daemon.
- Register `com.nix-darwin.cribl-edge` (`apps/cribl-edge.nix`) and
  `com.<user>.firewall-log-shipping` (`logging.nix`) **at their own definition
  sites**, so a rename can't silently drop coverage.
- **`docs/LAUNCHD-SELF-HEAL.md`** (new): failure mode, mechanism, and manual
  recovery runbook (bootout/bootstrap, never kickstart).

Obeys `docs/ACTIVATION-SCRIPTS-RULES.md`: no `set -e`, no early exit, all
failures are non-fatal warnings so the `/run/current-system` symlink update is
never blocked.

## Validation

- `nix-instantiate --parse` clean on all touched modules.
- `nixfmt --check` clean.
- markdownlint clean.
- Full `darwin-rebuild build` eval left to CI.

Not applied live — CI validates, then apply via a normal `darwin-rebuild switch`.