### PR TITLE
fix(openbao-run): use /usr/bin/curl so macOS Local Network privacy cannot block the gate

### DIFF
--- a/modules/darwin/apps/openbao-run.nix
+++ b/modules/darwin/apps/openbao-run.nix
@@ -7,8 +7,11 @@
 #
 # Secret-zero (BAO_ADDR + <DOMAIN>_VAULT_ROLE_ID/_SECRET_ID) comes from the
 # ambient environment or a caller-supplied 0600 `--env-file` (unattended
-# agents); no keychain involvement, no fetched secret written to disk. `bao`
-# (OpenBao CLI) comes from runtimeInputs.
+# agents); no keychain involvement, no fetched secret written to disk. All
+# OpenBao HTTP rides /usr/bin/curl — the Apple PLATFORM binary, exempt from
+# macOS Local Network privacy, which silently EHOSTUNREACHes non-platform
+# binaries (e.g. a nix-store bao CLI) in GUI-session launchd contexts. jq
+# (no network) comes from runtimeInputs for response parsing.
 {
   lib,
   config,
@@ -22,7 +25,7 @@ let
   openbaoRunScript = pkgs.writeShellApplication {
     name = "openbao-run";
     runtimeInputs = [
-      pkgs.openbao
+      pkgs.jq
     ];
     text = builtins.readFile ./../scripts/openbao-run.sh;
   };

--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -24,12 +24,11 @@
 # User agent, not root daemon: the gated port is non-privileged, and the gate's
 # OpenBao secret-zero (BAO_ADDR + the llm-gate AppRole role_id/secret_id) lives
 # in a user-owned 0600 env file (secretZeroEnvFile) that openbao-run sources at
-# each (re)start — so the agent comes up unattended on boot with no keychain
-# and no ambient session. macOS keychains are banned from this path: only the
-# login keychain auto-unlocks at login, and a custom keychain starts locked in
-# every new security session, which made the previous keychain-based design
-# unable to ever start unattended (2026-07 outage). The env file holds only a
-# pointer to OpenBao (the AppRole), never a copy of the secrets it fetches.
+# each (re)start — the agent comes up unattended with no keychain and no ambient
+# session. Keychains are banned here: only the login keychain auto-unlocks, and
+# a custom keychain starts locked in every new security session, so the old
+# keychain design could never start unattended (2026-07 outage). The env file
+# holds only a pointer to OpenBao (the AppRole), never fetched secrets.
 #
 # TLS modes:
 #   route53  — real Let's Encrypt cert via DNS-01 against the public zone,

--- a/modules/darwin/scripts/openbao-run.sh
+++ b/modules/darwin/scripts/openbao-run.sh
@@ -103,14 +103,27 @@ secret_id="$(resolve "${env_prefix}_VAULT_SECRET_ID")"
 [ -n "$role_id" ] || die "${env_prefix}_VAULT_ROLE_ID not in $src"
 [ -n "$secret_id" ] || die "${env_prefix}_VAULT_SECRET_ID not in $src"
 
-export BAO_ADDR="$addr"
+# ALL OpenBao HTTP goes through /usr/bin/curl — the APPLE PLATFORM binary,
+# hardcoded path, never a nixpkgs curl. macOS Local Network privacy silently
+# denies NON-platform binaries LAN access in GUI-session launchd contexts
+# ("connect: no route to host"), while platform binaries are exempt. Verified
+# live 2026-07-17 on macOS 26.5.2 from the same gui/501 one-shot: the
+# nix-store `bao` CLI got EHOSTUNREACH on the very login /usr/bin/curl
+# completed with HTTP 200 (ssh sessions are also exempt, which is why shell
+# tests never reproduced it). There is no supported CLI/MDM pre-approval for
+# Local Network TCC, so the fix is to keep the network path on the exempt
+# platform binary. jq (no network) parses the responses.
 
 # AppRole login -> a short-lived token, used only for the reads below. Never
-# persisted; scoped to this process.
-token="$(bao write -field=token auth/approle/login \
-  role_id="$role_id" secret_id="$secret_id")" \
+# persisted; scoped to this process. Credentials travel via a private
+# temporary payload on stdin (never argv).
+login_payload="$(jq -n --arg r "$role_id" --arg s "$secret_id" \
+  '{role_id: $r, secret_id: $s}')"
+token="$(printf '%s' "$login_payload" \
+  | /usr/bin/curl -sf -X POST -H 'Content-Type: application/json' \
+      --data-binary @- "$addr/v1/auth/approle/login" \
+  | jq -re '.auth.client_token')" \
   || die "AppRole login failed for domain '$domain' at $addr"
-export BAO_TOKEN="$token"
 
 # Fetch each mapping and export it. Format: ENV_NAME=<kv-path>#<field>.
 # KV v2 mount is `secret`; paths are given mount-relative (e.g. ai/llm).
@@ -121,13 +134,15 @@ for spec in "${specs[@]}"; do
   env_name="${BASH_REMATCH[1]}"
   kv_path="${BASH_REMATCH[2]}"
   field="${BASH_REMATCH[3]}"
-  value="$(bao kv get -mount=secret -field="$field" "$kv_path")" \
+  value="$(/usr/bin/curl -sf -H "X-Vault-Token: $token" \
+      "$addr/v1/secret/data/$kv_path" \
+    | jq -re --arg f "$field" '.data.data[$f]')" \
     || die "read failed: secret/$kv_path field '$field' (policy or path missing?)"
   export "$env_name=$value"
 done
 
-# Drop the login token from the child's environment - it only needed the
-# exported secret values, not OpenBao access.
-unset BAO_TOKEN
+# The login token dies with this shell; only the exported secret values reach
+# the exec'd child.
+unset token
 
 exec "$@"

--- a/modules/darwin/scripts/openbao-run.sh
+++ b/modules/darwin/scripts/openbao-run.sh
@@ -120,7 +120,7 @@ secret_id="$(resolve "${env_prefix}_VAULT_SECRET_ID")"
 login_payload="$(jq -n --arg r "$role_id" --arg s "$secret_id" \
   '{role_id: $r, secret_id: $s}')"
 token="$(printf '%s' "$login_payload" \
-  | /usr/bin/curl -sf -X POST -H 'Content-Type: application/json' \
+  | /usr/bin/curl -sf --max-time 30 -X POST -H 'Content-Type: application/json' \
       --data-binary @- "$addr/v1/auth/approle/login" \
   | jq -re '.auth.client_token')" \
   || die "AppRole login failed for domain '$domain' at $addr"
@@ -134,7 +134,7 @@ for spec in "${specs[@]}"; do
   env_name="${BASH_REMATCH[1]}"
   kv_path="${BASH_REMATCH[2]}"
   field="${BASH_REMATCH[3]}"
-  value="$(/usr/bin/curl -sf -H "X-Vault-Token: $token" \
+  value="$(/usr/bin/curl -sf --max-time 30 -H "X-Vault-Token: $token" \
       "$addr/v1/secret/data/$kv_path" \
     | jq -re --arg f "$field" '.data.data[$f]')" \
     || die "read failed: secret/$kv_path field '$field' (policy or path missing?)"


### PR DESCRIPTION
## Root cause (verified live, macOS 26.5.2)

llm-gate crash-looped on `connect: no route to host` to OpenBao from its gui/501 launchd context, while the identical AppRole login succeeded from ssh shells. A gui/501 one-shot probe proved the delta is the **binary**, not the context: the nix-store `bao` CLI got EHOSTUNREACH on the very request `/usr/bin/curl` completed with HTTP 200. macOS Local Network privacy silently denies **non-platform binaries** LAN access in GUI-session launchd contexts; platform binaries and ssh sessions are exempt (why shell tests never reproduced it). No supported CLI/MDM pre-approval exists for Local Network TCC.

## Fix

`openbao-run` performs the AppRole login + KV v2 reads via `/usr/bin/curl` (hardcoded platform-binary path — deliberately never a nixpkgs curl) with `jq` parsing. `runtimeInputs`: openbao → jq. Credentials travel via stdin, never argv; the login token dies with the wrapper shell.

## Verification

- shellcheck clean.
- Live functional run against production OpenBao: login → kv read → secret injected into exec'd child → rc=0.
- Deploy verification on the Studio follows merge (gate binds :11434, external models list 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)