### PR TITLE
chore: drop unnecessary braces from $GIT_HOME refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ pass before merge. You may run it locally to verify before pushing, but it is no
 ## Worktree Workflow
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin
+cd $GIT_HOME_PUBLIC/nix-darwin
 git fetch origin
 git worktree add <branch> -b <branch> origin/main
 cd <branch>

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ as flake inputs.
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/JacobPEvans/nix-darwin.git ${GIT_HOME_PUBLIC}/nix-darwin
-cd ${GIT_HOME_PUBLIC}/nix-darwin
+git clone https://github.com/JacobPEvans/nix-darwin.git $GIT_HOME_PUBLIC/nix-darwin
+cd $GIT_HOME_PUBLIC/nix-darwin
 
 # 2. Build and activate for the first time
 sudo darwin-rebuild switch --flake .

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -42,7 +42,7 @@ sudo darwin-rebuild switch --flake ~/.config/nix
 Or manually install hooks (if not using full rebuild):
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin
+cd $GIT_HOME_PUBLIC/nix-darwin
 pre-commit install
 ```
 

--- a/docs/boot-failure/permanent-fix.md
+++ b/docs/boot-failure/permanent-fix.md
@@ -182,7 +182,7 @@ is missing, along with a `nix-recover` helper function.
 After making these changes:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin
+cd $GIT_HOME_PUBLIC/nix-darwin
 git add modules/
 git commit -m "fix: multi-layered boot failure recovery"
 sudo darwin-rebuild switch --flake .

--- a/docs/investigations/current-system-symlink-issue.md
+++ b/docs/investigations/current-system-symlink-issue.md
@@ -222,7 +222,7 @@ work even if lsregister fails.
 To verify the fix works:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/nix-darwin/main
+cd $GIT_HOME_PUBLIC/nix-darwin/main
 sudo darwin-rebuild switch --flake .
 ```
 

--- a/hosts/common/macos-setup.zsh
+++ b/hosts/common/macos-setup.zsh
@@ -14,4 +14,4 @@ tabs -2
 # Clean up .DS_Store files in common directories.
 # Single find across all dirs; -exec rm {} + batches args for fewer rm invocations.
 # Runs in the background to avoid blocking shell startup.
-{ find ~/.config/ "${GIT_HOME}/" ~/obsidian/ -name ".DS_Store" -depth -exec rm {} + 2>/dev/null; } &!
+{ find ~/.config/ "$GIT_HOME/" ~/obsidian/ -name ".DS_Store" -depth -exec rm {} + 2>/dev/null; } &!

--- a/modules/darwin/finder.nix
+++ b/modules/darwin/finder.nix
@@ -38,7 +38,7 @@ _: {
 
     # Show full POSIX path in window title
     # Default: false
-    # Example: "${GIT_HOME}/project" instead of "project"
+    # Example: "$GIT_HOME/project" instead of "project"
     _FXShowPosixPathInTitle = true;
 
     # Default view style for new windows


### PR DESCRIPTION
Bare `$GIT_HOME` / `$GIT_HOME_PUBLIC` is valid standard bash in each of these — the next character is always a path separator or a quote, so the variable name terminates on its own and the braces add nothing.

Braces are deliberately kept wherever removing them would change meaning (`${VAR}_suffix`, `${VAR:-default}`, `${#VAR}`, `${VAR%.*}`); no such case exists in this repo.

**Verified** the two non-markdown files still parse:
- `modules/darwin/finder.nix` — `nix-instantiate --parse` OK. Its occurrence sits inside a `#` comment (Nix does not interpolate there), so it is inert either way — included because that comment documents this exact convention.
- `hosts/common/macos-setup.zsh` — `zsh -n` OK. `"$GIT_HOME/"` stays quoted, so word-splitting behaviour is unchanged.

Part of a workspace-wide convention cleanup; the canonical `~/git/AGENTS.md` path-variable table has been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)