### PR TITLE
fix(launchd): harden self-heal checks

### DIFF
--- a/modules/darwin/launchd-self-heal.nix
+++ b/modules/darwin/launchd-self-heal.nix
@@ -40,36 +40,40 @@ in
     '';
   };
 
-  config = lib.mkIf (cfg.labels != [ ]) {
-    # postActivation + mkAfter: run after nix-darwin's own launchd reconcile so
-    # we observe the post-switch state. Follows docs/ACTIVATION-SCRIPTS-RULES.md
-    # — no `set -e`/early exit; every failure is a non-fatal warning so the
-    # critical /run/current-system symlink update is never blocked.
-    system.activationScripts.postActivation.text = lib.mkAfter ''
-      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: checking ${toString (builtins.length cfg.labels)} critical daemon(s)..."
-      for label in ${lib.escapeShellArgs cfg.labels}; do
-        plist="/Library/LaunchDaemons/$label.plist"
-        if [ ! -f "$plist" ]; then
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label plist missing, skipping" >&2
-          continue
-        fi
-        # A running daemon prints a numeric `pid = N`; a dead/penalty-boxed one
-        # (state = spawn scheduled) has no pid line even though it is loaded.
-        if /bin/launchctl print system/"$label" 2>/dev/null | grep -qE 'pid = [0-9]'; then
-          continue
-        fi
-        # Not running. Force a clean reload. NEVER `launchctl kickstart` here —
-        # it HANGS forever on a penalty-boxed daemon. bootout clears the wedged
-        # state; bootstrap starts it fresh (RunAtLoad). bootout is allowed to
-        # fail (daemon may be fully absent), hence `|| true`.
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label not running; reloading (bootout+bootstrap)" >&2
-        /bin/launchctl bootout system/"$label" 2>/dev/null || true
-        if /bin/launchctl bootstrap system "$plist" 2>/dev/null; then
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded" >&2
-        else
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label bootstrap failed" >&2
-        fi
-      done
-    '';
-  };
+  config =
+    let
+      uniqueLabels = lib.unique cfg.labels;
+    in
+    lib.mkIf (uniqueLabels != [ ]) {
+      # postActivation + mkAfter: run after nix-darwin's own launchd reconcile so
+      # we observe the post-switch state. Follows docs/ACTIVATION-SCRIPTS-RULES.md
+      # — no `set -e`/early exit; every failure is a non-fatal warning so the
+      # critical /run/current-system symlink update is never blocked.
+      system.activationScripts.postActivation.text = lib.mkAfter ''
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: checking ${toString (builtins.length uniqueLabels)} critical daemon(s)..."
+        for label in ${lib.escapeShellArgs uniqueLabels}; do
+          plist="/Library/LaunchDaemons/$label.plist"
+          if [ ! -f "$plist" ]; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label plist missing, skipping" >&2
+            continue
+          fi
+          # A running daemon prints a numeric `pid = N`; a dead/penalty-boxed one
+          # (state = spawn scheduled) has no pid line even though it is loaded.
+          if /bin/launchctl print system/"$label" 2>/dev/null | grep -qE '^[[:space:]]*pid = [0-9]+[[:space:]]*$'; then
+            continue
+          fi
+          # Not running. Force a clean reload. NEVER `launchctl kickstart` here —
+          # it HANGS forever on a penalty-boxed daemon. bootout clears the wedged
+          # state; bootstrap starts it fresh (RunAtLoad). bootout is allowed to
+          # fail (daemon may be fully absent), hence `|| true`.
+          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label not running; reloading (bootout+bootstrap)" >&2
+          /bin/launchctl bootout system/"$label" 2>/dev/null || true
+          if /bin/launchctl bootstrap system "$plist" 2>/dev/null; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded" >&2
+          else
+            echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label bootstrap failed" >&2
+          fi
+        done
+      '';
+    };
 }


### PR DESCRIPTION
Deduplicate registered daemon labels before activation and anchor PID detection to the actual launchctl field. Validated with nix formatting, git diff checks, and nix flake check --no-build. Refs: dryvist/nix-darwin#1703