### PR TITLE
fix(cluster): guard alf-allow in postActivation (non-fatal)

### DIFF
--- a/modules/darwin/cluster-link-prep.nix
+++ b/modules/darwin/cluster-link-prep.nix
@@ -107,7 +107,7 @@ in
       } ${lib.getExe prepPkg} || echo "cluster-link-prep: non-fatal failure (see log above)"
       # The JACCL rendezvous listener needs an explicit application-firewall
       # allowance (uv CPython is ad-hoc-signed) — see scripts/cluster-alf-allow.sh.
-      CLUSTER_USER_HOME="${userConfig.user.homeDir}" ${lib.getExe alfAllowPkg}
+      CLUSTER_USER_HOME="${userConfig.user.homeDir}" ${lib.getExe alfAllowPkg} || echo "cluster-alf-allow: non-fatal failure (see log above)"
     '';
   };
 }


### PR DESCRIPTION
Review on promotion PR #1733 caught that `alfAllowPkg` lacks the `|| echo` guard its sibling `prepPkg` has, violating the block's own never-fail-activation contract. One-line guard.

Session: claude-mbp-03a3a401

🤖 Generated with [Claude Code](https://claude.com/claude-code)