### PR TITLE
fix(cluster): keep failed labels for retry on partial cluster-restore

### DIFF
--- a/hosts/common/scripts/cluster-restore.sh
+++ b/hosts/common/scripts/cluster-restore.sh
@@ -14,13 +14,30 @@ state_file="$HOME/Library/Application Support/mlx-cluster/quiesced-agents"
 }
 
 restored=0
+failed=""
 while IFS= read -r label; do
   [ -n "$label" ] || continue
   plist="$HOME/Library/LaunchAgents/$label.plist"
-  if [ -f "$plist" ] && launchctl bootstrap "gui/$uid" "$plist" 2> /dev/null; then
+  [ -f "$plist" ] || continue # uninstalled since the quiesce: skip silently
+  if launchctl bootstrap "gui/$uid" "$plist" 2> /dev/null; then
     restored=$((restored + 1))
+  elif launchctl print "gui/$uid/$label" > /dev/null 2>&1; then
+    # bootstrap refuses an already-loaded agent (e.g. a double restore):
+    # loaded is the goal state, count it restored.
+    restored=$((restored + 1))
+  else
+    failed="$failed$label"$'\n'
   fi
 done < "$state_file"
+
+if [ -n "$failed" ]; then
+  # Keep only the labels that failed to come back: deleting the whole record
+  # on a partial restore silently orphaned them with no retry path. A rerun
+  # of cluster-restore (or the next link-down tick) picks them up.
+  printf '%s' "$failed" > "$state_file"
+  echo "cluster-restore: bootstrapped $restored agents; kept $(printf '%s' "$failed" | grep -c .) failed labels for retry" >&2
+  exit 1
+fi
 
 rm -f "$state_file"
 echo "cluster-restore: bootstrapped $restored agents back"


### PR DESCRIPTION
## What

Cluster-audit follow-up (smallest of the batch). `cluster-restore.sh` deleted the quiesced-agents record unconditionally, so any agent whose `launchctl bootstrap` failed mid-loop was silently orphaned with no retry path.

- Only successfully restored labels leave the record; failures are written back to the state file, reported on stderr, and the script exits nonzero so a rerun (or the operator) picks them up.
- An agent that is already loaded counts as restored — `bootstrap` refuses those, and loaded is the goal state — so a double restore cannot wedge labels in the file.
- Known interaction, deliberate: a state file left non-empty by a failed restore makes the next `cluster-quiesce` report "already quiesced" and skip its sweep — that is the existing idempotence guard doing its job; the nonzero exit + stderr line is the signal to resolve the stragglers first.

## Verification

- `shellcheck` clean.
- Manual dry-run pair (`cluster-quiesce` → `cluster-restore`, no cable needed) is the documented pre-plug prep step and exercises the changed path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qDkR2rUedDgTVqEea6opu