### PR TITLE
feat(offbox): per-job min-age override to stop immutable jobs wedging

### DIFF
--- a/modules/darwin/apps/offbox-sync.nix
+++ b/modules/darwin/apps/offbox-sync.nix
@@ -86,11 +86,27 @@ let
           trees, where a changed file is corruption rather than an update.
         '';
       };
+      minAge = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "30m";
+        description = ''
+          Per-job override of the global minAge. Needed when a source writes
+          one file over a long span with pauses in it: the global 2m floor lets
+          such a file be copied during a lull, and when the writer appends
+          afterwards an immutable job wedges permanently on an immutable-file
+          -modified error. Every later run then fails, so nothing else in that
+          job replicates either. Observed live. Set above the longest write
+          span for the source. Null inherits the global value.
+        '';
+      };
     };
   };
 
   # `--min-age` is applied to every job: a file still being written (an
   # in-flight video chunk, a half-flushed frame) must not be copied mid-write.
+  # The global floor is not enough on its own for a source that writes one file
+  # over many minutes with idle gaps — see the per-job `minAge` option.
   mkJobArgs =
     job:
     lib.concatStringsSep " " (
@@ -104,7 +120,7 @@ let
         # quoting error. Double quotes expand and still protect whitespace;
         # job.dest is a module option, not user input.
         "\":sftp:\${OFFBOX_ROOT}/${job.dest}\""
-        "--min-age ${cfg.minAge}"
+        "--min-age ${if job.minAge != null then job.minAge else cfg.minAge}"
         "--transfers ${toString cfg.transfers}"
         "--checkers ${toString cfg.checkers}"
         "--sftp-concurrency ${toString cfg.transfers}"


### PR DESCRIPTION
## The bug, observed live

An `immutable` offbox job can wedge **permanently**, and when it does the whole job stops replicating — not just the one file.

Mechanism:

1. A source writes a single file over many minutes with idle gaps in between.
2. The global `minAge` floor is 2m, so during a lull the file looks settled and gets copied.
3. The writer appends more data afterwards.
4. Source and destination now differ, and `--immutable` correctly refuses to overwrite — forever.
5. rclone exits non-zero on **every subsequent run**, so nothing else in that job replicates either.

Live evidence from the affected job: the same file failed on every 5-minute run for hours with `Source and destination exist but do not match: immutable file modified`, followed by `Can't retry any of the errors`. The file's own write span was ~11 minutes — well past the 2m floor, with gaps inside it.

This is not a flaw in `--immutable`, which is doing exactly what it is documented to do. The flaw is that a single global 2m floor cannot serve both a mutable tree that wants fast replication and a source that writes one file slowly.

## The fix

A per-job `minAge` that overrides the global value, defaulting to `null` = inherit. Set it above the longest write span for that source.

Raising the *global* floor instead would have worked in one line, but it degrades RPO for every other job — including small mutable trees where 2m is correct. In a data-protection path that is a real regression, so the override is the smaller net change.

## Verification

Rendered the runner through `lib.evalModules` with two jobs — one overriding, one inheriting — and grepped the emitted rclone invocations:

```text
rclone copy /tmp/a ":sftp:${OFFBOX_ROOT}/a" --min-age 30m ... --immutable >> "$LOG/override.log"
rclone copy /tmp/b ":sftp:${OFFBOX_ROOT}/b" --min-age 2m  ...           >> "$LOG/inherit.log"
```

Override takes `30m`, inheritor keeps the global `2m`. `nixfmt` clean.

Skipped a committed module-eval test: this repo has no nix module test harness (only bats for shell scripts), and adding one for a ternary is not worth the machinery. The consuming build is the check.

## Scope

Mechanism only — no consumer paths, no hostnames, nothing environment-specific. Unwedging the already-affected remote file is handled separately; this stops it recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwpKQeBokBMgFBU1GkgVZa
