### PR TITLE
fix(llm-gate): stop XDG_CONFIG_HOME from breaking doppler token lookup

### DIFF
--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -257,11 +257,15 @@ in
       ThrottleInterval = 15;
       WorkingDirectory = cfg.dataDir;
       EnvironmentVariables = {
-        # HOME so `doppler` finds ~/.doppler (its scoped service token); Caddy's
-        # own storage is pinned under the gate dir via XDG below.
+        # HOME so `doppler` finds ~/.doppler (its WorkingDirectory-scoped service
+        # token). Do NOT set XDG_CONFIG_HOME here: `doppler` honors it OVER
+        # ~/.doppler, so pinning it (for Caddy's sake) silently redirects the CLI's
+        # config lookup to an empty dir and the gate dies "you must provide a
+        # token" -> exit 78 -> crash-loop (2026-07-14 outage). Caddy needs no
+        # XDG_CONFIG_HOME: its config comes from --config and its cert/state
+        # storage is pinned via XDG_DATA_HOME below.
         HOME = userConfig.user.homeDir;
         XDG_DATA_HOME = "${cfg.dataDir}/data";
-        XDG_CONFIG_HOME = "${cfg.dataDir}/config";
       };
       StandardOutPath = "${cfg.logDir}/llm-gate.log";
       StandardErrorPath = "${cfg.logDir}/llm-gate.error.log";


### PR DESCRIPTION
## Problem

The Studio's `com.nix-darwin.llm-gate` LaunchAgent crash-looped `exit 78 (EX_CONFIG)`, taking the router -> Studio TLS gate hop down and failing every Hermes cron with `MidStreamFallbackError` (2026-07-14 outage). Root cause: the job set `XDG_CONFIG_HOME = "${dataDir}/config"` to isolate Caddy's config dir, but **`doppler` honors `XDG_CONFIG_HOME` over `~/.doppler`**. So the CLI looked for its `WorkingDirectory`-scoped service token at an empty path, found none, and died `you must provide a token`. `launchctl kickstart -k` could not clear the resulting penalty box (only `bootout`+`bootstrap` did) — the same failure mode `launchd-self-heal.nix` (#1697) exists for.

## Fix

Remove the one `XDG_CONFIG_HOME` line. Caddy needs it for nothing here — its config comes from `--config` and its cert/state storage stays pinned via `XDG_DATA_HOME`. Doppler falls back to `~/.doppler` (where the scoped token lives). A comment documents the gotcha so it is not re-added.

## Verification

- `statix check` + `nixfmt --check` clean on the module.
- Live-proven on the Studio via the equivalent env: with `XDG_CONFIG_HOME` unset, `doppler run` resolves the token and Caddy serves (external `/v1/models` -> 401, a completion returns `finish_reason: stop`).

## Note

Superseded eventually by the OpenBao gate migration (#1698), which removes Doppler from this path entirely — but that is user-gated on a live OpenBao converge, and this outage needed the Doppler path correct now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)