### PR TITLE
feat(dock): add Microsoft Teams and filter persistent apps with native Nix

### DIFF
--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -24,7 +24,7 @@ let
   userConfig = import ../../../lib/user-config.nix;
   inherit (userConfig.user) homeDir;
 
-  enableWorkstationApps = hostConfig.homebrew.enableWorkstationApps or (!hostConfig.isServer);
+  inherit (hostConfig.homebrew) enableWorkstationApps;
 in
 {
   system.defaults.dock = {

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -34,46 +34,45 @@ in
     # Uses native Nix conditional expressions (`lib.optionals`) driven by
     # `hostConfig` capabilities to include GUI applications only on hosts where
     # they are installed (workstations), while keeping server Docks clean.
-    persistent-apps =
-      [
-        # System settings & time (system apps present on all hosts)
-        "/System/Applications/System Settings.app"
-        "/System/Applications/Clock.app"
-        "/System/Applications/Reminders.app"
-        "/System/Applications/Calendar.app"
-        "/Applications/Safari.app"
+    persistent-apps = [
+      # System settings & time (system apps present on all hosts)
+      "/System/Applications/System Settings.app"
+      "/System/Applications/Clock.app"
+      "/System/Applications/Reminders.app"
+      "/System/Applications/Calendar.app"
+      "/Applications/Safari.app"
 
-        # Terminal (present on all hosts)
-        "/Applications/Ghostty.app"
-      ]
-      ++ lib.optionals enableWorkstationApps [
-        "/Applications/Toggl Track.app"
+      # Terminal (present on all hosts)
+      "/Applications/Ghostty.app"
+    ]
+    ++ lib.optionals enableWorkstationApps [
+      "/Applications/Toggl Track.app"
 
-        # Knowledge & Notes
-        "/Applications/Obsidian.app"
+      # Knowledge & Notes
+      "/Applications/Obsidian.app"
 
-        # Development & Tools
-        "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
+      # Development & Tools
+      "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
 
-        # Communication
-        "/System/Applications/Mail.app"
-        "/System/Applications/Messages.app"
-        "/Applications/Slack.app"
-        "/Applications/Microsoft Teams.app"
-      ]
-      ++ [
-        # AI & API tools (present on all hosts)
-        "/Applications/ProxMan.app"
-        "/Applications/Claude.app"
-        "${homeDir}/Applications/Gemini.app"
-        "/Applications/ChatGPT.app"
-        "/Applications/Codex.app"
-      ]
-      ++ lib.optionals enableWorkstationApps [
-        # Third Party Browsers
-        "/Applications/Brave Browser.app"
-        "/Applications/Google Chrome.app"
-      ];
+      # Communication
+      "/System/Applications/Mail.app"
+      "/System/Applications/Messages.app"
+      "/Applications/Slack.app"
+      "/Applications/Microsoft Teams.app"
+    ]
+    ++ [
+      # AI & API tools (present on all hosts)
+      "/Applications/ProxMan.app"
+      "/Applications/Claude.app"
+      "${homeDir}/Applications/Gemini.app"
+      "/Applications/ChatGPT.app"
+      "/Applications/Codex.app"
+    ]
+    ++ lib.optionals enableWorkstationApps [
+      # Third Party Browsers
+      "/Applications/Brave Browser.app"
+      "/Applications/Google Chrome.app"
+    ];
 
     # ========================================================================
     # Right side of Dock (after separator) - Folders & utilities

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -18,55 +18,62 @@
 # 2026-07-29, which Homebrew upgrades in place. VS Code remains on copyApps; if
 # its grants prove to lapse the same way, it should follow.
 
-_:
+{ lib, hostConfig, ... }:
 
 let
   userConfig = import ../../../lib/user-config.nix;
   inherit (userConfig.user) homeDir;
+
+  enableWorkstationApps = hostConfig.homebrew.enableWorkstationApps or (!hostConfig.isServer);
 in
 {
   system.defaults.dock = {
     # ========================================================================
     # Left side of Dock (before separator) - Main apps
     # ========================================================================
-    persistent-apps = [
-      # System settings & time (immediately after the fixed Finder Dock item)
-      "/System/Applications/System Settings.app"
-      "/System/Applications/Clock.app"
-      "/System/Applications/Reminders.app"
-      "/System/Applications/Calendar.app"
-      "/Applications/Toggl Track.app"
+    # Uses native Nix conditional expressions (`lib.optionals`) driven by
+    # `hostConfig` capabilities to include GUI applications only on hosts where
+    # they are installed (workstations), while keeping server Docks clean.
+    persistent-apps =
+      [
+        # System settings & time (system apps present on all hosts)
+        "/System/Applications/System Settings.app"
+        "/System/Applications/Clock.app"
+        "/System/Applications/Reminders.app"
+        "/System/Applications/Calendar.app"
+        "/Applications/Safari.app"
 
-      # Knowledge & Notes (after Toggl)
-      "/Applications/Obsidian.app"
+        # Terminal (present on all hosts)
+        "/Applications/Ghostty.app"
+      ]
+      ++ lib.optionals enableWorkstationApps [
+        "/Applications/Toggl Track.app"
 
-      # Development & Tools (after Toggl)
-      # /Applications, not Home Manager Apps: Ghostty moved to a greedy Homebrew
-      # cask on 2026-07-29 so its TCC grants survive (see modules/darwin/homebrew.nix).
-      # A Dock entry pointing at the old copyApps path would silently resolve to
-      # a bundle that activation no longer writes.
-      "/Applications/Ghostty.app"
-      "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
+        # Knowledge & Notes
+        "/Applications/Obsidian.app"
 
-      # Communication
-      "/System/Applications/Mail.app" # Apple Mail (system app)
-      "/Applications/Slack.app"
-      "/System/Applications/Messages.app"
+        # Development & Tools
+        "${homeDir}/Applications/Home Manager Apps/Visual Studio Code.app"
 
-      # AI & API tools
-      "/Applications/ProxMan.app"
-      "/Applications/Claude.app" # Anthropic Claude desktop app (homebrew cask)
-      "/Applications/ChatGPT.app"
-      "/Applications/Codex.app"
-      "${homeDir}/Applications/Gemini.app" # Google Gemini AI assistant
-
-      # Browsers
-      "/Applications/Safari.app"
-      "/Applications/Brave Browser.app"
-      "/Applications/Google Chrome.app"
-
-      # NOTE: RapidAPI, Postman, and Bitwarden removed from dock per #438
-    ];
+        # Communication
+        "/System/Applications/Mail.app"
+        "/System/Applications/Messages.app"
+        "/Applications/Slack.app"
+        "/Applications/Microsoft Teams.app"
+      ]
+      ++ [
+        # AI & API tools (present on all hosts)
+        "/Applications/ProxMan.app"
+        "/Applications/Claude.app"
+        "${homeDir}/Applications/Gemini.app"
+        "/Applications/ChatGPT.app"
+        "/Applications/Codex.app"
+      ]
+      ++ lib.optionals enableWorkstationApps [
+        # Third Party Browsers
+        "/Applications/Brave Browser.app"
+        "/Applications/Google Chrome.app"
+      ];
 
     # ========================================================================
     # Right side of Dock (after separator) - Folders & utilities


### PR DESCRIPTION
## Summary
- Added Microsoft Teams (`/Applications/Microsoft Teams.app`) to persistent Dock apps in the Communication section after Slack and Messages.
- Structured `modules/darwin/dock/persistent-apps.nix` using 100% native Nix expressions (`lib.optionals`) driven by `hostConfig.homebrew.enableWorkstationApps`.
- Workstation hosts include full GUI app suite while server hosts omit uninstalled workstation apps at Nix evaluation time.

## Verification
- `nix fmt && statix check && deadnix` passed.
- `nix flake check` passed.