### PR TITLE
ci: assert homelab allowRules render into autoMode.allow

### DIFF
--- a/.github/workflows/_claude-settings.yml
+++ b/.github/workflows/_claude-settings.yml
@@ -73,6 +73,37 @@ jobs:
           fi
           echo "Permission patterns are valid!"
 
+      # Semantic guard: every homelab.allowRules value declared in the consumer
+      # (lib/user-config.nix) must round-trip into the host's rendered
+      # autoMode.allow. If the nix-ai flake input is pinned to a rev that predates
+      # the homelab.allowRules wiring, the `... or [ ]` fallback silently drops the
+      # values and the classifier rules never take effect — a build that passes but
+      # renders nothing ("merged != live"). This asserts that cannot happen unnoticed.
+      # jevans-mbp is representative: the wiring is host-agnostic, so one homelab
+      # host with homelab.enable = true suffices to catch a stale/broken pin.
+      - name: Assert homelab allowRules render into autoMode.allow
+        run: |
+          declared="$(nix eval --impure --json \
+            --expr "(import $PWD/lib/user-config.nix).homelab.allowRules or []")"
+          rendered="$(nix eval --json \
+            '.#darwinConfigurations.jevans-mbp.config.home-manager.users.jevans.programs.claude.autoMode.allow')"
+          python3 - "$declared" "$rendered" <<'PY'
+          import json, sys
+          declared = json.loads(sys.argv[1])
+          rendered = set(json.loads(sys.argv[2]))
+          missing = [d for d in declared if d not in rendered]
+          if missing:
+              print("::error::homelab.allowRules declared in lib/user-config.nix but NOT "
+                    "rendered into autoMode.allow.")
+              print("::error::Most likely the nix-ai flake input predates the "
+                    "homelab.allowRules wiring - bump flake.lock (deps-update-flake.yml).")
+              for m in missing:
+                  print(f"::error:: unrendered rule: {m[:70]}...")
+              sys.exit(1)
+          print(f"OK: all {len(declared)} homelab.allowRules round-trip "
+                f"into autoMode.allow ({len(rendered)} rules total).")
+          PY
+
       - name: Validation Timing
         if: always()
         run: |

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -79,6 +79,10 @@ jobs:
               - '.markdownlint.yml'
             claude:
               - '.claude/**'
+              # flake.lock changes the rendered settings via the nix-ai input
+              # (e.g. homelab.allowRules), so settings validation must run on a
+              # deps-only lock bump too — otherwise a stale pin ships unchecked.
+              - 'flake.lock'
 
       - name: Detect Dependency-Only Commits
         id: detect-deps
@@ -154,5 +158,7 @@ jobs:
           # For deps-only commits: All jobs can be skipped
           # For non-Nix changes: nix-build and nix-validate can be skipped
           # For Nix changes: Only validation jobs can be skipped, nix-build must pass
-          allowed-skips: ${{ (needs.changes.outputs.is-deps-only == 'true' && 'nix-build, nix-validate, markdown-lint, claude-settings, file-size') || (needs.changes.outputs.nix == 'false' && 'nix-build, nix-validate, markdown-lint, claude-settings, file-size') || 'nix-validate, markdown-lint, claude-settings, file-size' }}
+          # claude-settings is intentionally NOT skippable for deps-only: a
+          # flake.lock bump can change the rendered settings, so it must validate.
+          allowed-skips: ${{ (needs.changes.outputs.is-deps-only == 'true' && 'nix-build, nix-validate, markdown-lint, file-size') || (needs.changes.outputs.nix == 'false' && 'nix-build, nix-validate, markdown-lint, claude-settings, file-size') || 'nix-validate, markdown-lint, claude-settings, file-size' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Problem

A `flake.lock` bump that pins the `nix-ai` input to a rev predating the `homelab.allowRules` wiring lets the `... or [ ]` fallback silently drop the declared rules — the build passes, but the classifier rules never render. "Merged ≠ live." This session hit exactly that: #1749 merged the rule values, but until the lock was bumped, the rendered `autoMode.allow` stayed at the base count with the homelab rules absent.

Two gaps let it ship unchecked:
1. **Claude Settings validation only triggered on `.claude/**`.** A `flake.lock`-only deps PR (e.g. #1758) had `claude == false`, so the job was skipped — and it was in the `is-deps-only` allowed-skips list.
2. **Even when it ran, validation was schema-only** — structural, never asserting the rendered content.

## Fix

- **`ci-gate.yml`**: add `flake.lock` to the `claude` path filter (a lock bump can change rendered settings via `nix-ai`), and drop `claude-settings` from the `is-deps-only` allowed-skips so it is required on deps PRs.
- **`_claude-settings.yml`**: new step asserting every `homelab.allowRules` value declared in `lib/user-config.nix` round-trips into a homelab host's rendered `autoMode.allow`. On failure it points at `deps-update-flake.yml` (the lock-bump path). Host-agnostic bug → one representative homelab host (`jevans-mbp`) suffices.

## Verification

Ran the assertion locally against the current tree: **2 declared, 6 rendered, 0 missing → pass**. Simulated a stale lock (rendered set missing the declared rules): **assertion exits 1**, as intended. The step uses only repo-derived `nix eval` output passed as positional argv — no `github.event.*` interpolation, so no injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)