### PR TITLE
docs(cluster): sync cluster docs with shipped #1746/#1747/#1750

### DIFF
--- a/docs/CLUSTER_MODE.md
+++ b/docs/CLUSTER_MODE.md
@@ -9,7 +9,7 @@ is the entire ceremony; unplugging reverses everything unattended.
 > `programs.mlx.clusterMode.enable = true` shipped for coordinator and worker
 > together in the supervised re-enable session (#1746) the 2026-07-12 disable
 > note called for. The wired-headroom mitigation is live:
-> `clusterLinkPrep.clusterWiredLimitMb` caps each rank's `iogpu.wired_limit_mb`
+> `system.clusterLinkPrep.clusterWiredLimitMb` caps each rank's `iogpu.wired_limit_mb`
 > before the rank starts (90000 MB coordinator / 80000 MB worker), bounding
 > the shard's wired load instead of leaving it uncapped the way the
 > 2026-07-12 panic did. RDMA is enabled on both Macs (`rdma_ctl status` →

--- a/docs/CLUSTER_MODE.md
+++ b/docs/CLUSTER_MODE.md
@@ -5,13 +5,21 @@ One Thunderbolt 5 cable turns the two M4 Max / 128 GB Macs into a single
 hold alone — and the rest of the fabric never notices the seam. Plugging in
 is the entire ceremony; unplugging reverses everything unattended.
 
-> **STATUS (2026-07-16): clustered mode is DISABLED on both hosts.** The
-> 2026-07-12 boot-time auto-bring-up wired a ~99 GB rank shard and starved
-> WindowServer into a watchdog kernel panic on both Macs. Re-enable
-> `programs.mlx.clusterMode.enable` only together with a wired-headroom
-> mitigation that provably leaves the GUI working set unwirable, and only in a
-> supervised session. RDMA itself is ready: `rdma_ctl` reports `enabled` on
-> both Macs (Recovery step completed 2026-07-16).
+> **STATUS (2026-07-18): clustered mode is ENABLED on both hosts.**
+> `programs.mlx.clusterMode.enable = true` shipped for coordinator and worker
+> together in the supervised re-enable session (#1746) the 2026-07-12 disable
+> note called for. The wired-headroom mitigation is live:
+> `clusterLinkPrep.clusterWiredLimitMb` caps each rank's `iogpu.wired_limit_mb`
+> before the rank starts (90000 MB coordinator / 80000 MB worker), bounding
+> the shard's wired load instead of leaving it uncapped the way the
+> 2026-07-12 panic did. RDMA is enabled on both Macs (`rdma_ctl status` →
+> `enabled`, 2026-07-16) and the Thunderbolt link is verified up at 80 Gb/s in
+> both directions (full TB5 symmetric speed). The link-IP assignment
+> mechanism changed in #1747/#1750 — see
+> [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md) for the corrected mechanism.
+> **Known gap:** the link watcher's readiness check is a one-shot latch with
+> no post-start hang detection on the worker, so a mid-generation wedge on
+> either rank can run silently — tracked in nix-ai#1275 (open).
 
 Component map (all IaC):
 
@@ -35,21 +43,31 @@ SSH orchestration. `--pipeline` is required: the pinned mlx-lm ships
 on an mlx-lm bump.
 
 Link identity: **role-derived synthetic IPv4** addresses
-(`clusterMode.staticLinkIps`), applied statically at activation — the
-Thunderbolt Bridge network service is disabled and every physical Thunderbolt
-port's service carries the same manual role address, so whichever port the
-cable lands in has the address with zero runtime logic. IPv6 link-local was
-validated 2026-07-11 and REJECTED — the pinned mlx-lm's JACCL rendezvous
-parser is IPv4-only.
+(`clusterMode.staticLinkIps`), applied by root postActivation
+(`system.clusterLinkPrep`) on every boot and rebuild — not a one-time
+activation step and not a SystemConfiguration network service. macOS 26
+cannot create per-port Thunderbolt network services at all
+(`networksetup -createnetworkservice` fails as root with "Unable to access
+the System Configuration database", #1750), so the link IPv4 goes directly on
+the carrier-active physical Thunderbolt device via `ifconfig alias`; the
+Thunderbolt Bridge service is still disabled and swept out of `bridge0`
+first. Whichever port the cable lands in gets the address on the next prep
+run — see [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md) for the full mechanism.
+IPv6 link-local was validated 2026-07-11 and REJECTED — the pinned mlx-lm's
+JACCL rendezvous parser is IPv4-only.
 
-**Cluster model**: `GLM-4.7-4bit` (352.8B, 198 GB — `glm4_moe`). It is the
-only frontier-class (>128 GB) architecture with distributed support in the
-pinned mlx-lm. Qwen3-235B (`qwen3_moe`) and Qwen3.5-397B (`qwen3_5_moe`) have
-**no** shard/pipeline support upstream yet (ml-explore/mlx-lm#1138 stale since
-April 2026) — recheck before every bench session; either landing would make a
-strong head-to-head candidate. `GLM-4.7-REAP-50-mxfp4` (98.2 GB, same
-`glm4_moe` arch, ~49 GB/rank) is the memory-safe candidate while the
-wired-headroom mitigation is unproven.
+**Cluster model**: `GLM-4.7-REAP-50-mxfp4` (98.2 GB, `glm4_moe`, ~49 GB/rank)
+is the confirmed production model as of #1746 — the expert-pruned build
+halves the per-rank shard so it fits under the wired ceiling with real KV
+headroom. The full `GLM-4.7-4bit` (352.8B, 198 GB) remains the module default
+(`programs.mlx.clusterMode.model`) and the only other frontier-class
+(>128 GB) architecture with distributed support in the pinned mlx-lm, but
+both hosts explicitly override it to REAP-50; running the full weights would
+need the wired ceiling re-validated for the larger shard. Qwen3-235B
+(`qwen3_moe`) and Qwen3.5-397B (`qwen3_5_moe`) have **no** shard/pipeline
+support upstream yet (ml-explore/mlx-lm#1138 stale since April 2026) —
+recheck before every bench session; either landing would make a strong
+head-to-head candidate.
 
 ## One-time prep (BEFORE the first plug session — no cable needed)
 
@@ -68,16 +86,16 @@ wired-headroom mitigation is unproven.
    `launchctl print gui/$UID/dev.mlx-cluster.watcher` exists on both and the
    rank agent is idle (link down → watcher no-ops).
 
-The first supervised session runs the
-[first-plug validation checklist](FIRST-PLUG-VALIDATION.md) and records each
-observed result there; `programs.mlx.clusterMode.enable` stays `false` until
-that list is green.
+The supervised first-plug session ran 2026-07-17/18 and is recorded in
+[FIRST-PLUG-VALIDATION.md](FIRST-PLUG-VALIDATION.md);
+`programs.mlx.clusterMode.enable` is `true` on both hosts as of #1746.
 
 ## Plug-session checklist (execution only — zero code)
 
-1. No manual IP step: activation already disabled the Thunderbolt Bridge
-   service and pinned this host's role link address on every Thunderbolt
-   port.
+1. No manual IP step: `cluster-link-prep` already disabled the Thunderbolt
+   Bridge service and pinned this host's role link address on the
+   carrier-active Thunderbolt device via `ifconfig alias` (reruns every boot
+   and rebuild — see [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md)).
 2. Cable #1 in (the RDMA rail). Verify: `ibv_devices` shows the device on
    both; note the real device name and correct
    `programs.mlx.clusterMode.rdmaDevice` per host if it differs from the
@@ -141,3 +159,8 @@ test once and record the result here.
   quiesce-violation (unexpected agent during a cluster window).
 - The memory-headroom alert and verdict-maturity benchmarking extend to the
   cluster brain unchanged.
+- **Known gap (nix-ai#1275, open)**: the coordinator's readiness check is a
+  one-shot latch — once a rank answers one `/v1/models` probe it is never
+  re-verified, so a mid-generation hang runs silently past the load-grace
+  timer. The worker has no post-start hang detection at all. A wedge can sit
+  for 90+ minutes with the watcher reporting nothing.

--- a/docs/FIRST-PLUG-VALIDATION.md
+++ b/docs/FIRST-PLUG-VALIDATION.md
@@ -1,63 +1,73 @@
-# First-plug validation checklist
+# First-plug validation record (historical)
 
-The committed checklist for the first supervised cluster session
-(2026-07-16 cluster config audit). Everything code-side is merged or in PR
-(#1718, #1719, #1720, nix-ai#1245); this file tracks the physical validation
-that only the Thunderbolt cable can provide.
+**Superseded 2026-07-18: cluster mode is live.** The supervised first-plug
+session this checklist gated ran 2026-07-17/18 and shipped as #1746 —
+`programs.mlx.clusterMode.enable = true` on both hosts, running the
+`GLM-4.7-REAP-50-mxfp4` production model. This file is kept as the durable
+record of what was and was not directly observed during that session, the
+same way [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md) holds the Recovery-mode
+steps and [CLUSTER_MODE.md](CLUSTER_MODE.md) holds current status.
 
-Run every item in a **supervised session**. `programs.mlx.clusterMode.enable`
-stays `false` until this list is green. Record the observed result inline —
-this is the durable record, the same way [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md)
-holds the Recovery-mode steps and [CLUSTER_MODE.md](CLUSTER_MODE.md) holds
-the plug-session ceremony.
+Two link-IP bugs (#1747, #1750) were found and fixed live during this same
+session — see [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md#network-substrate-two-track--do-not-bridge-the-rdma-path)
+for the corrected mechanism.
 
 ## Checklist
 
-- [ ] **RDMA device visible.** `ibv_devices` shows the TB RDMA device on both
-  Macs. Note the real device name and whether it matches the runtime-derived
-  `rdma_<iface>` default. Set `programs.mlx.clusterMode.rdmaDevice` only if it
-  does not.
-  - _Result:_
+- [x] **RDMA device visible.** `ibv_devices` shows the TB RDMA device on both
+  Macs; the Thunderbolt link is verified up at 80 Gb/s in both directions.
+  - _Result:_ Confirmed 2026-07-16/18. `rdmaDevice` left at the `rdma_en2`
+    default on both hosts (no override needed).
 
-- [ ] **JACCL hello-world.** `mlx.launch --backend jaccl` small-model smoke
-  across both nodes completes.
-  - _Result:_
+- [x] **JACCL hello-world.** `mlx.launch --backend jaccl` / the production
+  `--pipeline` rank start across both nodes completes.
+  - _Result:_ Confirmed — both ranks reach `mx.distributed.init()` and load
+    their REAP-50 shard in production (#1746).
 
-- [ ] **Cluster wired ceilings.** Validate `system.clusterLinkPrep`
-  wired-memory limits (coordinator 90000 MB, worker 80000 MB): watch memory
-  pressure and WindowServer responsiveness through a full REAP-50 load and a
-  long generation on both ranks. Adjust the values and record the outcome.
-  - _Result:_
+- [x] **Cluster wired ceilings.** `system.clusterLinkPrep` wired-memory
+  limits (coordinator 90000 MB, worker 80000 MB) are live and bound the
+  REAP-50 shard's wired load.
+  - _Result:_ Values deployed and active (`hosts/common/default.nix`). No
+    repeat of the 2026-07-12 WindowServer panic observed. **(verify)**:
+    whether these values have been stress-tested under a long generation
+    with the GUI working set under separate memory pressure is not
+    separately confirmed.
 
 - [ ] **Link-down restore.** Confirm the link-down path returns each host to
   its day wired value.
-  - _Result:_
+  - _Result:_ **(verify)** — not directly confirmed in this session's record.
 
-- [ ] **Readiness probe.** Confirm the coordinator watcher logs `rank ready`
-  and the load-grace default (1800 s) comfortably covers the REAP-50 load.
-  - _Result:_
+- [x] **Readiness probe.** Confirm the coordinator watcher logs `rank ready`.
+  - _Result:_ Confirmed the coordinator's rank reached readiness (one
+    successful `/v1/models` probe). **Caveat found live**: readiness is a
+    one-shot latch never re-verified after that point, and the worker has no
+    post-start hang detection at all — tracked as nix-ai#1275 (open), not a
+    first-plug blocker but a known operational gap going forward.
 
 - [ ] **Unplug test.** Yank the cable mid-generation: router falls back, ranks
   stop, day serving re-warms, worker agents restore.
-  - _Result:_
+  - _Result:_ **(verify)** — not directly confirmed in this session's record.
 
 - [ ] **Second cable.** Test whether JACCL uses a second link between the same
   pair (expected: no). Record the result in
   [CLUSTER_MODE.md](CLUSTER_MODE.md#second-cable).
-  - _Result:_
+  - _Result:_ **(verify)** — not tested.
 
 - [ ] **Recovery-mode Reduced Security.** Record in
   [TB5-RDMA-CLUSTER.md](TB5-RDMA-CLUSTER.md) whether the Recovery-mode
-  `rdma_ctl enable` needed Reduced Security (step ran 2026-07-16; the doc
-  still asks for the observation).
-  - _Result:_
+  `rdma_ctl enable` needed Reduced Security.
+  - _Result:_ **(verify)** — not recorded; RDMA enable predates this session
+    (2026-07-16).
 
 - [ ] **Reboot-with-cable-in.** Verify the quiesce-on-kickstart fix
   (nix-ai#1245) unloads day serving before the rank starts.
-  - _Result:_
+  - _Result:_ **(verify)** — not directly confirmed in this session's record.
 
 ## Sign-off
 
-When every box is checked and the results recorded, enable
-`programs.mlx.clusterMode.enable = true` on both hosts and rebuild. Until then,
-clustered mode stays off.
+Cluster mode went live 2026-07-18 (#1746) on the strength of the checked
+items above — the core gating risk (wired-headroom panic) has a live
+mitigation and RDMA/JACCL are confirmed working end-to-end in production.
+The unchecked items are real gaps in the validation record, not known
+failures; verify them opportunistically rather than treating this file as
+still gating `enable`.

--- a/docs/TB5-RDMA-CLUSTER.md
+++ b/docs/TB5-RDMA-CLUSTER.md
@@ -88,7 +88,7 @@ model's weights + KV headroom), never the whole pooled model. A shard-sized
 wired allocation that crowds the GUI working set starves macOS and the RDMA
 stack itself — this is not theoretical: the 2026-07-12 auto-bring-up wired a
 ~99 GB shard per node and kernel-panicked BOTH hosts (WindowServer watchdog).
-The mitigation is live as of #1746: `clusterLinkPrep.clusterWiredLimitMb`
+The mitigation is live as of #1746: `system.clusterLinkPrep.clusterWiredLimitMb`
 caps each rank's ceiling before it starts (90000 MB coordinator / 80000 MB
 worker) and restores the day value at link-down. See
 [CLUSTER_MODE.md](CLUSTER_MODE.md) for current status.

--- a/docs/TB5-RDMA-CLUSTER.md
+++ b/docs/TB5-RDMA-CLUSTER.md
@@ -41,12 +41,31 @@ to be executed from Recovery OS", exit 77, even as root):
 The RDMA transport is point-to-point and is NOT IP-over-Thunderbolt-Bridge.
 macOS keeps re-enslaving Thunderbolt ports into the "Thunderbolt Bridge"
 network service (device bridge0), which breaks the exclusive L2 that Apple
-RDMA needs. The `system.clusterLinkPrep` module owns this, statically, at
-activation: the Thunderbolt Bridge network service is disabled, and every
-physical Thunderbolt port's network service carries the SAME manual role
-IPv4 — only one port is ever cabled to the peer, inactive services install
-no routes, so whichever port the cable lands in has the address. No runtime
-daemon, no per-plug convergence.
+RDMA needs. The `system.clusterLinkPrep` module owns this, idempotently, on
+every boot and rebuild (root postActivation, no runtime daemon):
+
+1. Disables the Thunderbolt Bridge network service.
+2. Sweeps any Thunderbolt device still enslaved in `bridge0` out, enumerated
+   from `networksetup -listallhardwareports` (not the service order — with
+   no per-port services the service order carries no Thunderbolt lines at
+   all in the broken state being repaired).
+3. Puts the link IPv4 directly on the carrier-active physical Thunderbolt
+   **device** via `ifconfig alias` — deliberately not a SystemConfiguration
+   network service. On macOS 26, `networksetup -createnetworkservice` fails
+   as root with "Unable to access the System Configuration database" even
+   for un-enslaved ports (verified 2026-07-18, dryvist/nix-darwin#1750), so
+   per-port services cannot be created at all on hosts that never had them.
+   Only the carrier-active device gets the address — aliasing the same
+   subnet on several up interfaces makes the kernel bind the /24 route to
+   whichever came first, which silently blackholes traffic if the cable is
+   on a different port. Persistence comes from this prep rerunning at every
+   boot and rebuild, not from SystemConfiguration state; moving the cable
+   heals on the next run.
+
+This mechanism replaced an earlier one (dryvist/nix-darwin#1747) that tried
+to create a per-port network service for each Thunderbolt hardware port and
+set its address via `networksetup -setmanual` — that approach never worked
+on macOS 26 because service creation itself fails as root (#1750).
 
 - The rendezvous address is **IPv4 only**: the pinned mlx-lm's JACCL parser
   rejects every IPv6 form, including `[::1]:port` (validated 2026-07-11). The
@@ -54,8 +73,10 @@ daemon, no per-plug convergence.
   (`programs.mlx.clusterMode.staticLinkIps`), not site topology.
 - Use the regular LAN for out-of-band bootstrap/SSH between the nodes (the
   Thunderbolt Bridge service is disabled on cluster hosts).
-- Never hardcode the interface name anywhere — every Thunderbolt port
-  carries the link address, so moving the cable needs no config change.
+- Never hardcode the interface name anywhere — the prep enumerates every
+  Thunderbolt device and addresses only the carrier-active one, so moving
+  the cable to a different port heals on the next boot/rebuild with no
+  config change.
 - Assert the RDMA transport is actually active before benchmarking:
   `ibv_devices` lists the RDMA device. A working `ping` between the nodes
   proves only the IP path, not RDMA.
@@ -67,16 +88,22 @@ model's weights + KV headroom), never the whole pooled model. A shard-sized
 wired allocation that crowds the GUI working set starves macOS and the RDMA
 stack itself — this is not theoretical: the 2026-07-12 auto-bring-up wired a
 ~99 GB shard per node and kernel-panicked BOTH hosts (WindowServer watchdog).
-Clustered mode stays disabled until a wired-headroom mitigation provably
-leaves the GUI working set unwirable on each node.
+The mitigation is live as of #1746: `clusterLinkPrep.clusterWiredLimitMb`
+caps each rank's ceiling before it starts (90000 MB coordinator / 80000 MB
+worker) and restores the day value at link-down. See
+[CLUSTER_MODE.md](CLUSTER_MODE.md) for current status.
 
 ## Verification checklist
 
 - [x] `rdma_ctl status` → `enabled` on both Macs (2026-07-16)
-- [ ] `ibv_devices` shows the TB RDMA device on both
-- [ ] JACCL smoke: `mlx.launch --backend jaccl` with a small model across
-      both nodes completes
-- [ ] Big-model target answers a chat completion end-to-end from the MBP
+- [x] `ibv_devices` shows the TB RDMA device on both — link verified up at
+      80 Gb/s in both directions (#1746)
+- [x] JACCL smoke: production `--pipeline` serving is live on both ranks
+      (#1746)
+- [ ] Big-model target answers a chat completion end-to-end from the MBP —
+      **(verify)**: a real request reached prefill and then hung mid-generation
+      in the 2026-07-17/18 session (nix-ai#1275, open); a clean end-to-end
+      completion is not yet separately confirmed.
 
 The full first-plug supervised run is tracked in
 [FIRST-PLUG-VALIDATION.md](FIRST-PLUG-VALIDATION.md), including


### PR DESCRIPTION
## Summary

The two-Mac JACCL cluster re-enable (#1746) and the two link-IP fixes
(#1747, #1750) shipped without a docs pass — `docs/CLUSTER_MODE.md`,
`docs/TB5-RDMA-CLUSTER.md`, and `docs/FIRST-PLUG-VALIDATION.md` still
described the 2026-07-16 DISABLED state and the old per-port
SystemConfiguration network-service link-IP mechanism, both superseded.

- **`docs/CLUSTER_MODE.md`**: status banner now reflects `clusterMode.enable
  = true` on both hosts, the live `clusterWiredLimitMb` mitigation
  (90000/80000 MB), the confirmed production model
  (`GLM-4.7-REAP-50-mxfp4`), and the corrected link-IP mechanism. Added a
  note on the open nix-ai#1275 watcher readiness gap.
- **`docs/TB5-RDMA-CLUSTER.md`**: rewrote the "Network substrate" section to
  describe the `ifconfig alias`-on-physical-device mechanism (#1747/#1750)
  instead of the per-port network-service approach that never worked on
  macOS 26. Updated the memory-sizing and verification-checklist sections
  for consistency with the live status.
- **`docs/FIRST-PLUG-VALIDATION.md`**: converted from a live gating
  checklist to a historical validation record — cluster mode is already
  live, so `enable` is no longer gated on this file. Checked items with
  direct evidence, left items without direct confirmation unchecked and
  marked `(verify)` rather than asserting them.

## Verification

- `markdownlint-cli2` — 0 errors
- `pre-commit run --files <changed files>` — all hooks pass (lychee link
  checker included)

## Notes for the reviewer

- I did not touch `modules/darwin/scripts/cluster-link-prep.sh`'s own header
  comment, which is also stale (still describes the old per-port-service
  mechanism) — out of scope for a docs-only PR, flagging for a follow-up.
- The router-flip step in `CLUSTER_MODE.md` (`ai_night_brain_enabled` /
  ansible-proxmox-apps `llm_router` role) was left untouched — that role no
  longer exists on `ansible-proxmox-apps` develop, so the brain/router
  architecture is mid-change and out of scope here per explicit instruction.