### PR TITLE
fix(flake): follow canonical plugin skills input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -791,31 +791,15 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1783847174,
-        "narHash": "sha256-0x5NB1/ruQil0MNgk1cEmg31GOLIneYABzoyguUqtMQ=",
+        "lastModified": 1784062929,
+        "narHash": "sha256-aTE2Rrkabc/LiQfqZBQiB9y/yne5vJKpXrvWXJLpgt8=",
         "owner": "dryvist",
         "repo": "claude-code-plugins",
-        "rev": "4fc2185a3628a392702d37ed4b0876951967f325",
+        "rev": "0b39041e8c9ed555c62667e89eb72abc5dcef0cd",
         "type": "github"
       },
       "original": {
         "owner": "dryvist",
-        "repo": "claude-code-plugins",
-        "type": "github"
-      }
-    },
-    "jacobpevans-cc-plugins_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1783096239,
-        "narHash": "sha256-9fK/q7nQRyRxu3GOf+JzhrdwNZ00lcs7YnBUIIZafFE=",
-        "owner": "JacobPEvans",
-        "repo": "claude-code-plugins",
-        "rev": "281ab4d7f780e39f53ca2a77b7858f593e6a941e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
         "type": "github"
       }
@@ -1027,7 +1011,9 @@
           "home-manager"
         ],
         "huggingface-skills": "huggingface-skills",
-        "jacobpevans-cc-plugins": "jacobpevans-cc-plugins_2",
+        "jacobpevans-cc-plugins": [
+          "jacobpevans-cc-plugins"
+        ],
         "karpathy-skills": "karpathy-skills_2",
         "lunar-claude": "lunar-claude",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
         home-manager.follows = "home-manager";
         ai-assistant-instructions.follows = "ai-assistant-instructions";
         claude-code-plugins.follows = "claude-code-plugins";
+        nix-claude-code.inputs.jacobpevans-cc-plugins.follows = "jacobpevans-cc-plugins";
       };
     };
 


### PR DESCRIPTION
## Summary
- make nix-ai's nested plugin source follow nix-darwin's canonical dryvist/claude-code-plugins input
- remove the stale duplicate plugin node that omitted premium-agent-orchestration and six companion skills

## Validation
- nix flake check --no-build
- nix build .#lib.ci.hmActivationPackage --no-link --print-build-logs
- verified the resolved source contains premium-agent-orchestration, git-flow-next, session-status, promote-release, homelab-runbooks, and claude-skill-authoring

## Activation
- local darwin-rebuild switch requires sudo and was not runnable in this non-interactive session; the PR CI performs the native rebuild gate.