### PR TITLE
fix(llm-gate): replace keychain secret-zero with 0600 env-file

### DIFF
--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -62,8 +62,8 @@ in
     # ========================================================================
     # Caddy terminates TLS on the LAN address and enforces the bearer token; the
     # model server stays on 127.0.0.1. Runs as a user LaunchAgent wrapped in
-    # `doppler run` — the bearer token, Route53 ACME creds, and region are pulled
-    # live from Doppler (never stored on this host or in sops; see llm-gate.nix).
+    # `openbao-run` — the bearer token, Route53 ACME creds, and region are pulled
+    # live from OpenBao (never stored on this host or in sops; see llm-gate.nix).
     # route53 mode issues a real Let's Encrypt cert via DNS-01, so the cert covers
     # both the host FQDN and the `llm-large` service alias below and SNI succeeds
     # for either name.

--- a/modules/darwin/apps/openbao-run.nix
+++ b/modules/darwin/apps/openbao-run.nix
@@ -5,9 +5,10 @@
 # same shape `doppler run -- <cmd>` provided. This removes the external Doppler
 # dependency from local serving components (starting with the llm-large gate).
 #
-# Secret-zero (BAO_ADDR + <DOMAIN>_VAULT_ROLE_ID/_SECRET_ID) is supplied
-# ambiently by the openbao keychain resolver; no fetched secret is written to
-# disk. `bao` (OpenBao CLI) comes from runtimeInputs.
+# Secret-zero (BAO_ADDR + <DOMAIN>_VAULT_ROLE_ID/_SECRET_ID) comes from the
+# ambient environment or a caller-supplied 0600 `--env-file` (unattended
+# agents); no keychain involvement, no fetched secret written to disk. `bao`
+# (OpenBao CLI) comes from runtimeInputs.
 {
   lib,
   config,

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -23,10 +23,13 @@
 #
 # User agent, not root daemon: the gated port is non-privileged, and the gate's
 # OpenBao secret-zero (BAO_ADDR + the llm-gate AppRole role_id/secret_id) lives
-# in an auto-readable login keychain (secretZeroKeychain), which unlocks at
-# login so the agent comes up unattended on boot. The keychain holds only a
-# pointer to OpenBao (the AppRole), never a copy of the secrets it fetches;
-# activation scripts (root, no keychain access) never touch it.
+# in a user-owned 0600 env file (secretZeroEnvFile) that openbao-run sources at
+# each (re)start — so the agent comes up unattended on boot with no keychain
+# and no ambient session. macOS keychains are banned from this path: only the
+# login keychain auto-unlocks at login, and a custom keychain starts locked in
+# every new security session, which made the previous keychain-based design
+# unable to ever start unattended (2026-07 outage). The env file holds only a
+# pointer to OpenBao (the AppRole), never a copy of the secrets it fetches.
 #
 # TLS modes:
 #   route53  — real Let's Encrypt cert via DNS-01 against the public zone,
@@ -192,19 +195,21 @@ in
     user = lib.mkOption {
       type = lib.types.str;
       default = userConfig.user.name;
-      description = "Login user that owns the agent, the data dir, and the secret-zero keychain (keychain auth is per-user; the gate runs as a user LaunchAgent).";
+      description = "Login user that owns the agent, the data dir, and the secret-zero env file (the gate runs as a user LaunchAgent).";
     };
 
-    secretZeroKeychain = lib.mkOption {
+    secretZeroEnvFile = lib.mkOption {
       type = lib.types.str;
-      default = "${userConfig.user.homeDir}/Library/Keychains/automation.keychain-db";
+      default = "${userConfig.user.homeDir}/.local/share/llm-gate/bootstrap.env";
       description = ''
-        Auto-readable keychain holding the gate's OpenBao secret-zero:
+        User-owned 0600 env file holding the gate's OpenBao secret-zero:
         BAO_ADDR and the llm-gate AppRole's LLM_GATE_VAULT_ROLE_ID /
-        LLM_GATE_VAULT_SECRET_ID. openbao-run reads these unattended at each
-        (re)start (env first, then this keychain) and logs in to fetch the
-        gate's secrets — no Doppler session, no password prompt (the keychain
-        unlocks at login). Replaces the per-user ~/.doppler service token.
+        LLM_GATE_VAULT_SECRET_ID. openbao-run sources it unattended at each
+        (re)start and logs in to fetch the gate's secrets — no Doppler
+        session, no keychain (keychains cannot auto-unlock unattended; see
+        header). Seeded out-of-band over ssh; openbao-run refuses the file
+        unless its mode is exactly 0600. Rotation = rewrite the file, restart
+        the agent.
       '';
     };
 
@@ -245,8 +250,8 @@ in
         (lib.getExe config.programs.openbao-run.package)
         "--domain"
         "llm-gate"
-        "--keychain"
-        cfg.secretZeroKeychain
+        "--env-file"
+        cfg.secretZeroEnvFile
       ]
       ++ lib.optionals (cfg.tlsMode == "route53") [
         "--secret"
@@ -272,8 +277,8 @@ in
       WorkingDirectory = cfg.dataDir;
       EnvironmentVariables = {
         # Caddy's storage is pinned under the gate dir via XDG below. HOME is
-        # kept for tools that expect it; openbao-run reads its secret-zero
-        # keychain by absolute path, so it needs no ~/.doppler session.
+        # kept for tools that expect it; openbao-run sources its secret-zero
+        # env file by absolute path, so it needs no ~/.doppler session.
         HOME = userConfig.user.homeDir;
         XDG_DATA_HOME = "${cfg.dataDir}/data";
         XDG_CONFIG_HOME = "${cfg.dataDir}/config";

--- a/modules/darwin/scripts/openbao-run.sh
+++ b/modules/darwin/scripts/openbao-run.sh
@@ -4,13 +4,19 @@
 # Fetches named secrets from OpenBao via an AppRole login and execs a command
 # with them injected as environment variables - exactly what `doppler run` did,
 # with no external dependency. Secret-zero (the OpenBao address + a domain
-# AppRole's role_id/secret_id) is read from the AMBIENT ENVIRONMENT, published
-# per-domain by the openbao keychain resolver (launchctl setenv
-# <DOMAIN>_VAULT_ROLE_ID / _SECRET_ID). No fetched secret is ever written to
-# disk; the values live only in the environment of the exec'd child.
+# AppRole's role_id/secret_id) is read from the AMBIENT ENVIRONMENT first; for
+# unattended launchd agents with no ambient session, `--env-file` names a
+# 0600 user-owned file sourced before resolution. macOS keychains are NOT a
+# secret-zero path: only the login keychain auto-unlocks at login, and custom
+# keychains start locked in every new security session, so a keychain-backed
+# agent can never start unattended (the 2026-07 llm-gate outage; the old
+# `--keychain` flag was removed for exactly that reason). No fetched secret is
+# ever written to disk; the values live only in the environment of the exec'd
+# child.
 #
 # Usage:
 #   openbao-run --domain local-llm \
+#     [--env-file <0600-path>] \
 #     --secret ENV_NAME=<kv-path>#<field> [--secret ...] \
 #     -- <command> [args...]
 #
@@ -32,7 +38,7 @@ die() {
 }
 
 domain=""
-keychain=""
+env_file=""
 declare -a specs=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -40,8 +46,8 @@ while [ "$#" -gt 0 ]; do
       domain="${2:?--domain needs a value}"
       shift 2
       ;;
-    --keychain)
-      keychain="${2:?--keychain needs a path}"
+    --env-file)
+      env_file="${2:?--env-file needs a path}"
       shift 2
       ;;
     --secret)
@@ -52,7 +58,7 @@ while [ "$#" -gt 0 ]; do
       shift
       break
       ;;
-    *) die "unknown argument: $1 (expected --domain, --keychain, --secret, or --)" ;;
+    *) die "unknown argument: $1 (expected --domain, --env-file, --secret, or --)" ;;
   esac
 done
 
@@ -60,25 +66,33 @@ done
 [ "${#specs[@]}" -gt 0 ] || die "no --secret mappings given"
 [ "$#" -gt 0 ] || die "no command after -- to exec"
 
-# Secret-zero resolution: env first (for interactive/CI callers), then the
-# macOS keychain (for unattended launchd agents with no Doppler session). The
-# keychain is the doppler-free delivery: an auto-readable keychain unlocks at
-# login, so `security find-generic-password -s <name> -w <keychain>` returns
-# the value with no password prompt. `security` is hardcoded to its system path
-# (not a nixpkgs package).
+# Secret-zero env file: sourced before resolution so unattended launchd agents
+# get their bootstrap (BAO_ADDR + AppRole creds) with no keychain and no
+# ambient session. Must be user-owned 0600 — refuse anything looser, since the
+# file authenticates to OpenBao.
+if [ -n "$env_file" ]; then
+  [ -f "$env_file" ] || die "--env-file '$env_file' does not exist (seed it: BAO_ADDR + <DOMAIN>_VAULT_ROLE_ID/_SECRET_ID)"
+  perms="$(/usr/bin/stat -f '%Lp' "$env_file")"
+  [ "$perms" = "600" ] || die "--env-file '$env_file' must be mode 0600 (is $perms)"
+  set -a
+  # shellcheck source=/dev/null
+  . "$env_file"
+  set +a
+fi
+
+# Secret-zero resolution: the environment (ambient for interactive/CI callers,
+# or populated by the --env-file source above for unattended agents).
 resolve() {
-  local name="$1" val
-  val="$(printenv "$name" 2>/dev/null || true)"
-  if [ -z "$val" ] && [ -n "$keychain" ]; then
-    val="$(/usr/bin/security find-generic-password -s "$name" -w "$keychain" 2>/dev/null || true)"
-  fi
-  printf '%s' "$val"
+  printenv "$1" 2>/dev/null || true
 }
+
+src="environment"
+[ -n "$env_file" ] && src="environment or env file $env_file"
 
 # OpenBao address: honor either the OpenBao-native or the legacy Vault name.
 addr="$(resolve BAO_ADDR)"
 [ -n "$addr" ] || addr="$(resolve VAULT_ADDR)"
-[ -n "$addr" ] || die "BAO_ADDR not in environment or keychain '$keychain'"
+[ -n "$addr" ] || die "BAO_ADDR not in $src"
 
 # This domain's AppRole role_id/secret_id, named e.g. LLM_GATE_VAULT_ROLE_ID
 # (domain uppercased, - -> _).
@@ -86,8 +100,8 @@ env_prefix="${domain^^}"
 env_prefix="${env_prefix//-/_}"
 role_id="$(resolve "${env_prefix}_VAULT_ROLE_ID")"
 secret_id="$(resolve "${env_prefix}_VAULT_SECRET_ID")"
-[ -n "$role_id" ] || die "${env_prefix}_VAULT_ROLE_ID not in environment or keychain '$keychain'"
-[ -n "$secret_id" ] || die "${env_prefix}_VAULT_SECRET_ID not in environment or keychain '$keychain'"
+[ -n "$role_id" ] || die "${env_prefix}_VAULT_ROLE_ID not in $src"
+[ -n "$secret_id" ] || die "${env_prefix}_VAULT_SECRET_ID not in $src"
 
 export BAO_ADDR="$addr"
 


### PR DESCRIPTION
## What

- `openbao-run`: new `--env-file <path>` — sources a user-owned env file (refused unless mode 0600) before secret-zero resolution; removes `--keychain` and the keychain fallback entirely (llm-gate was its only caller).
- `llm-gate.nix`: `secretZeroKeychain` → `secretZeroEnvFile` (default `~/.local/share/llm-gate/bootstrap.env`, inside the 0700 dataDir); LaunchAgent passes `--env-file`.
- Comment fixes: module header describes the env-file contract; mac-studio host comment no longer claims Doppler.

## Why

The gate could never start unattended: macOS auto-unlocks only the login keychain, and the custom automation keychain starts locked in every new security session — a design flaw that kept the gate crash-looping after any reboot and made remote seeding impossible. Secret-zero now follows the sanctioned no-keychain pattern (env / 0600 file → OpenBao AppRole). The env file holds only the AppRole pointer, never fetched secrets; rotation = rewrite file + restart agent.

## Verification

- shellcheck clean.
- Functional test: 0644 file refused with explicit error; 0600 file sourced, resolution proceeds to AppRole login.
- `nix-instantiate --parse` clean on both modules.
- Live verification (gate serves externally) happens at deploy on the Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)