### PR TITLE
feat(cluster): stamp configurationRevision + wire generation auto-heal dir

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -940,11 +940,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1784493224,
-        "narHash": "sha256-ysaEnLily9ZtwyjjRvfehxdppIw2B5MypmLlHt2bArw=",
+        "lastModified": 1784554665,
+        "narHash": "sha256-dt4XsE8/ysFJ9oCCRQ2vscZL20B9s+ffW4sx/MfVL6k=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "b7f34841f447dffb2c7fce2caafa4555c1168423",
+        "rev": "21bb181f3f47ab5358191f5642f1b899bf3b81a9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       darwin,
       home-manager,
@@ -172,6 +173,13 @@
           };
           modules = [
             ./hosts/${label}/default.nix
+
+            # Stamp every generation with the source commit so cross-host
+            # generation parity is checkable (cluster-join step-0 preflight
+            # compares darwin-version's configurationRevision to the deploy
+            # branch HEAD). Dirty builds stamp null and fail that preflight
+            # closed by design.
+            { system.configurationRevision = self.rev or null; }
 
             # Determinate Nix: official module for nix.conf, GC, and determinate-nixd config
             determinate.darwinModules.default

--- a/hosts/common/cluster-wired-limit.nix
+++ b/hosts/common/cluster-wired-limit.nix
@@ -17,6 +17,7 @@
 # cluster-quiesce.nix. Deriving from osConfig (never re-declaring the numbers)
 # makes drift between the sudoers grant and the watcher restore impossible.
 {
+  config,
   lib,
   osConfig,
   hostConfig,
@@ -54,6 +55,10 @@ in
     programs.mlx.clusterMode = {
       wiredLimitMb = linkPrep.clusterWiredLimitMb;
       inherit (linkPrep) dayWiredLimitMb;
+
+      # Auto-heal source for the cluster-join generation-parity preflight:
+      # drift from the deploy branch HEAD ff-pulls this checkout and rebuilds.
+      generationFlakeDir = "${config.home.homeDirectory}/git/public/nix/nix-darwin/main";
 
       # EXPERIMENT (INC-17070, remove once resolved): disables the prompt cache
       # on both cluster ranks to isolate a multi-request pipeline hang. The only


### PR DESCRIPTION
## Summary

- `system.configurationRevision = self.rev or null` on every host: each generation now carries its source commit, making cross-Mac generation parity checkable (`darwin-version --json`). Dirty builds stamp null and fail the cluster preflight closed by design.
- `programs.mlx.clusterMode.generationFlakeDir` wired in the cluster bridge module so cluster-join can auto-heal drift (ff-only pull + darwin-rebuild switch) from the canonical checkout.
- nix-ai pin bumped to pick up the step-0 generation-parity preflight (nix-ai#1298) and the 80B-Instruct reasoning-parser fix (nix-ai#1297).

Companion to nix-ai#1298: together they guarantee every Mac in the cluster runs the exact same nix generation before any clustering config begins, with auto-healing.

## Test plan

- [x] `nix flake check` clean (both darwinConfigurations evaluate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yh8vodT7vPhGKbZNRtoAy