### PR TITLE
chore(deps): bump ai-assistant-instructions and nix-ai for tiered stack

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,11 +916,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1784221112,
-        "narHash": "sha256-TBpnuo99FL4QHzqQb0wIFgVDZZOWxd4Dzfxo9luOPtE=",
+        "lastModified": 1784244662,
+        "narHash": "sha256-dOF1dZ7mW4v3fzV+8sb3K5XhZPhznTiCnI7XQ+/lIis=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c7208cb5f7b011c2fc1bd3a49e19416c21050255",
+        "rev": "a0bd3ec824f87b1db6b65200b0f67e406f012cde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up the tiered rule stack (#745) and nix-ai promotion. Rendered always-on core verified at 3837 body chars (gate max 4000). System build verified with darwin-rebuild build.