### PR TITLE
fix(security): unset AppRole bootstrap creds before exec + un-silence diagnostics

### DIFF
--- a/modules/darwin/llm-gate.nix
+++ b/modules/darwin/llm-gate.nix
@@ -201,13 +201,13 @@ in
       type = lib.types.str;
       default = "${userConfig.user.homeDir}/.local/share/llm-gate/bootstrap.env";
       description = ''
-        User-owned 0600 env file holding the gate's OpenBao secret-zero:
+        User-owned 0600 or 0400 env file holding the gate's OpenBao secret-zero:
         BAO_ADDR and the llm-gate AppRole's LLM_GATE_VAULT_ROLE_ID /
         LLM_GATE_VAULT_SECRET_ID. openbao-run sources it unattended at each
         (re)start and logs in to fetch the gate's secrets — no Doppler
         session, no keychain (keychains cannot auto-unlock unattended; see
         header). Seeded out-of-band over ssh; openbao-run refuses the file
-        unless its mode is exactly 0600. Rotation = rewrite the file, restart
+        unless its mode is 0600 or 0400. Rotation = rewrite the file, restart
         the agent.
       '';
     };

--- a/modules/darwin/scripts/cluster-link-prep.sh
+++ b/modules/darwin/scripts/cluster-link-prep.sh
@@ -76,7 +76,12 @@ while IFS= read -r tb_dev; do
     # from a SIBLING port can drop the shared connected route out from under
     # this one (observed 2026-07-18 — traffic then fell through to the
     # default route on an unrelated NIC). Delete+add restores the route.
-    $has_ip && /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete
+    # Guarded so a transient delete failure neither aborts the script under
+    # an inherited `set -e` nor skips the alias re-add below.
+    if $has_ip; then
+      /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete \
+        || echo "$prefix WARN failed to delete $CLUSTER_LINK_IP from $tb_dev before re-add" >&2
+    fi
     if /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" netmask 255.255.255.0 alias; then
       echo "$prefix set $CLUSTER_LINK_IP on $tb_dev (carrier active)"
     else

--- a/modules/darwin/scripts/cluster-link-prep.sh
+++ b/modules/darwin/scripts/cluster-link-prep.sh
@@ -76,14 +76,14 @@ while IFS= read -r tb_dev; do
     # from a SIBLING port can drop the shared connected route out from under
     # this one (observed 2026-07-18 — traffic then fell through to the
     # default route on an unrelated NIC). Delete+add restores the route.
-    $has_ip && /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete 2>/dev/null
-    if /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" netmask 255.255.255.0 alias 2>/dev/null; then
+    $has_ip && /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete
+    if /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" netmask 255.255.255.0 alias; then
       echo "$prefix set $CLUSTER_LINK_IP on $tb_dev (carrier active)"
     else
       echo "$prefix WARN failed to set $CLUSTER_LINK_IP on $tb_dev" >&2
     fi
   elif ! $is_active && $has_ip; then
-    if /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete 2>/dev/null; then
+    if /sbin/ifconfig "$tb_dev" inet "$CLUSTER_LINK_IP" delete; then
       echo "$prefix removed $CLUSTER_LINK_IP from $tb_dev (no carrier)"
     else
       echo "$prefix WARN failed to remove $CLUSTER_LINK_IP from $tb_dev" >&2

--- a/modules/darwin/scripts/openbao-run.sh
+++ b/modules/darwin/scripts/openbao-run.sh
@@ -68,12 +68,12 @@ done
 
 # Secret-zero env file: sourced before resolution so unattended launchd agents
 # get their bootstrap (BAO_ADDR + AppRole creds) with no keychain and no
-# ambient session. Must be user-owned 0600 — refuse anything looser, since the
-# file authenticates to OpenBao.
+# ambient session. Must be user-owned 0600 or 0400 — refuse anything looser,
+# since the file authenticates to OpenBao.
 if [ -n "$env_file" ]; then
   [ -f "$env_file" ] || die "--env-file '$env_file' does not exist (seed it: BAO_ADDR + <DOMAIN>_VAULT_ROLE_ID/_SECRET_ID)"
   perms="$(/usr/bin/stat -f '%Lp' "$env_file")"
-  [ "$perms" = "600" ] || die "--env-file '$env_file' must be mode 0600 (is $perms)"
+  [ "$perms" = "600" ] || [ "$perms" = "400" ] || die "--env-file '$env_file' must be mode 0600 or 0400 (is $perms)"
   set -a
   # shellcheck source=/dev/null
   . "$env_file"
@@ -120,7 +120,7 @@ secret_id="$(resolve "${env_prefix}_VAULT_SECRET_ID")"
 login_payload="$(jq -n --arg r "$role_id" --arg s "$secret_id" \
   '{role_id: $r, secret_id: $s}')"
 token="$(printf '%s' "$login_payload" \
-  | /usr/bin/curl -sf --max-time 30 -X POST -H 'Content-Type: application/json' \
+  | /usr/bin/curl -sSf --max-time 30 -X POST -H 'Content-Type: application/json' \
       --data-binary @- "$addr/v1/auth/approle/login" \
   | jq -re '.auth.client_token')" \
   || die "AppRole login failed for domain '$domain' at $addr"
@@ -134,15 +134,15 @@ for spec in "${specs[@]}"; do
   env_name="${BASH_REMATCH[1]}"
   kv_path="${BASH_REMATCH[2]}"
   field="${BASH_REMATCH[3]}"
-  value="$(/usr/bin/curl -sf --max-time 30 -H "X-Vault-Token: $token" \
+  value="$(/usr/bin/curl -sSf --max-time 30 -H "X-Vault-Token: $token" \
       "$addr/v1/secret/data/$kv_path" \
     | jq -re --arg f "$field" '.data.data[$f]')" \
     || die "read failed: secret/$kv_path field '$field' (policy or path missing?)"
   export "$env_name=$value"
 done
 
-# The login token dies with this shell; only the exported secret values reach
-# the exec'd child.
-unset token
+# The login token and AppRole bootstrap creds die with this shell; only the
+# exported secret values (from the loop above) reach the exec'd child.
+unset token "${env_prefix}_VAULT_ROLE_ID" "${env_prefix}_VAULT_SECRET_ID"
 
 exec "$@"


### PR DESCRIPTION
## Summary

Fixes all 7 gemini-code-assist findings raised on the develop→main promotion PR (#1751).

- **openbao-run.sh** (security-high): `set -a`-sourced env-file variables
  (the domain's AppRole `ROLE_ID`/`SECRET_ID`) were never unset before
  `exec "$@"`, so bootstrap credentials leaked into the exec'd child's
  (e.g. Caddy's) environment. Now unset alongside the login token.
- **openbao-run.sh**: env-file permission check now accepts `0600` or
  `0400` (read-only is a stricter, legitimate mode) instead of requiring
  exactly `0600`.
- **llm-gate.nix**: `secretZeroEnvFile` doc string updated to match the
  0600/0400 behavior above.
- **openbao-run.sh** (x2): AppRole login and secret-fetch `curl` calls use
  `-sSf` instead of `-sf`, so failures print to stderr instead of dying
  silently.
- **cluster-link-prep.sh** (x2): removed `2>/dev/null` from the `ifconfig`
  alias/delete calls so diagnostics reach the logs. The delete+re-add
  re-plumbing and carrier-active-port-only aliasing semantics (the live-
  verified #1750 fix) are unchanged — only the stderr silencing is removed.

## Test plan

- [x] `bash -n` on both modified scripts
- [x] `shellcheck` on both modified scripts (clean)
- [x] `nix fmt -- --fail-on-change` on modified files (clean)
- [x] `statix check` / `deadnix` on modified nix file (clean)
- [x] pre-commit hooks passed on commit
- [ ] CI (Nix Build / Nix Validate / OSV / CodeQL)