### PR TITLE
fix(cribl,launchd): stop cribl-edge cold-boot race; verify self-heal actually revives daemons

### DIFF
--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -224,7 +224,15 @@ in
         Label = "com.nix-darwin.cribl-edge";
         ProgramArguments = [ "${startScript}/bin/cribl-edge-start" ];
         RunAtLoad = true;
-        KeepAlive = true;
+        # Plain `KeepAlive = true` races the Nix store mount at cold boot:
+        # /nix is a separate APFS volume mounted by the async RunAtLoad
+        # `systems.determinate.nix-store` daemon, so ProgramArguments'
+        # /nix/store/... path can be missing when launchd first spawns this
+        # daemon, crashing it into the penalty box for the rest of the
+        # uptime (observed both Macs, 2026-08-08 reboot). PathState makes
+        # launchd itself wait for /nix/store to exist before spawning, and
+        # keeps watching it — no reboot-dependent recovery needed.
+        KeepAlive.PathState."/nix/store" = true;
         ThrottleInterval = 10;
         UserName = cfg.serviceUser;
         GroupName = cfg.serviceGroup;

--- a/modules/darwin/launchd-self-heal.nix
+++ b/modules/darwin/launchd-self-heal.nix
@@ -50,30 +50,7 @@ in
       # — no `set -e`/early exit; every failure is a non-fatal warning so the
       # critical /run/current-system symlink update is never blocked.
       system.activationScripts.postActivation.text = lib.mkAfter ''
-        echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: checking ${toString (builtins.length uniqueLabels)} critical daemon(s)..."
-        for label in ${lib.escapeShellArgs uniqueLabels}; do
-          plist="/Library/LaunchDaemons/$label.plist"
-          if [ ! -f "$plist" ]; then
-            echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label plist missing, skipping" >&2
-            continue
-          fi
-          # A running daemon prints a numeric `pid = N`; a dead/penalty-boxed one
-          # (state = spawn scheduled) has no pid line even though it is loaded.
-          if /bin/launchctl print system/"$label" 2>/dev/null | grep -qE '^[[:space:]]*pid = [0-9]+[[:space:]]*$'; then
-            continue
-          fi
-          # Not running. Force a clean reload. NEVER `launchctl kickstart` here —
-          # it HANGS forever on a penalty-boxed daemon. bootout clears the wedged
-          # state; bootstrap starts it fresh (RunAtLoad). bootout is allowed to
-          # fail (daemon may be fully absent), hence `|| true`.
-          echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label not running; reloading (bootout+bootstrap)" >&2
-          /bin/launchctl bootout system/"$label" 2>/dev/null || true
-          if /bin/launchctl bootstrap system "$plist" 2>/dev/null; then
-            echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded" >&2
-          else
-            echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label bootstrap failed" >&2
-          fi
-        done
+        ${./scripts/launchd-self-heal.sh} ${lib.escapeShellArgs uniqueLabels}
       '';
     };
 }

--- a/modules/darwin/scripts/launchd-self-heal.sh
+++ b/modules/darwin/scripts/launchd-self-heal.sh
@@ -40,7 +40,7 @@ for label in "$@"; do
   healed=0
   for wait_secs in 5 15; do
     /bin/launchctl bootout "system/$label" 2>/dev/null || true
-    /bin/launchctl bootstrap system "$plist" 2>/dev/null || true
+    /bin/launchctl bootstrap system "$plist" || true
     sleep "$wait_secs"
     if is_running "$label"; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded and running" >&2

--- a/modules/darwin/scripts/launchd-self-heal.sh
+++ b/modules/darwin/scripts/launchd-self-heal.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Self-heal critical KeepAlive LaunchDaemons after every activation.
+#
+# Args: one LaunchDaemon label per positional argument (e.g.
+# com.nix-darwin.cribl-edge). See modules/darwin/launchd-self-heal.nix for
+# the option that feeds this script and the full rationale.
+#
+# No `set -e`: every failure here must be a non-fatal warning so the
+# critical /run/current-system symlink update (which runs after this) is
+# never blocked. See docs/ACTIVATION-SCRIPTS-RULES.md.
+set -uo pipefail
+
+is_running() {
+  /bin/launchctl print "system/$1" 2>/dev/null | grep -qE '^[[:space:]]*pid = [0-9]+[[:space:]]*$'
+}
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: checking $# critical daemon(s)..."
+for label in "$@"; do
+  plist="/Library/LaunchDaemons/$label.plist"
+  if [ ! -f "$plist" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label plist missing, skipping" >&2
+    continue
+  fi
+
+  if is_running "$label"; then
+    continue
+  fi
+
+  # Not running. Force a clean reload. NEVER `launchctl kickstart` here — it
+  # HANGS forever on a penalty-boxed daemon. bootout clears the wedged state;
+  # bootstrap starts it fresh (RunAtLoad). bootout is allowed to fail (daemon
+  # may be fully absent), hence `|| true`.
+  #
+  # A single reload isn't proof of life: if the daemon's cause of death is
+  # still present (e.g. a genuinely broken config, not just a wedged launchd
+  # state), the fresh spawn crashes again immediately and relapses into the
+  # penalty box with nothing to notice. So re-check after each attempt and
+  # retry once more with a longer wait before giving up loudly.
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] launchd self-heal: $label not running; reloading (bootout+bootstrap)" >&2
+  healed=0
+  for wait_secs in 5 15; do
+    /bin/launchctl bootout "system/$label" 2>/dev/null || true
+    /bin/launchctl bootstrap system "$plist" 2>/dev/null || true
+    sleep "$wait_secs"
+    if is_running "$label"; then
+      echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] launchd self-heal: $label reloaded and running" >&2
+      healed=1
+      break
+    fi
+  done
+  if [ "$healed" -ne 1 ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [ERROR] launchd self-heal: $label still not running after reload retries — needs manual investigation" >&2
+  fi
+done


### PR DESCRIPTION
## Summary
- `cribl-edge`'s LaunchDaemon spawns from a `/nix/store/...` path but `/nix` is a separate APFS volume mounted asynchronously at boot; a cold-boot race could crash it (exit 78 EX_CONFIG) into launchd's penalty box for the rest of the uptime. `KeepAlive.PathState."/nix/store" = true` makes launchd wait for the mount instead of racing it.
- `launchd-self-heal`'s postActivation loop only reloads a dead daemon once per activation with no check that the reload actually worked. Extracted to `modules/darwin/scripts/launchd-self-heal.sh` and added a retry (5s, then 15s) with a proof-of-life re-check, logging loudly if still dead.

## Test plan
- [x] `nix fmt` — no changes
- [x] `statix check` / `deadnix` — clean
- [x] `shellcheck modules/darwin/scripts/launchd-self-heal.sh` — clean
- [x] `nix flake check --no-build` — both `darwinConfigurations.jevans-mbp` and `darwinConfigurations.jevans-ms` evaluate
- [ ] CI (`ci-gate.yml`)
- [ ] Manual verification on both Macs after next `darwin-rebuild switch`: confirm `cribl-edge` survives a full reboot cycle

Do not merge — reported for review per team-lead request.

Assisted-by: Claude:claude-fable-5

https://claude.ai/code/session_01JUC9nrRCjvRfpbceCRgDp9