### PR TITLE
fix(cluster-link): allow uv CPython through the application firewall

### DIFF
--- a/modules/darwin/cluster-link-prep.nix
+++ b/modules/darwin/cluster-link-prep.nix
@@ -24,6 +24,7 @@
 
 let
   cfg = config.system.clusterLinkPrep;
+  userConfig = import ../../lib/user-config.nix;
   convergePkg = pkgs.writeShellApplication {
     name = "cluster-link-converge";
     runtimeInputs = [
@@ -31,6 +32,10 @@ let
       pkgs.gnugrep
     ];
     text = builtins.readFile ./scripts/cluster-link-converge.sh;
+  };
+  alfAllowPkg = pkgs.writeShellApplication {
+    name = "cluster-alf-allow";
+    text = builtins.readFile ./scripts/cluster-alf-allow.sh;
   };
 in
 {
@@ -79,6 +84,11 @@ in
     # intentionally non-fatal steps run without `set -e`).
     system.activationScripts.postActivation.text = lib.mkAfter (
       builtins.readFile ./scripts/cluster-link-prep.sh
+      # The JACCL rendezvous listener needs an explicit application-firewall
+      # allowance (uv CPython is ad-hoc-signed) — see scripts/cluster-alf-allow.sh.
+      + ''
+        CLUSTER_USER_HOME=${userConfig.user.homeDir} ${lib.getExe alfAllowPkg}
+      ''
     );
   };
 }

--- a/modules/darwin/cluster-link-prep.nix
+++ b/modules/darwin/cluster-link-prep.nix
@@ -87,7 +87,7 @@ in
       # The JACCL rendezvous listener needs an explicit application-firewall
       # allowance (uv CPython is ad-hoc-signed) — see scripts/cluster-alf-allow.sh.
       + ''
-        CLUSTER_USER_HOME=${userConfig.user.homeDir} ${lib.getExe alfAllowPkg}
+        CLUSTER_USER_HOME="${userConfig.user.homeDir}" ${lib.getExe alfAllowPkg}
       ''
     );
   };

--- a/modules/darwin/scripts/cluster-alf-allow.sh
+++ b/modules/darwin/scripts/cluster-alf-allow.sh
@@ -8,10 +8,12 @@
 # LISTEN both look healthy. Allow each interpreter explicitly; --add and
 # --unblockapp are idempotent, so re-running on every activation is safe and
 # self-heals across interpreter version bumps.
+: "${CLUSTER_USER_HOME:?CLUSTER_USER_HOME must be set (injected by cluster-link-prep.nix)}"
 SFW=/usr/libexec/ApplicationFirewall/socketfilterfw
 for py in "$CLUSTER_USER_HOME"/.local/share/uv/python/cpython-*/bin/python3*; do
   [ -x "$py" ] || continue
-  "$SFW" --add "$py" > /dev/null 2>&1 || true
-  "$SFW" --unblockapp "$py" > /dev/null 2>&1 || true
+  # stdout is success noise; stderr stays visible in the activation log.
+  "$SFW" --add "$py" > /dev/null || true
+  "$SFW" --unblockapp "$py" > /dev/null || true
   echo "cluster-alf-allow: allowed $py"
 done

--- a/modules/darwin/scripts/cluster-alf-allow.sh
+++ b/modules/darwin/scripts/cluster-alf-allow.sh
@@ -1,0 +1,17 @@
+# Allow uv-managed CPython interpreters through the macOS application firewall.
+#
+# The JACCL rendezvous listener binds the Thunderbolt link address
+# (non-loopback), so the application firewall filters it. uv-managed CPython
+# is ad-hoc / linker-signed ("Identifier=-"), which the firewall's
+# "automatically allow signed software" setting does NOT cover — inbound SYNs
+# are dropped silently and the worker rank times out (errno 60) while ping and
+# LISTEN both look healthy. Allow each interpreter explicitly; --add and
+# --unblockapp are idempotent, so re-running on every activation is safe and
+# self-heals across interpreter version bumps.
+SFW=/usr/libexec/ApplicationFirewall/socketfilterfw
+for py in "$CLUSTER_USER_HOME"/.local/share/uv/python/cpython-*/bin/python3*; do
+  [ -x "$py" ] || continue
+  "$SFW" --add "$py" > /dev/null 2>&1 || true
+  "$SFW" --unblockapp "$py" > /dev/null 2>&1 || true
+  echo "cluster-alf-allow: allowed $py"
+done


### PR DESCRIPTION
## What

Ports the never-PR'd `feat/night-link-reload` fix (2026-07-11, pre cluster-mode rename) onto current `develop`: the JACCL rendezvous listener binds the Thunderbolt link address, and uv-managed CPython is ad-hoc-signed, so the application firewall silently drops inbound SYNs (worker rank errno 60 while ping/LISTEN look healthy). Adds each uv-managed interpreter to the ALF allow list at activation — `--add`/`--unblockapp` are idempotent, so this self-heals across interpreter version bumps.

The second commit on that old branch (a no-op comment to force a launchd reload out of an exit-78 penalty box) is obsolete — the cluster-mode rename already changed every derived store path — and is dropped.

## Test plan

- `nix flake check` + `statix` pass locally.
- Runtime effect is on the cluster hosts at next activation; verify with `socketfilterfw --listapps | grep cpython` after rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rdwc5T5WAu4qoc3a3NzxkX