### PR TITLE
feat(dock): add GIMP and refresh app layout

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -58,6 +58,14 @@ Source: `modules/darwin/common.nix`
 | --- | --- |
 | mas | Mac App Store CLI |
 
+### Graphical Applications
+
+Source: `modules/darwin/common.nix`
+
+| Package | Description |
+| --- | --- |
+| gimp | GNU Image Manipulation Program photo editor |
+
 ---
 
 ## Cross-Platform Packages

--- a/modules/darwin/common.nix
+++ b/modules/darwin/common.nix
@@ -74,6 +74,11 @@ in
     mas # Mac App Store CLI
 
     # ========================================================================
+    # Graphical applications
+    # ========================================================================
+    gimp # GNU Image Manipulation Program photo editor
+
+    # ========================================================================
     # Network & process tools
     # ========================================================================
     ngrep # Network packet grep (useful for debugging)

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -30,7 +30,8 @@ in
     # Left side of Dock (before separator) - Main apps
     # ========================================================================
     persistent-apps = [
-      # Time & Tasks
+      # System settings & time (immediately after the fixed Finder Dock item)
+      "/System/Applications/System Settings.app"
       "/System/Applications/Clock.app"
       "/System/Applications/Reminders.app"
       "/System/Applications/Calendar.app"
@@ -49,26 +50,21 @@ in
 
       # Communication
       "/System/Applications/Mail.app" # Apple Mail (system app)
-      "/Applications/Microsoft Outlook.app"
-      "/Applications/Microsoft Teams.app"
       "/Applications/Slack.app"
-      "/Applications/zoom.us.app" # Manual install - now at system level
       "/System/Applications/Messages.app"
 
-      # AI Assistants
+      # AI & API tools
+      "/Applications/ProxMan.app"
       "/Applications/Claude.app" # Anthropic Claude desktop app (homebrew cask)
+      "/Applications/ChatGPT.app"
+      "/Applications/Codex.app"
       "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
-      "/Applications/Antigravity IDE.app" # Google Antigravity IDE
 
       # Browsers
       "/Applications/Safari.app"
       "/Applications/Brave Browser.app"
+      "/Applications/Google Chrome.app"
 
-      # Remote Desktop
-      "/Applications/Windows App.app"
-
-      # NOTE: Additional AI tools (ChatGPT, Cursor) can be found in
-      # ~/Applications/Home Manager Apps/, but they are not pinned to the Dock.
       # NOTE: RapidAPI, Postman, and Bitwarden removed from dock per #438
     ];
 


### PR DESCRIPTION
## Summary
- install GIMP from nixpkgs as a system package
- place Finder, System Settings, ProxMan, ChatGPT, Codex, and Chrome in the requested Dock order
- remove the requested outdated Dock pins

## Validation
- `nixfmt --check modules/darwin/common.nix modules/darwin/dock/persistent-apps.nix`
- `statix check modules/darwin/common.nix`
- `statix check modules/darwin/dock/persistent-apps.nix`
- `deadnix --fail modules/darwin/common.nix modules/darwin/dock/persistent-apps.nix`
- `markdownlint-cli2 MANIFEST.md`
- evaluated `darwinConfigurations.jevans-mbp` Dock and system package outputs
- `nix flake check`