### PR TITLE
fix(mac-studio): stop preload from carrying a misleading alias name

### DIFF
--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -149,9 +149,19 @@ in
       concurrencyLimit = serveConcurrency;
     };
 
-    # Resident brain warmed at boot: the 35B, the only servable model. The
-    # role name is unchanged because every role now resolves to that entry.
-    preload = [ "goal-judge" ];
+    # Resident brain warmed at boot: the 35B, the only servable model.
+    # "default" is one of several role aliases that all resolve to that same
+    # entry in singleModel mode (line ~106 above lists them). This used to
+    # read `[ "goal-judge" ]` — also a valid alias to the SAME resident, so
+    # functionally a no-op change — but that name reads as "warm a separate,
+    # smaller judge model", which does not exist on this host: every role
+    # here, including goal-judge, aliases the one 35B resident (ttl=0). That
+    # misreading cost a real multi-hour misdiagnosis of a warmup starvation
+    # incident on 2026-08-01 (the actual cause was external: something
+    # kickstarting the warmup agent in a tight loop, force-reloading this
+    # SAME resident over and over — see nix-ai's mlx-warmup.py RE-INVOCATION
+    # BOUND). "default" says what actually happens here.
+    preload = [ "default" ];
 
     # Clustered mode: this Mac is rank 0 (coordinator) of the two-Mac JACCL
     # brain when the Thunderbolt cable is in — it binds the cluster endpoint on

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -151,7 +151,8 @@ in
 
     # Resident brain warmed at boot: the 35B, the only servable model.
     # "default" is one of several role aliases that all resolve to that same
-    # entry in singleModel mode (line ~106 above lists them). This used to
+    # entry in singleModel mode; the full list is qwen36-35b's `roles`
+    # attribute above, which is also where goal-judge is declared. This used to
     # read `[ "goal-judge" ]` — also a valid alias to the SAME resident, so
     # functionally a no-op change — but that name reads as "warm a separate,
     # smaller judge model", which does not exist on this host: every role


### PR DESCRIPTION
## Summary

- `programs.mlx.preload = [ "goal-judge" ]` and `[ "default" ]` are functionally identical on this host: both are role aliases that resolve to the same singleModel resident (the 35B, ttl=0) per nix-ai's `llama-swap-topology.nix`. There is no separate, smaller judge model on this host — every role, including `goal-judge`, aliases the one resident once `singleModel` is set (verified against the live deployed llama-swap config: the resident's `aliases` list includes `goal-judge` alongside `default`, `tool-calling`, etc.).
- The old name reads as "warm a small, separate judge model that gets evicted on its own TTL" — which stopped being true at the 2026-07-23 singleModel migration but the preload entry was never renamed. That misreading cost a real multi-hour misdiagnosis of a warmup-starvation incident on 2026-08-01: the actual cause was external (something kickstarting the warmup agent in a tight loop, force-reloading this SAME resident repeatedly — see nix-ai PR #1491), not a second evictable model being targeted by mistake.
- `preload = [ "default" ]` says what actually happens: this host warms its one resident. Zero behavior change.

## Test plan

- [x] `nixfmt` / `statix` / `deadnix` clean.
- [x] `pre-commit run --files lib/hosts/mac-studio.nix` clean (all hooks pass, including semgrep and the file-size gate).
- [x] `nix eval .#darwinConfigurations.jevans-ms.config.system.build.toplevel.drvPath` succeeds with no eval errors (full closure evaluation, confirms the option substitution type-checks end to end).
- [ ] CI green on this PR.

https://claude.ai/code/session_01MrWxkxkRYGSDxvAPYWvFkg