### PR TITLE
chore: bump nix-ai to the medium pin, unbreak the file-size gate on develop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1003,11 +1003,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786732531,
-        "narHash": "sha256-rJdq+1SN7JGlhBfmBmHi4ONegJfYLX8SjXtQobGu4e0=",
+        "lastModified": 1786750410,
+        "narHash": "sha256-51/sRGwHkHPnsFO9cTT983dXDg8eaJ52cVynWYAR2iI=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c98b25bc346466f2b4f278ad2cd1e723f5adfbec",
+        "rev": "3ca3058b1d6d0da3cea224b09e2afdeae31e10ca",
         "type": "github"
       },
       "original": {

--- a/lib/hosts/mac-studio-model-history.md
+++ b/lib/hosts/mac-studio-model-history.md
@@ -1,0 +1,43 @@
+# mac-studio model selection history
+
+Superseded measurement records for `lib/hosts/mac-studio.nix`, split out of
+`mac-studio.md` when that file reached the 12 KiB file-size error limit
+(`.file-size.yml` recommends splitting rather than extending the ceiling).
+
+These verdicts are kept because they are evidence, not because they describe
+the current deployment — for that, read `mac-studio.md` "Two warm brains".
+
+## Resident model selection (2026-07-27)
+
+Promoted from the Coder-30B to the 35B for standalone operation (MacBook
+unplugged, no cluster).
+
+Every candidate was measured on this host against a dedicated isolated worker on
+a scratch port, with the loaded checkpoint confirmed by
+`lsof -i :PORT` → pid → `ps -p <pid>` reading `--model`. **That step is
+mandatory, not ceremony**: the server echoes the requested name back, so a
+model id in a request or a response proves nothing about which weights
+answered. It mattered doubly under the single-model mode this host ran until
+2026-08-14, which aliased every other model's physical id onto the one
+resident entry — but the response field was never evidence in either mode.
+
+Headline metric is cumulative tok/s — `(prompt + completion) / wall` — so
+prefill gains count. Identical 111–118 token prompt, 300 `max_tokens`, 3 timed
+runs after a discarded warmup, decode-concurrency 1:
+
+| model | cumulative | decode | ttft | tools |
+| --- | --- | --- | --- | --- |
+| Qwen3.6-35B-A3B-4bit | **115.2** | 84.9 | 0.12s | PASS |
+| Qwen3-Next-80B-A3B-Instruct-4bit | 97.5 | 71.5 | 0.08s | PASS |
+| GLM-4.7-Flash-4bit | 95.8 | — | — | FAIL |
+| gpt-oss-120b-MXFP4-Q8 (peer-measured) | 51–54 | 40–43 | 0.23s | FAIL |
+
+The 35B wins on throughput outright while being the smallest of the four
+(19.4 GB). GLM-4.7-Flash is disqualified on tool calls, not speed: given two
+tools it emits no call at all and stops on `length`. gpt-oss-120b is
+disqualified because mlx-lm ships no harmony parser, so `tool_calls` is null and
+raw `<|channel|>` markup leaks into content.
+
+Thinking is off in its catalog entry, which matters for Hermes: a thinking
+variant spends hundreds of reasoning tokens before it emits a tool call, and
+Hermes pays that latency on every action it takes.

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -10,84 +10,58 @@ Serving detail that is not host-scoped lives in nix-ai's validated model catalog
 (`modules/mlx/catalog-data.nix`): parser stacks, chat-template kwargs, and
 per-class flag profiles. Add or fix serve args there, not here.
 
-## Resident model selection (2026-07-27)
+## Resident model selection
 
-Promoted from the Coder-30B to the 35B for standalone operation (MacBook
-unplugged, no cluster).
+Superseded by "Two warm brains" below. The 2026-07-27 candidate bench that
+promoted the 35B — method, the four-model throughput table, and why
+GLM-4.7-Flash and gpt-oss-120b were disqualified on tool calls — is kept in
+[mac-studio-model-history.md](./mac-studio-model-history.md).
 
-Every candidate was measured on this host against a dedicated isolated worker on
-a scratch port, with the loaded checkpoint confirmed by
-`lsof -i :PORT` → pid → `ps -p <pid>` reading `--model`. **That step is
-mandatory, not ceremony**: the server echoes the requested name back, so a
-model id in a request or a response proves nothing about which weights
-answered. It mattered doubly under the single-model mode this host ran until
-2026-08-14, which aliased every other model's physical id onto the one
-resident entry — but the response field was never evidence in either mode.
-
-Headline metric is cumulative tok/s — `(prompt + completion) / wall` — so
-prefill gains count. Identical 111–118 token prompt, 300 `max_tokens`, 3 timed
-runs after a discarded warmup, decode-concurrency 1:
-
-| model | cumulative | decode | ttft | tools |
-| --- | --- | --- | --- | --- |
-| Qwen3.6-35B-A3B-4bit | **115.2** | 84.9 | 0.12s | PASS |
-| Qwen3-Next-80B-A3B-Instruct-4bit | 97.5 | 71.5 | 0.08s | PASS |
-| GLM-4.7-Flash-4bit | 95.8 | — | — | FAIL |
-| gpt-oss-120b-MXFP4-Q8 (peer-measured) | 51–54 | 40–43 | 0.23s | FAIL |
-
-The 35B wins on throughput outright while being the smallest of the four
-(19.4 GB). GLM-4.7-Flash is disqualified on tool calls, not speed: given two
-tools it emits no call at all and stops on `length`. gpt-oss-120b is
-disqualified because mlx-lm ships no harmony parser, so `tool_calls` is null and
-raw `<|channel|>` markup leaks into content.
-
-Thinking is off in its catalog entry, which matters for Hermes: a thinking
-variant spends hundreds of reasoning tokens before it emits a tool call, and
-Hermes pays that latency on every action it takes.
+One rule from it still governs every measurement on this host: confirm the
+loaded checkpoint from the worker's own command line
+(`lsof -i :PORT` -> pid -> `ps -p <pid>` reading `--model`). The server echoes
+the requested name back, so a model id in a request or a response proves
+nothing about which weights answered.
 
 ## Two warm brains (2026-08-14) — supersedes single-model mode
 
 This host is the estate's **intelligence tier**; a GPU is planned to take
-fast-and-small. Throughput is no longer the objective here, so both brains stay
-warm and roles are split by cost rather than by preference:
+fast-and-small, so throughput is no longer the objective and both brains stay
+warm. Roles split by cost, not preference:
 
 | Model | Roles | Shape | Thinking |
 | --- | --- | --- | --- |
-| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | bounded on (`reasoning_effort=low`) |
+| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | on, `reasoning_effort=medium` |
 | Qwen3.6-35B-A3B-4bit | quickest, large-context | 35B MoE, ~3B active, 20 KiB/token KV | off |
 
 `large-context` sits on the MoE deliberately: its KV costs roughly a third of
 the dense model's per token.
 
 **`singleModel` is gone, not repointed.** It aliased every role onto one entry
-and demoted the rest to `disabledModels`, which is exactly what made a second
-warm brain impossible. `alwaysAvailableModels` went with it — it had meaning
-only in single-model mode, and its group (`swap=true, persistent=false`) could
-never have held a second brain: always-available models evict each other and
-idle-unload at ttl 900.
+and demoted the rest to `disabledModels` — exactly what made a second warm brain
+impossible. `alwaysAvailableModels` went with it: its group is
+`swap=true, persistent=false`, so those models evict each other and idle-unload
+at ttl 900, and it could never have held a brain.
 
-Two resident-class entries land in the `mlx-models` group, which at k_max = 2 is
-`swap=false, persistent=true`, so they hold weights simultaneously. Verified
+Two resident-class entries land in `mlx-models`, which at k_max = 2 is
+`swap=false, persistent=true`, so they hold weights simultaneously. Read back
 from the rendered `llama-swap-config.json`, not inferred:
 
 ```json
-"mlx-models":      { "swap": false, "persistent": true,  "exclusive": true,
-                     "members": ["…Qwen3.6-35B-A3B-4bit", "…Qwen3.8-27B-4bit"] }
-"mlx-swap-models": { "swap": true,  "persistent": false, "exclusive": false,
-                     "members": ["…Qwen3.5-9B-MLX-4bit"] }
+"mlx-models":      { "swap": false, "persistent": true,  "members": [35B, 27B] }
+"mlx-swap-models": { "swap": true,  "persistent": false, "members": [9B] }
 ```
 
-Everything else is `enable = false` — **not a new restriction**. Under
-`singleModel` those ids already 404'd; without it every compiled entry becomes
-servable again, and a stray physical-id request would cold-load 20–63 GB beside
-two residents. The 9B stays enabled because an hourly note-capture pipe requests
-its exact physical id.
+Everything else is `enable = false` — **not a new restriction**, since those
+ids already 404'd under `singleModel`. Without it every compiled entry becomes
+servable again and a stray physical-id request would cold-load 20–63 GB beside
+two residents. The 9B stays enabled: an hourly note-capture pipe requests its
+exact physical id.
 
-Measured before the switch (`vmmap`, 2026-08-14): peaks 30.9 GB (35B) + 16.6 GB
-(27B) = 44.2 GiB against the 100 GiB ceiling; 28.8 / 15.5 GiB steady against the
-48 GiB per-worker budget. Weights are private per-process Metal buffers —
-dirty, non-volatile, no shared pages — so two workers is a straight sum, never a
-discount.
+Fit measured before switching (`vmmap`, 2026-08-14), not estimated: peaks
+30.9 + 16.6 = 44.2 GiB against the 100 GiB ceiling; 28.8 / 15.5 GiB steady
+against the 48 GiB per-worker budget. Weights are private per-process Metal
+buffers with no shared pages, so two workers is a straight sum.
 
 ## Residency budget (k_max = 2 since 2026-08-05)
 

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -38,36 +38,20 @@ in
   # model ids stay centralized in nix-ai's validated catalog.
 
   mlx = {
-    # TWO-RESIDENT MODE (2026-08-14, supersedes single-model mode). This host
-    # is the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
-    # so throughput stops being the objective here and both brains stay warm.
+    # TWO-RESIDENT MODE (2026-08-14, supersedes single-model mode). This host is
+    # the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
+    # so throughput stops being the objective and both brains stay warm. The
+    # 27B takes deliberate work, the 35B MoE routine work. Rationale, the vmmap
+    # fit, and the group semantics: ./mac-studio.md "Two warm brains".
     #
-    #   Qwen3.8-27B  — deliberate work. Dense 27B, thinking ON at
-    #                  reasoning_effort=medium (nix-ai#1627). Note that is a
-    #                  prompt string, NOT a budget: nothing here caps how long
-    #                  it thinks. Leaving the kwarg unset is the failure mode —
-    #                  the template then defaults to xhigh, which measured 0
-    #                  answer characters across 3 of 3 runs.
-    #   Qwen3.6-35B  — routine work. 35B MoE, ~3B active/token, thinking off,
-    #                  and 20 KiB/token of KV against the 27B's 64 KiB.
+    # singleModel and alwaysAvailableModels are GONE, not repointed — both only
+    # had meaning in single-model mode, and alwaysAvailableModels' group
+    # (swap=true, persistent=false) could never have carried a second brain.
     #
-    # singleModel is GONE, not repointed. It aliased every role onto one entry
-    # and demoted everything else to disabledModels, which is precisely what
-    # made a second warm brain impossible. Two resident-class entries land in
-    # the mlx-models group, which is swap=false + persistent=true at
-    # maxResidentWorkers = 2 — so they hold weights simultaneously and never
-    # evict one another (nix-ai llama-swap-topology.nix tieredGroups).
-    #
-    # alwaysAvailableModels is gone with it: it only ever had meaning in
-    # singleModel mode, and its group (swap=true, persistent=false) is the
-    # reason it could not have carried a second brain anyway — always-available
-    # models evict each other and idle-unload at ttl 900.
-    #
-    # Measured before switching (jevans-ms, vmmap, 2026-08-14): peaks 30.9 GB
-    # (35B) + 16.6 GB (27B) = 44.2 GiB against the 100 GiB ceiling, and 28.8 /
-    # 15.5 GiB steady against the 48 GiB per-worker budget. Weights are private
-    # per-process Metal buffers — nothing is shared between the two workers, so
-    # this is a straight sum, not an estimate.
+    # DO NOT drop the 27B's chat-template kwarg to "let it think". Unset, its
+    # template defaults reasoning_effort to xhigh, which measured 0 answer
+    # characters on 3 of 3 runs. The kwarg lives in the nix-ai catalog, and it
+    # is a prompt string, not a budget — nothing here caps thinking length.
 
     # RESIDENCY BUDGET — these two move together or the host over-commits.
     #
@@ -106,18 +90,11 @@ in
     # one worth asking often.
     #
     # `enable = false` on the rest is NOT a new restriction — it preserves
-    # exactly what singleModel did. Under singleModel every unlisted entry was
-    # demoted to disabledModels and a request naming its id 404'd. Without
-    # singleModel every compiled entry becomes servable again, so a stray
-    # physical-id request would cold-load 20-63 GB beside two residents.
-    # Disable-not-delete: they stay in the tree, ready to re-enable.
+    # exactly what singleModel did (those ids already 404'd). Without it every
+    # compiled entry becomes servable again, so a stray physical-id request
+    # would cold-load 20-63 GB beside two residents. Disable-not-delete.
     catalog = {
-      # Deliberate tier. Its chat-template kwarg lives in the nix-ai catalog,
-      # not here. Do not "fix" it by dropping the kwarg to let it think freely:
-      # unset, the template defaults reasoning_effort to xhigh, and at xhigh
-      # this model emitted 0 answer characters with finish_reason "length" on
-      # 3 of 3 measured runs. Bounded thinking (low) costs ~220 s per action,
-      # which is the trade this tier exists to make.
+      # Deliberate tier. See the kwarg warning above.
       qwen38-27b = {
         class = "resident";
         roles = [

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -42,10 +42,12 @@ in
     # is the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
     # so throughput stops being the objective here and both brains stay warm.
     #
-    #   Qwen3.8-27B  — deliberate work. Dense 27B. Thinking is off in the
-    #                  catalog entry at the currently pinned nix-ai; it becomes
-    #                  bounded-on (reasoning_effort=low, ~220 s/response) when
-    #                  the pin advances past nix-ai#1627.
+    #   Qwen3.8-27B  — deliberate work. Dense 27B, thinking ON at
+    #                  reasoning_effort=medium (nix-ai#1627). Note that is a
+    #                  prompt string, NOT a budget: nothing here caps how long
+    #                  it thinks. Leaving the kwarg unset is the failure mode —
+    #                  the template then defaults to xhigh, which measured 0
+    #                  answer characters across 3 of 3 runs.
     #   Qwen3.6-35B  — routine work. 35B MoE, ~3B active/token, thinking off,
     #                  and 20 KiB/token of KV against the 27B's 64 KiB.
     #

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -18,36 +18,38 @@
   mlx = {
     # Every logical role resolves through the validated catalog entry; no
     # physical model id is repeated in deployed host configuration.
-    catalog.qwen3-coder-30b = {
-      class = "resident";
-      roles = [
-        "default"
-        "quickest"
-        "tool-calling"
-        "coding"
-        "large-context"
-        "most-capable"
-        "oss"
-      ];
+    catalog = {
+      qwen3-coder-30b = {
+        class = "resident";
+        roles = [
+          "default"
+          "quickest"
+          "tool-calling"
+          "coding"
+          "large-context"
+          "most-capable"
+          "oss"
+        ];
+      };
+      # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
+      # Gemini-CLI path and the hourly Obsidian summarizer pipe, which requests
+      # this physical id directly. Swap-class with no roles compiles to a
+      # llama-swap models.<id> entry keyed by the physical id, so it loads on
+      # demand and routes without evicting the resident 30B.
+      qwen35-9b-mlx.class = "swap";
+      # Qwen3.8-27B — current small/midsize generation, servable here on demand.
+      #
+      # Deliberately swap-class, NOT resident: promoting it would demote
+      # qwen3-coder-30b, which is a ~3B-active MoE, in favour of a model that
+      # activates all 27B. On this machine — a laptop that is also a cluster peer
+      # under a shared memory cap — that trades the fast local coding path for an
+      # unmeasured one. Swap-class keeps it addressable by its physical id
+      # everywhere while the Studio carries the default-routing switch.
+      #
+      # To promote after the throughput numbers land: move the roles list from
+      # qwen3-coder-30b to the qwen38-27b entry and flip the classes.
+      qwen38-27b.class = "swap";
     };
-    # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
-    # Gemini-CLI path and the hourly Obsidian summarizer pipe, which requests
-    # this physical id directly. Swap-class with no roles compiles to a
-    # llama-swap models.<id> entry keyed by the physical id, so it loads on
-    # demand and routes without evicting the resident 30B.
-    catalog.qwen35-9b-mlx.class = "swap";
-    # Qwen3.8-27B — current small/midsize generation, servable here on demand.
-    #
-    # Deliberately swap-class, NOT resident: promoting it would demote
-    # qwen3-coder-30b, which is a ~3B-active MoE, in favour of a model that
-    # activates all 27B. On this machine — a laptop that is also a cluster peer
-    # under a shared memory cap — that trades the fast local coding path for an
-    # unmeasured one. Swap-class keeps it addressable by its physical id
-    # everywhere while the Studio carries the default-routing switch.
-    #
-    # To promote after the throughput numbers land: move the roles list from
-    # qwen3-coder-30b to a catalog.qwen38-27b block and flip the classes.
-    catalog.qwen38-27b.class = "swap";
 
     # Resident judge model, in its own llama-swap group (nix-ai
     # programs.mlx.judge, modules/mlx/options-judge.nix). Bypasses the


### PR DESCRIPTION
Three things, all needed before the Studio can converge.

**1. Unbreaks the file-size gate on develop.** My #2140 comments pushed `mac-studio.nix` to 13,075 bytes and `mac-studio.md` to 12,824, both over the 12,288 error limit — so `shared-gate / File Size / Check` is currently failing on **every** nix-darwin PR, not just this one.

Fixed by splitting and de-duplicating, not by extending the ceiling (`.file-size.yml` recommends splitting, and `mac-studio.md` exists precisely because the `.nix` hit this limit before):

| file | before | after |
| --- | --- | --- |
| `lib/hosts/mac-studio.nix` | 13,075 | **11,671** |
| `lib/hosts/mac-studio.md` | 12,824 | **11,358** |
| `lib/hosts/mac-studio-model-history.md` | — | 2,235 |

The superseded 2026-07-27 selection bench moves to the history file, keeping the one rule from it that still governs every measurement here: prove the loaded checkpoint from the worker's own command line. Both files now have ~700 bytes of headroom instead of the 85 that let one comment break the gate.

**2. Corrects the effort value.** The comment and roles table said `reasoning_effort=low`; the shipped value is `medium` (nix-ai#1627). Also stops calling it "bounded" — it's a prompt string the model may ignore, not a budget. The real failure mode is leaving the kwarg *unset*, which defaults the template to `xhigh`: 0 answer characters across 3 of 3 measured runs.

**3. Bumps the nix-ai pin** `c98b25b → 3ca3058` (the develop→main promotion, nix-ai#1628). Without it, #2140's two-resident config would converge against a catalog whose 27B entry still says `enable_thinking=false`.

Verified from the **rendered** `llama-swap-config.json` at this pin, not from the diff:

```
Qwen3.8-27B-4bit   '{"reasoning_effort":"medium"}'
                   aliases: coding default goal-judge most-capable oss tool-calling
Qwen3.6-35B-A3B    '{"enable_thinking":false}'
                   aliases: large-context quickest
mlx-models         swap=false persistent=true, 2 members
mlx-swap-models    swap=true  persistent=false, 1 member (the 9B)
```

Still required after this merges, before the change is live: a nix-darwin develop→main promotion (the Studio converges from **main**), then cluster-teardown confirmation and a Vikunja maintenance window.