### PR TITLE
fix(mlx): remove the wedge trigger and guarantee recovery on the Macs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,11 +916,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1784244662,
-        "narHash": "sha256-dOF1dZ7mW4v3fzV+8sb3K5XhZPhznTiCnI7XQ+/lIis=",
+        "lastModified": 1784250875,
+        "narHash": "sha256-zK6bkqf39kmN8JTGPby2I/EDFQ+em4KXQTBjEo34jfM=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "a0bd3ec824f87b1db6b65200b0f67e406f012cde",
+        "rev": "fb2afdb5c054d3cb45e4234fdff35411fc7f25ff",
         "type": "github"
       },
       "original": {

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -63,6 +63,16 @@
       concurrencyLimit = 8;
     };
     autoUnloadIdleSeconds = 0;
+
+    # Applied to EVERY request so batches stay uniform. A penalty becomes a
+    # logits processor, and mlx_lm's batch generator dies on a batch that mixes
+    # requests carrying one with requests that do not — the wedge behind
+    # nix-ai#1234 (26916 crashes in this host's log). Router-side injection on a
+    # single alias produced exactly that mix against penalty-free health probes.
+    # Value matches what the router injected for ai-default; the uniformity is
+    # the point, not the number. Router-side injection can now be dropped.
+    defaultRepetitionPenalty = 1.05;
+
     # Resident brains warmed at boot: coder (coding) + stock 35B (tool-calling,
     # the ai-default fleet brain). gpt-oss + OptiQ omitted — swap-class above.
     preload = [

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -26,6 +26,13 @@
     cacheMemoryMb = 16384;
     prefillBatchSize = 2048;
 
+    # Same batch-uniformity guard as the serving host: a repetition penalty is
+    # a logits processor, and mlx_lm's batch generator dies on a batch mixing
+    # requests that carry one with requests that do not (nix-ai#1234). This dev
+    # sidecar sees ad-hoc callers with and without sampling params, which is the
+    # same mix — set it here too rather than wait to be surprised.
+    defaultRepetitionPenalty = 1.05;
+
     # Clustered mode: this Mac is rank 1 (worker) of the two-Mac JACCL cluster
     # when the Thunderbolt cable is in. The worker-side quiesce/restore hooks
     # (GUI quit + agent bootout allowlist sweep) are wired by


### PR DESCRIPTION
Bumps nix-ai (`c7208cb` → `fb2afdb`) for #1260 + #1262 and sets `defaultRepetitionPenalty` on both Macs. Together these remove the wedge **trigger** and guarantee **recovery** — they must land in one rebuild (see below).

## The wedge was never load flakiness

vllm-mlx turns a request's `repetition_penalty` into a logits processor; a penalty-free request gets `[]`. mlx_lm's `BatchedGenerator.extend` then pads processor-free entries with `None` instead of `[]`, and the decode step iterates it unconditionally:

```
for processor in self.logits_processors[e]:
TypeError: 'NoneType' object is not iterable
```

One penalized request beside one penalty-free request in the same batch kills the scheduler thread — every completion on that worker then hangs or returns empty until it is killed. **26,916 occurrences** in the serving host's log: the dominant failure mode, and it explains the "recurs under concurrency / both 35B twins / never self-recovers" pattern.

Our traffic hit it precisely: the router injects `repetition_penalty: 1.05` on `ai-default`, health probes send bare requests, continuous batching co-schedules them. **The monitoring was a trigger.**

`--default-repetition-penalty` gives every request a processor regardless of caller, so the mixed-batch path is unreachable — uniformity by construction rather than asking each client to remember. The MacBook gets it too: a dev sidecar sees the same ad-hoc mix of callers with and without sampling params.

## Why both halves ship together

#1260's watchdog probes a real completion every 60s. Deployed **without** #1262 that probe is penalty-free — i.e. a new wedge trigger. This PR is the first rebuild where both are present.

#1260 also fixes the other half: workers are spawned detached through `uv` (verified: a live worker's top process reports `PPID 1`), so a stopped proxy leaves the engine holding its port; every replacement dies on bind and the proxy 429s forever while `/v1/models` still answers 200 — **~1.5 h dark, no signal**, caused by `kickstart`, the wedge break-fix itself.

## Verification

- `nix build .#darwinConfigurations.jevans-ms.system` and `.jevans-mbp.system` both succeed. (This is what actually evaluates the mlx module — nix-ai's `flake check` reports `homeManagerModules` as unchecked.)
- The flag reaches the **generated llama-swap config**, not just the build — all 5 Studio models:

```
YES mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit
YES mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
YES mlx-community/Qwen3.6-35B-A3B-4bit
YES mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
YES mlx-community/gpt-oss-120b-MXFP4-Q8
```

- Mechanism confirmed by reading the installed `vllm_mlx`/`mlx_lm` sources, not inferred: `server.py:272` resolves the default when a request omits a penalty; `scheduler.py:~2046` builds the processors from it.

## After merge

`darwin-rebuild switch` on the serving host, confirm the launcher reaps and the watchdog probes a completion, then delete the temporary `/tmp` auto-heal and drop the router-side `extra_body` injection (now redundant).

Refs dryvist/nix-ai#1234.
