### PR TITLE
fix(openbao-github-creds): send string-form mint params — server ACL cannot match lists

### DIFF
--- a/modules/darwin/scripts/openbao-github-creds.sh
+++ b/modules/darwin/scripts/openbao-github-creds.sh
@@ -120,10 +120,14 @@ mint_read() {
 
 # Build the raw-token request body for one repo. Kept separate so --self-check
 # can assert its shape without a live server.
+# STRING forms are load-bearing (verified live 2026-07-18): OpenBao's ACL
+# cannot element-match a LIST-valued parameter and only matches
+# installation_id as a string — the server-side allowlist denies the
+# number/list forms outright.
 write_token_body() {
   local iid="$1" repo="$2"
-  jq -cn --argjson iid "${iid}" --arg repo "${repo}" \
-    '{installation_id: $iid, repositories: [$repo]}'
+  jq -cn --arg iid "${iid}" --arg repo "${repo}" \
+    '{installation_id: $iid, repositories: $repo}'
 }
 
 mint_write() {
@@ -249,7 +253,7 @@ cmd_token_read() { mint_read "$1"; echo; }
 self_check() {
   local out
   out="$(write_token_body 147266792 nix-darwin)"
-  [ "${out}" = '{"installation_id":147266792,"repositories":["nix-darwin"]}' ] \
+  [ "${out}" = '{"installation_id":"147266792","repositories":"nix-darwin"}' ] \
     || { echo "self-check FAIL: write body = ${out}"; return 1; }
   owner=""; repo=""; split_repo "dryvist/nix-darwin"
   [ "${owner}" = "dryvist" ] && [ "${repo}" = "nix-darwin" ] \


### PR DESCRIPTION
## What

Companion to ansible-proxmox-apps' string-form allowlist change. OpenBao's `allowed_parameters` never element-matches a LIST-valued request parameter and only matches `installation_id` in string form (verified live 2026-07-18) — the wrapper's old body shape (`{installation_id: <number>, repositories: [<repo>]}`) is denied server-side. Now sends both as strings; `--self-check` asserts the new shape.

## Test plan

- [x] `bash -n` clean; `write_token_body` emits `{"installation_id":"…","repositories":"…"}` (asserted locally)
- [x] Server-side proof: string form passes the ACL, list/number forms deny (live bisect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqhVhA3t3Uyyh1FtMHMdA