### PR TITLE
chore(deps): bump nix-ai to a998434 (vikunja via doppler-mcp)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,11 +916,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1784132121,
-        "narHash": "sha256-U1Wws5Wug4kAdONXqgAVK9B7B7cpvM/9y2qN2ELWqWQ=",
+        "lastModified": 1784220578,
+        "narHash": "sha256-h/zEVPvh2GBa5SGfaqlckKVUnb6mai0ZTX/VzaT15Us=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "0733be2639383c8d60997889c2c1baa539d93b11",
+        "rev": "a998434d9905e278e3b370dfb4c1b312842cacb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up dryvist/nix-ai#1241 so the vikunja MCP server launches with Doppler-injected credentials (`VIKUNJA_URL`/`VIKUNJA_API_TOKEN` from ai-ci-automation/prd). flake.lock-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoDD4HtJ5VD338N6CKEdxP