### PR TITLE
feat(packages): add entire CLI to core system packages

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -19,6 +19,7 @@ Source: `modules/darwin/common.nix`
 
 | Package | Description |
 | --- | --- |
+| entire | AI-session capture for git (records live agent sessions) |
 | git | Version control |
 | gnupg | GPG encryption and signing |
 | vim | Text editor |

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -64,6 +64,7 @@ in
     # ========================================================================
     # Core CLI tools (bootstrapping - needed before home-manager)
     # ========================================================================
+    entire # AI-session capture for git (records live agent sessions)
     git
     gnupg
     vim


### PR DESCRIPTION
## What

Adds `pkgs.entire` (AI-session capture for git) to `environment.systemPackages` next to the other bootstrapping CLI tools, plus the MANIFEST.md inventory row. Nixpkgs-first per repo policy — no homebrew, no overlay; the pinned nixpkgs currently resolves entire 0.6.2 (verified via `nix eval`).

Context: a 2026-07-15 Codex session planned exactly this change but its command bridge died before implementation. The earlier `feat/entire-pilot` PR #1626 (closed) was a different scope — enabling session capture in this repo — whereas this PR only installs the CLI system-wide.

## Test plan

- `nix flake check` passes locally.
- `nix eval .#darwinConfigurations.jevans-mbp.pkgs.entire.version` → `0.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rdwc5T5WAu4qoc3a3NzxkX