### PR TITLE
feat(openbao): GitHub token provider wrapper to retire GH_PAT keychain tiers

### DIFF
--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -67,6 +67,15 @@ in
     # `doppler run`, not a local keychain. See modules/darwin/apps/openbao-aws-creds.nix.
     openbao-aws-creds.enable = true;
 
+    # --- OpenBao-backed GitHub token provider ---
+    # Ships the `openbao-github-creds` wrapper (git credential helper + gh env
+    # source) that retires the local GH_PAT_* keychain tiers. Purely additive:
+    # installing the wrapper changes no git/gh config, so the current
+    # keychain-backed path keeps working until the interactive cutover (see
+    # terraform-proxmox docs/github-token-openbao-migration runbook). Secret-zero
+    # (VAULT_ADDR + the GitHub AppRole) is supplied ambiently by `doppler run`.
+    openbao-github-creds.enable = true;
+
     # --- Reboot-continuity auto-resume ---
     # Login-time LaunchAgent that resumes an armed Claude Code mission in tmux,
     # so a planned reboot (e.g. clearing leaked RDMA Protection Domains during

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -20,6 +20,7 @@ _:
     ./git-apfs-volume.nix
     ./github-runner-container.nix
     ./openbao-aws-creds.nix
+    ./openbao-github-creds.nix
     ./orbstack.nix
     ./raycast.nix
     ./screen-sharing.nix

--- a/modules/darwin/apps/openbao-github-creds.nix
+++ b/modules/darwin/apps/openbao-github-creds.nix
@@ -1,0 +1,47 @@
+# OpenBao-backed GitHub token provider
+#
+# Installs `openbao-github-creds` system-wide so `git` (as a credential helper)
+# and shell `gh-*` functions (via `openbao-github-creds token <purpose>`) can
+# resolve a purpose-scoped GitHub token from OpenBao KV on demand. Retires the
+# local tiered-PAT keychain services (GH_PAT_*).
+#
+# Secret-zero — VAULT_ADDR + the GitHub AppRole role_id/secret_id — is supplied
+# AMBIENTLY by the environment, in practice by running under `doppler run` (the
+# iac secret store injects them by name). There is deliberately NO local
+# keychain in this path, identical to openbao-aws-creds.nix after #1686: Doppler
+# holds the OpenBao bootstrap, OpenBao serves the GitHub tokens. `security` etc.
+# are not used here; jq + curl come from runtimeInputs.
+#
+# This module is purely additive: it ships the wrapper on PATH but changes no
+# git/gh config. The interactive cutover (pointing git's credential helper and
+# the gh-* shell functions at this wrapper, then deleting the GH_PAT_* keychain
+# services) is an operator step — see terraform-proxmox's
+# docs/github-token-openbao-migration runbook — so enabling this module cannot
+# break the current keychain-backed token path.
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.openbao-github-creds;
+
+  githubCredsScript = pkgs.writeShellApplication {
+    name = "openbao-github-creds";
+    runtimeInputs = [
+      pkgs.jq
+      pkgs.curl
+    ];
+    text = builtins.readFile ./../scripts/openbao-github-creds.sh;
+  };
+in
+{
+  options.programs.openbao-github-creds.enable = lib.mkEnableOption "the OpenBao-backed GitHub token provider (git credential helper + gh env source)";
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ githubCredsScript ];
+  };
+}

--- a/modules/darwin/scripts/openbao-github-creds.sh
+++ b/modules/darwin/scripts/openbao-github-creds.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# GitHub token provider backed by OpenBao — the git/gh analogue of
+# openbao-aws-creds.sh. Retires the local tiered-PAT keychain services
+# (GH_PAT_*) by fetching a purpose-scoped GitHub token from OpenBao KV on
+# demand. Two invocation modes share one code path:
+#
+#   1. git credential helper (token never enters the environment):
+#        openbao-github-creds get     (reads the credential request on stdin,
+#                                      emits `username`/`password`)
+#        openbao-github-creds store   (no-op — OpenBao is the store)
+#        openbao-github-creds erase   (no-op)
+#      Wire via: git config credential."https://github.com".helper \
+#        '!openbao-github-creds'   (git appends the operation, so it invokes
+#        `openbao-github-creds get`; do NOT add `get` here or it arrives twice).
+#
+#   2. env export (for `gh` and shell functions that set GITHUB_TOKEN):
+#        export GITHUB_TOKEN="$(openbao-github-creds token [purpose])"
+#      `gh` and `git`'s existing `gh auth git-credential` helper both honour
+#      GITHUB_TOKEN, so this one export cuts over git push AND gh together.
+#
+# SECRET-ZERO comes from the AMBIENT ENVIRONMENT, not a local keychain —
+# identical to openbao-aws-creds.sh after dryvist/nix-darwin#1686: VAULT_ADDR +
+# an AppRole role_id/secret_id, injected by running under `doppler run`. There
+# is deliberately NO local keychain in this path; Doppler holds the OpenBao
+# bootstrap, OpenBao serves the GitHub tokens.
+#
+# TIER / PURPOSE SELECTION (least privilege, mirrors the old GH_ENV_MODE tiers).
+# Purpose comes from $GH_ENV_MODE (or an explicit `token <purpose>` arg), and
+# selects BOTH the KV path and which AppRole's secret-zero to read:
+#
+#   GH_ENV_MODE            -> purpose          -> AppRole env prefix
+#   unset/DRYVIST/RESTRICTED  repo-write          GITHUB_READ   (default, always-on)
+#   ADMIN                     personal-admin      GITHUB_ADMIN  (elevated)
+#   ORG_ADMIN                 org-admin           GITHUB_ADMIN  (elevated)
+#   SECRETS_MANAGER           actions-secrets     GITHUB_ADMIN  (elevated)
+#   CLASSIC_ADMIN             classic-admin       GITHUB_ADMIN  (elevated)
+#   VISICORE                  visicore            GITHUB_ADMIN  (elevated)
+#
+# The GITHUB_READ AppRole secret-zero is injected by the default Doppler config,
+# so the repo-write token is always reachable. The GITHUB_ADMIN secret-zero is
+# scoped to a MORE-privileged Doppler config that a plain shell does NOT carry —
+# so pulling an admin token requires a deliberate `doppler run --config <admin>`
+# step. Doppler config scoping replaces the old elevate-access keychain unlock
+# as the "elevated needs a deliberate step" gate.
+#
+# ponytail: no on-disk token cache (unlike openbao-aws-creds, which caches
+# because `aws` calls credential_process on every API request). git/gh invoke a
+# credential helper roughly once per fetch/push and cache in-memory for that
+# operation, so one AppRole login + one KV read per push is cheap — and the hard
+# rule is "never write tokens to disk". Add a cache only if a real workload
+# measurably hammers OpenBao.
+#
+# `pkgs.writeShellApplication` wraps this in `set -euo pipefail` and lints it
+# (see the sibling scripts' notes), so this file omits its own set line.
+
+prefix="[openbao-github-creds]"
+die() { echo "$prefix ERROR $*" >&2; exit 1; }
+
+# Map the requested tier to (purpose, approle_env_prefix).
+resolve_tier() {
+  local mode="${1:-${GH_ENV_MODE:-}}"
+  case "${mode}" in
+    ADMIN)                 purpose="personal-admin"  approle_prefix="GITHUB_ADMIN" ;;
+    ORG_ADMIN)             purpose="org-admin"       approle_prefix="GITHUB_ADMIN" ;;
+    SECRETS_MANAGER)       purpose="actions-secrets" approle_prefix="GITHUB_ADMIN" ;;
+    CLASSIC_ADMIN)         purpose="classic-admin"   approle_prefix="GITHUB_ADMIN" ;;
+    VISICORE)              purpose="visicore"        approle_prefix="GITHUB_ADMIN" ;;
+    *)                     purpose="repo-write"      approle_prefix="GITHUB_READ"  ;;
+  esac
+}
+
+# Print the GitHub token for the resolved purpose to stdout.
+fetch_token() {
+  local explicit_purpose="${1:-}"
+  resolve_tier
+  [ -n "${explicit_purpose}" ] && purpose="${explicit_purpose}"
+
+  # Indirect-expand the AppRole secret-zero for the chosen tier, e.g.
+  # OPENBAO_APPROLE_GITHUB_READ_ROLE_ID / _SECRET_ID.
+  local bao_addr role_id_var secret_id_var role_id secret_id
+  bao_addr="${VAULT_ADDR:-}"
+  role_id_var="OPENBAO_APPROLE_${approle_prefix}_ROLE_ID"
+  secret_id_var="OPENBAO_APPROLE_${approle_prefix}_SECRET_ID"
+  role_id="${!role_id_var:-}"
+  secret_id="${!secret_id_var:-}"
+  if [ -z "${bao_addr}" ] || [ -z "${role_id}" ] || [ -z "${secret_id}" ]; then
+    die "VAULT_ADDR / ${role_id_var} / ${secret_id_var} not in environment — run under 'doppler run' so the OpenBao bootstrap is injected (purpose=${purpose})"
+  fi
+
+  local login_resp token
+  login_resp="$(curl -sf --max-time 10 -X POST \
+    -d "{\"role_id\":\"${role_id}\",\"secret_id\":\"${secret_id}\"}" \
+    "${bao_addr}/v1/auth/approle/login")" || die "AppRole login to ${bao_addr} failed"
+  token="$(jq -r '.auth.client_token // empty' <<<"${login_resp}")"
+  [ -n "${token}" ] || die "AppRole login returned no client_token"
+
+  local kv_resp gh_token
+  kv_resp="$(curl -sf --max-time 10 -H "X-Vault-Token: ${token}" \
+    "${bao_addr}/v1/secret/data/github/${purpose}")" || die "reading secret/github/${purpose} failed"
+  gh_token="$(jq -r '.data.data.token // empty' <<<"${kv_resp}")"
+  [ -n "${gh_token}" ] || die "secret/github/${purpose} has no .data.token"
+
+  printf '%s' "${gh_token}"
+}
+
+# git credential protocol: read key=value lines on stdin until a blank line.
+git_credential_get() {
+  local host="" line
+  while IFS= read -r line; do
+    [ -z "${line}" ] && break
+    case "${line}" in
+      host=*) host="${line#host=}" ;;
+    esac
+  done
+  # Only answer for github.com; anything else falls through to the next helper.
+  case "${host}" in
+    github.com|gist.github.com) : ;;
+    *) exit 0 ;;
+  esac
+  local gh_token
+  gh_token="$(fetch_token)"
+  printf 'username=x-access-token\npassword=%s\n' "${gh_token}"
+}
+
+case "${1:-}" in
+  get)         git_credential_get ;;
+  store|erase) exit 0 ;;             # OpenBao is the store; nothing to cache/forget.
+  token)       fetch_token "${2:-}"; echo ;;
+  *) die "usage: openbao-github-creds {get|store|erase|token [purpose]}" ;;
+esac

--- a/modules/darwin/scripts/openbao-github-creds.sh
+++ b/modules/darwin/scripts/openbao-github-creds.sh
@@ -61,20 +61,20 @@ die() { echo "$prefix ERROR $*" >&2; exit 1; }
 resolve_tier() {
   local mode="${1:-${GH_ENV_MODE:-}}"
   case "${mode}" in
-    ADMIN)                 purpose="personal-admin"  approle_prefix="GITHUB_ADMIN" ;;
-    ORG_ADMIN)             purpose="org-admin"       approle_prefix="GITHUB_ADMIN" ;;
-    SECRETS_MANAGER)       purpose="actions-secrets" approle_prefix="GITHUB_ADMIN" ;;
-    CLASSIC_ADMIN)         purpose="classic-admin"   approle_prefix="GITHUB_ADMIN" ;;
-    VISICORE)              purpose="visicore"        approle_prefix="GITHUB_ADMIN" ;;
-    *)                     purpose="repo-write"      approle_prefix="GITHUB_READ"  ;;
+    ADMIN|personal-admin)           purpose="personal-admin"  approle_prefix="GITHUB_ADMIN" ;;
+    ORG_ADMIN|org-admin)            purpose="org-admin"       approle_prefix="GITHUB_ADMIN" ;;
+    SECRETS_MANAGER|actions-secrets) purpose="actions-secrets" approle_prefix="GITHUB_ADMIN" ;;
+    CLASSIC_ADMIN|classic-admin)    purpose="classic-admin"   approle_prefix="GITHUB_ADMIN" ;;
+    VISICORE|visicore)              purpose="visicore"        approle_prefix="GITHUB_ADMIN" ;;
+    *)                              purpose="${mode:-repo-write}" approle_prefix="GITHUB_READ" ;;
   esac
 }
 
 # Print the GitHub token for the resolved purpose to stdout.
 fetch_token() {
   local explicit_purpose="${1:-}"
-  resolve_tier
-  [ -n "${explicit_purpose}" ] && purpose="${explicit_purpose}"
+  local purpose="" approle_prefix=""
+  resolve_tier "${explicit_purpose}"
 
   # Indirect-expand the AppRole secret-zero for the chosen tier, e.g.
   # OPENBAO_APPROLE_GITHUB_READ_ROLE_ID / _SECRET_ID.


### PR DESCRIPTION
# feat(openbao): GitHub token provider wrapper to retire GH_PAT keychain tiers

## What

Adds `openbao-github-creds` — the git/gh analogue of the existing
`openbao-aws-creds` credential_process wrapper — as the **code half** of
retiring this machine's local tiered GitHub PAT keychain services (`GH_PAT_*`)
and sourcing `git`/`gh` tokens from OpenBao instead. Consistent with the
secret-zero model from #1663 and #1686 (OpenBao serves the tokens, Doppler is
secret-zero only, no local keychain in the path).

This is not an interactive cutover. The interactive cutover (seeding OpenBao KV + Doppler,
pointing git/gh at the wrapper, verifying a real push, then deleting the keychain
services) is an operator runbook, not part of this PR.

## Changes

+ `modules/darwin/scripts/openbao-github-creds.sh` — fetches a purpose-scoped
  token from `secret/github/<purpose>` (KV v2) on demand. Two modes: `get` (git
  credential helper, token never enters the env) and `token <purpose>` (prints
  to stdout for `gh`/shell `GITHUB_TOKEN` export). Secret-zero (`VAULT_ADDR` +
  the AppRole role_id/secret_id) is read from the ambient env, injected by
  `doppler run` — same shape as `openbao-aws-creds.sh` after #1686. No disk cache
  (git/gh call it ~once per operation; the rule is never write tokens to disk).
+ `modules/darwin/apps/openbao-github-creds.nix` — builds the wrapper via
  `writeShellApplication` and ships it system-wide behind
  `programs.openbao-github-creds.enable`. Mirrors `openbao-aws-creds.nix`.
+ `modules/darwin/apps/default.nix` — imports the new module.
+ `hosts/macbook-m4/default.nix` — `openbao-github-creds.enable = true`.

## Least-privilege design

Six keychain tiers collapse to six KV paths under **two AppRoles**:

+ `github-read` (always-on, default Doppler config) → only `secret/github/repo-write`.
+ `github-admin` (scoped to a more-privileged Doppler config the default shell
  does NOT carry) → the five elevated paths (`personal-admin`, `org-admin`,
  `actions-secrets`, `visicore`, `classic-admin`). Pulling an admin token thus
  requires a deliberate `doppler run --config <admin>` — Doppler config scoping
  replaces the old password-gated `elevate-access.keychain-db` unlock as the
  "elevated needs a deliberate step" gate.

`GH_ENV_MODE` selects the purpose+AppRole, preserving the current tiering.

## Safety / additivity

Purely additive: the module only puts the wrapper on `PATH`; it changes no
git/gh config. The current keychain-backed token flow
(`hosts/common/gh-token-switching.zsh`) is untouched and keeps working. Cutover
and keychain deletion happen later, per the runbook, gated on a verified real
push through OpenBao.

## Verification done here

+ `shellcheck` clean on the script.
+ Stubbed self-check (mocked `curl`) — 8/8: default→`repo-write`, explicit
  purpose arg, `ORG_ADMIN`/`VISICORE` modes, git-credential `get` handshake for
  `github.com`, non-github host fall-through, and admin-tier fails closed when
  its secret-zero is absent.
+ `nix eval` of `darwinConfigurations.jevans-mbp.…toplevel.drvPath` succeeds with
  the module enabled.

Not done (operator/live steps): OpenBao writes, Doppler seeding, `darwin-rebuild`,
the real push. No keychain entry was read (values), modified, or deleted.

## Coordination

Open PR #1698 (`feat/openbao-gate-migration`) also touches OpenBao but on a
different surface (the llm-large L7 gate, `modules/darwin/llm-gate.nix` /
Doppler), so no file overlap with this change. Flagging for awareness since both
are OpenBao-adjacent; this PR does not depend on it.

## Follow-up (not in this PR)

Cutover runbook: `terraform-proxmox` `docs/github-token-openbao-migration.md`
(the OpenBao path/policy layout, seeding steps, git/gh wiring, verification, and
the keychain-deletion + `gh-token-switching.zsh` / `lib/user-config.nix` cleanup).

## Open decisions for the user

1. Is `GH_PAT_CLASSIC_ADMIN` still needed, or can fine-grained tokens cover it
   (drop `secret/github/classic-admin`)?
2. Keep `actions-secrets` as a separate narrow path or fold into `org-admin`?
3. Give `visicore` its own third AppRole for tenant isolation instead of sharing
   `github-admin`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

