### PR TITLE
feat: wire VCT CLI workstations

### DIFF
--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -8,7 +8,6 @@
 {
   config,
   lib,
-  options,
   osConfig,
   pkgs,
   hostConfig,
@@ -190,8 +189,10 @@ in
       };
       sweepRoots = [ "${config.home.homeDirectory}/.local/share/uv/python" ];
     };
-  }
-  // lib.optionalAttrs (options.programs ? vctCli) {
+
+    # VisiCore operator CLIs — workstation-only. Set unconditionally so a
+    # nix-ai lock predating the option fails the build instead of quietly
+    # dropping the feature.
     vctCli.enable = !hostConfig.isServer;
   };
 

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -8,6 +8,7 @@
 {
   config,
   lib,
+  options,
   osConfig,
   pkgs,
   hostConfig,
@@ -62,13 +63,6 @@ in
     ./mlx-cluster-signing.nix
   ];
 
-  # Share system-level Homebrew taps with nix-ai's trust.json.
-  # homebrew.taps entries can be strings or submodule attrsets (nix-darwin
-  # normalizes to attrsets with a `name`); the nix-ai option takes strings.
-  programs.ai-homebrew.trustedTaps = map (
-    t: if builtins.isString t then t else t.name
-  ) osConfig.homebrew.taps;
-
   # ==========================================================================
   # macOS Application Management (copyApps for TCC stability)
   # ==========================================================================
@@ -118,6 +112,11 @@ in
   };
 
   programs = {
+    # Share system-level Homebrew taps with nix-ai's trust.json.
+    # homebrew.taps entries can be strings or submodule attrsets (nix-darwin
+    # normalizes to attrsets with a `name`); the nix-ai option takes strings.
+    ai-homebrew.trustedTaps = map (t: if builtins.isString t then t else t.name) osConfig.homebrew.taps;
+
     # --- GitHub credentials for git: OpenBao-minted, never keychain ---
     # git resolves GitHub HTTPS credentials through the OpenBao-backed wrapper
     # (modules/darwin/apps/openbao-github-creds.nix): ambient READ tokens per
@@ -191,6 +190,9 @@ in
       };
       sweepRoots = [ "${config.home.homeDirectory}/.local/share/uv/python" ];
     };
+  }
+  // lib.optionalAttrs (options.programs ? vctCli) {
+    vctCli.enable = !hostConfig.isServer;
   };
 
   # ==========================================================================

--- a/hosts/common/zsh-macos.nix
+++ b/hosts/common/zsh-macos.nix
@@ -17,16 +17,11 @@
   ...
 }:
 let
-  system = pkgs.stdenv.hostPlatform.system;
-  vctPackages =
-    if nix-ai ? packages && builtins.hasAttr system nix-ai.packages then
-      nix-ai.packages.${system}
-    else
-      { };
-  vctCriblPkg =
-    if builtins.hasAttr "vct-cribl-cli" vctPackages then vctPackages.vct-cribl-cli else null;
-  vctSplunkPkg =
-    if builtins.hasAttr "vct-splunk-cli" vctPackages then vctPackages.vct-splunk-cli else null;
+  # Referenced unconditionally: a nix-ai lock too old to carry these packages
+  # must fail the build loudly. Guarding the lookup would drop both launchers
+  # silently and leave `cribl`/`splunk` resolving to the uncredentialed
+  # binaries on PATH with nothing said about it.
+  inherit (nix-ai.packages.${pkgs.stdenv.hostPlatform.system}) vct-cribl-cli vct-splunk-cli;
 in
 {
   programs.zsh = {
@@ -95,14 +90,19 @@ in
       # --- VisiCore operator CLI launchers ---
       # Selectors come from the automation keychain at call time; Doppler
       # injects the actual credentials only into the child process.
-      ${lib.optionalString (!hostConfig.isServer && vctCriblPkg != null && vctSplunkPkg != null) ''
+      #
+      # The keychain identity is interpolated at build time rather than read
+      # from $_KC_AI_ACCOUNT/$_KC_AI_DB: those are unset at the end of this
+      # file, so a call-time read of them resolves to the empty string and
+      # every launch fails against the wrong keychain.
+      ${lib.optionalString (!hostConfig.isServer) ''
         _vct_with_doppler() {
           local exe="$1"
           shift
 
           local doppler_project doppler_config
-          doppler_project="$(_get_keychain_secret 'VCT_DOPPLER_PROJECT' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"
-          doppler_config="$(_get_keychain_secret 'VCT_DOPPLER_CONFIG' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"
+          doppler_project="$(_get_keychain_secret 'VCT_DOPPLER_PROJECT' ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
+          doppler_config="$(_get_keychain_secret 'VCT_DOPPLER_CONFIG' ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
 
           if [ -z "$doppler_project" ] || [ -z "$doppler_config" ]; then
             print -u2 "[vct-cli] ERROR missing Doppler selector keychain entries for VCT_DOPPLER_PROJECT or VCT_DOPPLER_CONFIG"
@@ -113,11 +113,11 @@ in
         }
 
         _vct_cribl() {
-          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vctCriblPkg)} "$@"
+          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vct-cribl-cli)} "$@"
         }
 
         _vct_splunk() {
-          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vctSplunkPkg)} "$@"
+          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vct-splunk-cli)} "$@"
         }
 
         alias cribl='_vct_cribl'

--- a/hosts/common/zsh-macos.nix
+++ b/hosts/common/zsh-macos.nix
@@ -10,10 +10,24 @@
 # sources resolve from this directory.
 {
   lib,
+  nix-ai,
+  pkgs,
   userConfig,
   hostConfig,
   ...
 }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  vctPackages =
+    if nix-ai ? packages && builtins.hasAttr system nix-ai.packages then
+      nix-ai.packages.${system}
+    else
+      { };
+  vctCriblPkg =
+    if builtins.hasAttr "vct-cribl-cli" vctPackages then vctPackages.vct-cribl-cli else null;
+  vctSplunkPkg =
+    if builtins.hasAttr "vct-splunk-cli" vctPackages then vctPackages.vct-splunk-cli else null;
+in
 {
   programs.zsh = {
     # mkBefore preserves the pre-split merge order (macos ahead of nix-home's
@@ -65,9 +79,6 @@
         export OPENAI_API_KEY=''${OPENAI_API_KEY:-"$(_get_keychain_secret 'OPENAI_API_KEY' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"}
       ''}
 
-      unset -f _get_keychain_secret  # No longer needed after init
-      unset _KC_USER _KC_AI_ACCOUNT _KC_AI_DB
-
       # --- GitHub authentication ---
       # GitHub tokens are minted on demand by OpenBao (ephemeral GitHub App
       # installation tokens) through the openbao-github-creds git credential
@@ -80,6 +91,40 @@
       ${lib.optionalString (!hostConfig.isServer) ''
         source ${./gh-auth.zsh}
       ''}
+
+      # --- VisiCore operator CLI launchers ---
+      # Selectors come from the automation keychain at call time; Doppler
+      # injects the actual credentials only into the child process.
+      ${lib.optionalString (!hostConfig.isServer && vctCriblPkg != null && vctSplunkPkg != null) ''
+        _vct_with_doppler() {
+          local exe="$1"
+          shift
+
+          local doppler_project doppler_config
+          doppler_project="$(_get_keychain_secret 'VCT_DOPPLER_PROJECT' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"
+          doppler_config="$(_get_keychain_secret 'VCT_DOPPLER_CONFIG' "$_KC_AI_ACCOUNT" "$_KC_AI_DB")"
+
+          if [ -z "$doppler_project" ] || [ -z "$doppler_config" ]; then
+            print -u2 "[vct-cli] ERROR missing Doppler selector keychain entries for VCT_DOPPLER_PROJECT or VCT_DOPPLER_CONFIG"
+            return 1
+          fi
+
+          doppler run -p "$doppler_project" -c "$doppler_config" -- "$exe" "$@"
+        }
+
+        _vct_cribl() {
+          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vctCriblPkg)} "$@"
+        }
+
+        _vct_splunk() {
+          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vctSplunkPkg)} "$@"
+        }
+
+        alias cribl='_vct_cribl'
+        alias splunk='_vct_splunk'
+      ''}
+
+      unset _KC_USER _KC_AI_ACCOUNT _KC_AI_DB
 
       # --- Custom-auth launcher for `claude` ---
       # Defines av-claude <profile> (aws-vault exec <profile> -- claude).

--- a/hosts/common/zsh-macos.nix
+++ b/hosts/common/zsh-macos.nix
@@ -17,11 +17,9 @@
   ...
 }:
 let
-  # Referenced unconditionally: a nix-ai lock too old to carry these packages
-  # must fail the build loudly. Guarding the lookup would drop both launchers
-  # silently and leave `cribl`/`splunk` resolving to the uncredentialed
-  # binaries on PATH with nothing said about it.
-  inherit (nix-ai.packages.${pkgs.stdenv.hostPlatform.system}) vct-cribl-cli vct-splunk-cli;
+  # Referenced unconditionally: a nix-ai lock too old to carry this package
+  # must fail the build loudly instead of silently dropping the launcher.
+  inherit (nix-ai.packages.${pkgs.stdenv.hostPlatform.system}) vct-cribl-cli;
 in
 {
   programs.zsh = {
@@ -87,41 +85,34 @@ in
         source ${./gh-auth.zsh}
       ''}
 
-      # --- VisiCore operator CLI launchers ---
-      # Selectors come from the automation keychain at call time; Doppler
-      # injects the actual credentials only into the child process.
+      # --- Keychain-selected Doppler launcher ---
+      # Accepts any command. Doppler's standard project/config selectors come
+      # from the automation keychain at call time, and the selected project's
+      # credentials exist only in the child process.
       #
       # The keychain identity is interpolated at build time rather than read
       # from $_KC_AI_ACCOUNT/$_KC_AI_DB: those are unset at the end of this
       # file, so a call-time read of them resolves to the empty string and
       # every launch fails against the wrong keychain.
       ${lib.optionalString (!hostConfig.isServer) ''
-        _vct_with_doppler() {
-          local exe="$1"
-          shift
-
+        _with_keychain_doppler() {
           local doppler_project doppler_config
-          doppler_project="$(_get_keychain_secret 'VCT_DOPPLER_PROJECT' ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
-          doppler_config="$(_get_keychain_secret 'VCT_DOPPLER_CONFIG' ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
+          doppler_project="$(_get_keychain_secret DOPPLER_PROJECT ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
+          doppler_config="$(_get_keychain_secret DOPPLER_CONFIG ${lib.escapeShellArg userConfig.keychain.aiAccount} ${lib.escapeShellArg userConfig.keychain.aiDb})"
 
           if [ -z "$doppler_project" ] || [ -z "$doppler_config" ]; then
-            print -u2 "[vct-cli] ERROR missing Doppler selector keychain entries for VCT_DOPPLER_PROJECT or VCT_DOPPLER_CONFIG"
+            print -u2 "[doppler] ERROR missing DOPPLER_PROJECT or DOPPLER_CONFIG in the automation Keychain"
             return 1
           fi
 
-          doppler run -p "$doppler_project" -c "$doppler_config" -- "$exe" "$@"
+          DOPPLER_PROJECT="$doppler_project" DOPPLER_CONFIG="$doppler_config" doppler run -- "$@"
         }
 
         _vct_cribl() {
-          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vct-cribl-cli)} "$@"
-        }
-
-        _vct_splunk() {
-          _vct_with_doppler ${lib.escapeShellArg (lib.getExe vct-splunk-cli)} "$@"
+          _with_keychain_doppler ${lib.escapeShellArg (lib.getExe vct-cribl-cli)} "$@"
         }
 
         alias cribl='_vct_cribl'
-        alias splunk='_vct_splunk'
       ''}
 
       unset _KC_USER _KC_AI_ACCOUNT _KC_AI_DB


### PR DESCRIPTION
## Summary
- enable the locked operator CLI packages on non-server hosts
- run Cribl through the generic Keychain-selected Doppler launcher using Doppler standard selectors
- leave Splunk as the directly installed Nix executable

## Testing
- `nix fmt`
- `nix flake check`
- generated `jevans-mbp` zsh syntax and launcher behavior checks
- workstation system build