### PR TITLE
feat(github-auth): cut git over to the OpenBao credential wrapper

### DIFF
--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -87,6 +87,27 @@
   };
 
   programs = {
+    # --- GitHub credentials for git: OpenBao-minted, never keychain ---
+    # git resolves GitHub HTTPS credentials through the OpenBao-backed wrapper
+    # (modules/darwin/apps/openbao-github-creds.nix): ambient READ tokens per
+    # owner, write only behind `openbao-github-creds claim`. `doppler run`
+    # supplies the wrapper's secret-zero ambiently; useHttpPath makes git send
+    # path=<owner>/<repo> so the wrapper picks the right read set. gh's own
+    # git credential helper is disabled so the wrapper is the ONLY GitHub
+    # credential path for git — a push without a claim fails loud at GitHub
+    # (read token, 403) instead of silently riding a broader credential.
+    gh.gitCredentialHelper.enable = false;
+    git.settings.credential = {
+      "https://github.com" = {
+        helper = "!doppler run -- openbao-github-creds";
+        useHttpPath = true;
+      };
+      "https://gist.github.com" = {
+        helper = "!doppler run -- openbao-github-creds";
+        useHttpPath = true;
+      };
+    };
+
     # Claude Code config (plugin disables, MCP server overrides) moved to
     # nix-ai/modules/claude-config.nix in dryvist/nix-ai#853 — Claude config
     # doesn't belong in nix-darwin (host-specific opinion lives in nix-ai).

--- a/hosts/mac-studio/default.nix
+++ b/hosts/mac-studio/default.nix
@@ -154,6 +154,13 @@ in
     # `doppler run`, not a local keychain. See modules/darwin/apps/openbao-aws-creds.nix.
     openbao-aws-creds.enable = true;
 
+    # --- OpenBao-backed GitHub token provider ---
+    # Same wrapper the laptop ships (hosts/macbook-m4): ambient READ tokens,
+    # per-repo WRITE behind a claim/lease, keychain-free. The git credential
+    # wiring lives in hosts/common/home.nix, so enabling this module is all a
+    # host needs for the OpenBao GitHub path.
+    openbao-github-creds.enable = true;
+
     # --- Reboot-continuity auto-resume ---
     # Same login-time armed-mission resume as the laptop; no-op unless armed
     # at runtime. See modules/darwin/apps/claude-continuity.nix.


### PR DESCRIPTION
## What

- `hosts/common/home.nix`: git's `https://github.com` / `https://gist.github.com` credential helper is now `!doppler run -- openbao-github-creds` with `useHttpPath`, and `programs.gh.gitCredentialHelper` is disabled — the OpenBao wrapper is the only git credential path for GitHub.
- `hosts/mac-studio/default.nix`: enable `programs.openbao-github-creds` (was laptop-only).

## Behavior

- git HTTPS reads mint an ambient per-owner READ token on demand.
- Pushes require `openbao-github-creds claim <owner>/<repo>` first (claimed `GITHUB_TOKEN` wins in the helper); an unclaimed push fails loud with a 403 instead of riding a broader credential.
- gh CLI token sourcing is intentionally untouched here; it moves off the keychain tier system in the follow-up retirement PR after the validation matrix passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUgunYLF5xEQ2FJiSLQ491