### PR TITLE
feat(macbook-m4): enable daily session archive to vendor buckets

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1004,11 +1004,11 @@
         "ponytail": "ponytail"
       },
       "locked": {
-        "lastModified": 1786103977,
-        "narHash": "sha256-MYvUBJu7C6iRt7VBElE6/s8xI+HXpcTkfR69QkgQcQY=",
+        "lastModified": 1786123794,
+        "narHash": "sha256-MBHvGglKnCsEcE0KE+V+09vXKqlqO2HXH14ExKOkZTU=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "f5672641655a019b06149ccae903b5ffe08f797a",
+        "rev": "924032e89143f142f7a680b6ea4a9c62ea6f4c3e",
         "type": "github"
       },
       "original": {

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -57,6 +57,18 @@ in
       remote = hosts.mac-studio.hostName;
     };
 
+    # Daily push of the same history to the per-vendor object buckets (nix-ai
+    # module) — the off-Mac copy behind the studio one. Runs as a launchd
+    # agent on purpose: agents carry no GUI responsible app, so macOS Local
+    # Network gating never applies to them, where the same push from a
+    # terminal-descended shell breaks whenever en0 wakes up on the storage
+    # subnet (probe-verified). Credentials are the ai-sessions-backup AppRole,
+    # doppler-injected per run; nothing is stored on this machine.
+    sessionArchive = {
+      enable = true;
+      endpoint = "https://s3.${userConfig.internalDomain}";
+    };
+
     # Recreates the tmux "cc" session at every login — a reboot always kills
     # the tmux server, and Termius' "tmux attach -t cc" startup command needs
     # the session to already exist. Workstation-only: this is the box reached


### PR DESCRIPTION
## Summary

- Enables the `sessionArchive` home-manager module on `macbook-m4`, pointed at the internal S3-compatible endpoint.
- Bumps the `nix-ai` flake input to pick up the `sessionArchive` module (now on `nix-ai`'s `main`).

## Test plan

- [x] `nix build .#lib.ci.hmActivationPackage` succeeds locally, including the new `dev.session-archive.plist` derivation.
- [x] `scripts/workflows/verify-symlinks.sh` passes against the built closure.
- [ ] CI (`ci-gate.yml` / `_nix-build.yml`) green on this PR.