### PR TITLE
feat(cluster): supervised re-enable of two-Mac JACCL clustered mode

### DIFF
--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -88,11 +88,12 @@
     # link watcher quiesces normal serving at link-up and re-warms the preload
     # list on unplug.
     clusterMode = {
-      # DISABLED 2026-07-12: boot-time auto-bring-up panicked both hosts
-      # (WindowServer starvation under the shard's wired load). Re-enable
-      # together with the worker, in a supervised session, now that the
-      # link-state wired ceiling (clusterLinkPrep.clusterWiredLimitMb) exists.
-      enable = false;
+      # RE-ENABLED 2026-07-18 in the supervised session the 2026-07-12
+      # disable note called for (boot-time auto-bring-up had panicked both
+      # hosts via WindowServer starvation; the link-state wired ceiling —
+      # clusterLinkPrep.clusterWiredLimitMb — now bounds the shard's wired
+      # load). Enabled together with the worker (lib/hosts/macbook-m4.nix).
+      enable = true;
       role = "coordinator";
       # Explicit cluster model, identical on both ranks. The expert-pruned
       # REAP-50 build (~98 GB, glm4_moe) halves the per-rank shard to ~49 GB

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -38,12 +38,13 @@
     # (GUI quit + agent bootout allowlist sweep) are wired by
     # hosts/common/cluster-quiesce.nix. Day config above is untouched.
     clusterMode = {
-      # DISABLED 2026-07-12: the boot-time watcher auto-started a rank whose
-      # ~99 GB wired shard starved WindowServer into a watchdog kernel panic
-      # on both hosts. Re-enable only together with the coordinator, in a
-      # supervised session, now that the link-state wired ceiling
-      # (clusterLinkPrep.clusterWiredLimitMb) exists.
-      enable = false;
+      # RE-ENABLED 2026-07-18 in the supervised session the 2026-07-12
+      # disable note called for (the boot-time watcher had auto-started a
+      # rank whose ~99 GB wired shard starved WindowServer into a watchdog
+      # kernel panic on both hosts; clusterLinkPrep.clusterWiredLimitMb now
+      # bounds the wired load, and the REAP-50 build halves the shard).
+      # Enabled together with the coordinator (lib/hosts/mac-studio.nix).
+      enable = true;
       role = "worker";
       # Explicit cluster model, identical on both ranks — see the coordinator
       # block (lib/hosts/mac-studio.nix) for the sizing rationale.


### PR DESCRIPTION
Flips `clusterMode.enable` to true on BOTH hosts (coordinator = mac-studio, worker = macbook-m4) — the paired re-enable the 2026-07-12 disable comments called for, executed in a supervised session.

Preconditions verified live tonight:
- Thunderbolt link UP at 80 Gb/s in both directions (Studio ↔ MacBook).
- `clusterLinkPrep.clusterWiredLimitMb` exists (the WindowServer-starvation mitigation).
- Cluster model `mlx-community/GLM-4.7-REAP-50-mxfp4` (~49 GB/rank shard) present on both HF volumes (Studio's final shards completing).
- RDMA enabled on both Macs (2026-07-16).

Deploy: merge → rebuild BOTH hosts → the link watchers detect the already-up cable, quiesce normal serving, and start the ranks; supervised memory watch during first load; verify rank-0 :11440 loopback + the gate's TLS :11440 site with a real completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)