### PR TITLE
chore(deps): bump nix-ai for splunk-mcp-connect SC2016 fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,11 +916,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1784220578,
-        "narHash": "sha256-h/zEVPvh2GBa5SGfaqlckKVUnb6mai0ZTX/VzaT15Us=",
+        "lastModified": 1784221112,
+        "narHash": "sha256-TBpnuo99FL4QHzqQb0wIFgVDZZOWxd4Dzfxo9luOPtE=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "a998434d9905e278e3b370dfb4c1b312842cacb3",
+        "rev": "c7208cb5f7b011c2fc1bd3a49e19416c21050255",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up dryvist/nix-ai#1243, which unbreaks `darwin-rebuild` (SC2016 in splunk-mcp-connect at consumer build time, introduced by nix-ai#1230). Verified: full system derivation builds with this pin via --override-input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoDD4HtJ5VD338N6CKEdxP