### PR TITLE
chore: drop hardcoded Apple container version numbers from comments

### DIFF
--- a/modules/darwin/apps/apple-container-runtime.nix
+++ b/modules/darwin/apps/apple-container-runtime.nix
@@ -1,6 +1,6 @@
 # Apple `container` Runtime Bring-Up (shared one-shot)
 #
-# Every module that supervises an Apple `container` (v1.0) Linux VM needs the
+# Every module that supervises an Apple `container` Linux VM needs the
 # per-user container-apiserver running first. This module owns that bring-up
 # as ONE launchd one-shot agent, shared by all consumers (cribl-stream,
 # github-runner-container) — each sets `enable = lib.mkDefault true` from its

--- a/modules/darwin/apps/cribl-stream.nix
+++ b/modules/darwin/apps/cribl-stream.nix
@@ -1,6 +1,6 @@
 # Cribl Stream Service Management (Apple container)
 #
-# Runs a single-instance Cribl Stream node in an Apple `container` (v1.0) as the
+# Runs a single-instance Cribl Stream node in an Apple `container` as the
 # local single egress for this Mac: everything collected here ships to this
 # Stream, which enriches, persistent-queues, and forwards once to the Proxmox
 # Stream tier (instead of many local sources each dialing Proxmox).

--- a/scripts/validate-nix-before-all.sh
+++ b/scripts/validate-nix-before-all.sh
@@ -19,7 +19,7 @@ EXCLUSIONS=(
   "claude-code:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "antigravity-cli:Intentionally using homebrew due to recent nixpkgs latency on latest packages"
   "bitwarden:nixpkgs build pins EOL electron_39 (insecure); cask uses Bitwarden's maintained build"
-  "container:Homebrew tracks Apple container 1.0.0 while nixpkgs is still 0.12.3; use current upstream runtime"
+  "container:Homebrew tracks Apple container releases ahead of nixpkgs; use current upstream runtime"
   "orbstack:Cask preferred over nixpkgs for TCC permission stability (nixpkgs symlink changes on rebuild, forcing TCC re-grant)"
   "postman:Nixpkgs version lags significantly behind upstream, causing Squirrel/ShipIt schema mismatch errors"
 )


### PR DESCRIPTION
Removes the static Apple `container` version numbers from two module headers and the nix-vs-brew exclusion note.

The Homebrew formula is unpinned, so installs already track the current upstream release. The numbers were documentation text only and had no effect on behaviour.

- `modules/darwin/apps/apple-container-runtime.nix`
- `modules/darwin/apps/cribl-stream.nix`
- `scripts/validate-nix-before-all.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyKfJHBKEJYjAf6YiVK5LU