### PR TITLE
chore: promote develop to main

### DIFF
--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -14,6 +14,11 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    # Intentionally non-negotiable: a full activation build past 20 minutes is
+    # a dependency or closure regression, not a reason to spend more CI time.
+    # Do not raise this cap; remove the source-build cause (as with Goose/BWS)
+    # so the failed required check blocks the regression until it is fixed.
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -110,7 +110,7 @@ Source: nix-home (`home.packages` via flake input)
 | Package | Description |
 | --- | --- |
 | bitwarden-cli | CLI for Bitwarden password manager (bw) |
-| bws | Bitwarden Secrets Manager CLI |
+| bws | Bitwarden Secrets Manager CLI, pinned from Bitwarden's official release to avoid nixpkgs' Rust source rebuild |
 | doppler | Doppler secrets manager CLI |
 
 ### Remote Shell

--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786704796,
-        "narHash": "sha256-h2RU4x1TULq3lwNqYf/Ja37BS5a4af8G09Krk4Y1aQs=",
+        "lastModified": 1786734499,
+        "narHash": "sha256-0Gab3PtPPqeE745klgkGBvRzJn5+kdCATN5EWM+WWh4=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "9e397cff66fab7b8aaef4f85214662c315f19dc3",
+        "rev": "38ee3253f5920e4a533c8f956bedb3ae96b12a9c",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
     "claude-code-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1786663793,
-        "narHash": "sha256-r63+HfQT9PdEOIjilhHFb8mZr9RE03YkYZKbwSQM0n8=",
+        "lastModified": 1786746050,
+        "narHash": "sha256-P7TI05eR2GGyRqbzzSykdPkuVFTGauBOEoNb4k/oU50=",
         "owner": "anthropics",
         "repo": "claude-code",
-        "rev": "1f6015b5d578adf79c8527443328a216d6b6a3f1",
+        "rev": "0fa8c19d50f70f9f383fb6ff5ce5209575267d21",
         "type": "github"
       },
       "original": {
@@ -439,11 +439,11 @@
     "dotgithub": {
       "flake": false,
       "locked": {
-        "lastModified": 1786662512,
-        "narHash": "sha256-xjpHB/SgNmbvNQWE+d7WsvThYnKpMC3nnYGE8MffnkQ=",
+        "lastModified": 1786731839,
+        "narHash": "sha256-yKUCLg9cncWW5cZWhGf0ae53dbIaEqXRnrkvDqNsQSM=",
         "owner": "dryvist",
         "repo": ".github",
-        "rev": "ab54a5221a70f64a35973d3f32ccc77897a156cd",
+        "rev": "3b4dde15d69b77abcea3eb8dd4433df8ad84695d",
         "type": "github"
       },
       "original": {
@@ -816,11 +816,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785933170,
-        "narHash": "sha256-e7RHrDuJqpBvduh1N+rq34zKSM1obFvjOINpK6mLTNk=",
+        "lastModified": 1786384856,
+        "narHash": "sha256-pQyLTJvR2/0JmTiqWtC6dNu4uJkGPcabfQ6NuxjL3s4=",
         "owner": "dryvist",
         "repo": "homelab-contracts",
-        "rev": "956b931032cd10f1c55438ac307ed74f06b38254",
+        "rev": "dca7b4f36ceb643e7177bf8dff95ed948ccc2488",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1786111298,
-        "narHash": "sha256-E4UuSCP9i2D7cvrpXDK0MBCPIxykhlkDvbN5by4jfRg=",
+        "lastModified": 1786745907,
+        "narHash": "sha256-Ap2tl7ZQ35ecPUYjSYtoSb6ELchFAHk1otEfGU61jvw=",
         "owner": "dryvist",
         "repo": "claude-code-plugins",
-        "rev": "09a498d93e9d4dd67616ca7e3f3bec0bc87c0332",
+        "rev": "a60c354eb7efc31789feb95dfc226c74d400a556",
         "type": "github"
       },
       "original": {
@@ -1003,11 +1003,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786732531,
-        "narHash": "sha256-rJdq+1SN7JGlhBfmBmHi4ONegJfYLX8SjXtQobGu4e0=",
+        "lastModified": 1786750410,
+        "narHash": "sha256-51/sRGwHkHPnsFO9cTT983dXDg8eaJ52cVynWYAR2iI=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c98b25bc346466f2b4f278ad2cd1e723f5adfbec",
+        "rev": "3ca3058b1d6d0da3cea224b09e2afdeae31e10ca",
         "type": "github"
       },
       "original": {
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783643909,
-        "narHash": "sha256-1jjabjQ7oDd0tW2MPqlzJsJwdnkJaXcEsREv+Sq7Ryw=",
+        "lastModified": 1786722813,
+        "narHash": "sha256-BfCcc2RqG2jCC2vCv87b7qFIF5ZF0LC/Kmu4Yx+Ca+I=",
         "owner": "dryvist",
         "repo": "nix-ai-open-harness",
-        "rev": "83c63ca64093dc31d3ed956a13e441b3a2fba89e",
+        "rev": "7fc3a8fc67c551b515444d614b5fb7124838747e",
         "type": "github"
       },
       "original": {
@@ -1172,11 +1172,11 @@
         "orbstack-kubernetes": "orbstack-kubernetes"
       },
       "locked": {
-        "lastModified": 1786624796,
-        "narHash": "sha256-QnY6CEXsrgjqCB0IWyIVY8I/ybNrA6/2mNyVVNZTBPg=",
+        "lastModified": 1786732769,
+        "narHash": "sha256-vN0PmuNRNa6NODFWsIuIOo/auL39HVG9latE1ARWAiI=",
         "owner": "dryvist",
         "repo": "nix-home",
-        "rev": "e1cc7a46cfff83c469ce7728a84d00de886146be",
+        "rev": "78940a37633ba5ccc1d11c5c346ef83ffd82ddae",
         "type": "github"
       },
       "original": {
@@ -1269,11 +1269,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1786534138,
+        "narHash": "sha256-fBJMdnKUTUDtfi/BYLr71HLaC9dG382arxLF2Egg2uo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "044bfe75bfe4c7bbe043dc17b5e42ea823b84a09",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     "autoresearch": {
       "flake": false,
       "locked": {
-        "lastModified": 1782200080,
-        "narHash": "sha256-nrV6ZUo6Q7p2tzGWCLurur4X8QXuZfOu5ioOZTyaqNQ=",
+        "lastModified": 1786573603,
+        "narHash": "sha256-Hwxlit87HPoHLLDiX/Tz4L5ONvmDf5B71KhTePNLyhU=",
         "owner": "uditgoenka",
         "repo": "autoresearch",
-        "rev": "870e9b8eca4fbe53cd6cb1247410373692e4aec3",
+        "rev": "050e30dc4ba0974b03f2873111b9901ec3211390",
         "type": "github"
       },
       "original": {
@@ -896,11 +896,11 @@
     "last30days-skill": {
       "flake": false,
       "locked": {
-        "lastModified": 1785550529,
-        "narHash": "sha256-wwpTbjl3sBDffXf4obDwpNSMEZX59yGWIbzqgaV5958=",
+        "lastModified": 1786139466,
+        "narHash": "sha256-aU0+GboMsmtpoOhJqQfe63EpLHcpuh00Q8ERbTdL3BM=",
         "owner": "mvanhorn",
         "repo": "last30days-skill",
-        "rev": "52f53312ff2f272e16bbc1785e1c04f9d9c19b31",
+        "rev": "1004324ad35a3ba656e6df0faabd54749e398455",
         "type": "github"
       },
       "original": {
@@ -1003,11 +1003,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786713955,
-        "narHash": "sha256-fR48Vgt46mF4gxq2H1xBS/6wqUeJbReTTl4NtEDc5hE=",
+        "lastModified": 1786732531,
+        "narHash": "sha256-rJdq+1SN7JGlhBfmBmHi4ONegJfYLX8SjXtQobGu4e0=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "cb497238e38d1a2b4c0c3d86c9daf46d372d09d5",
+        "rev": "c98b25bc346466f2b4f278ad2cd1e723f5adfbec",
         "type": "github"
       },
       "original": {
@@ -1253,11 +1253,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1786593342,
+        "narHash": "sha256-smTKQXMLLStzc8zJevMCckbk3My7SvbbLmPYZUJJKW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "6b5e5b7a6631f065bf6908986990b37d845f847f",
         "type": "github"
       },
       "original": {
@@ -1364,11 +1364,11 @@
     "ponytail": {
       "flake": false,
       "locked": {
-        "lastModified": 1784151135,
-        "narHash": "sha256-Y7d4s7uqjH6IbEXhqAiQ+yaxr6iiGcv2X64LuMtG1T8=",
+        "lastModified": 1786139041,
+        "narHash": "sha256-bGdXvzhWPwGdz3T2Yh2h6lf+3PBRFAfdBxP5pESmCHI=",
         "owner": "DietrichGebert",
         "repo": "ponytail",
-        "rev": "16f29800fd2681bdf24f3eb4ccffe38be3baec6b",
+        "rev": "2ed6c52c9d7e5e56942508591085fd45dea277d3",
         "type": "github"
       },
       "original": {

--- a/lib/hosts/mac-studio-model-history.md
+++ b/lib/hosts/mac-studio-model-history.md
@@ -1,0 +1,43 @@
+# mac-studio model selection history
+
+Superseded measurement records for `lib/hosts/mac-studio.nix`, split out of
+`mac-studio.md` when that file reached the 12 KiB file-size error limit
+(`.file-size.yml` recommends splitting rather than extending the ceiling).
+
+These verdicts are kept because they are evidence, not because they describe
+the current deployment — for that, read `mac-studio.md` "Two warm brains".
+
+## Resident model selection (2026-07-27)
+
+Promoted from the Coder-30B to the 35B for standalone operation (MacBook
+unplugged, no cluster).
+
+Every candidate was measured on this host against a dedicated isolated worker on
+a scratch port, with the loaded checkpoint confirmed by
+`lsof -i :PORT` → pid → `ps -p <pid>` reading `--model`. **That step is
+mandatory, not ceremony**: the server echoes the requested name back, so a
+model id in a request or a response proves nothing about which weights
+answered. It mattered doubly under the single-model mode this host ran until
+2026-08-14, which aliased every other model's physical id onto the one
+resident entry — but the response field was never evidence in either mode.
+
+Headline metric is cumulative tok/s — `(prompt + completion) / wall` — so
+prefill gains count. Identical 111–118 token prompt, 300 `max_tokens`, 3 timed
+runs after a discarded warmup, decode-concurrency 1:
+
+| model | cumulative | decode | ttft | tools |
+| --- | --- | --- | --- | --- |
+| Qwen3.6-35B-A3B-4bit | **115.2** | 84.9 | 0.12s | PASS |
+| Qwen3-Next-80B-A3B-Instruct-4bit | 97.5 | 71.5 | 0.08s | PASS |
+| GLM-4.7-Flash-4bit | 95.8 | — | — | FAIL |
+| gpt-oss-120b-MXFP4-Q8 (peer-measured) | 51–54 | 40–43 | 0.23s | FAIL |
+
+The 35B wins on throughput outright while being the smallest of the four
+(19.4 GB). GLM-4.7-Flash is disqualified on tool calls, not speed: given two
+tools it emits no call at all and stops on `length`. gpt-oss-120b is
+disqualified because mlx-lm ships no harmony parser, so `tool_calls` is null and
+raw `<|channel|>` markup leaks into content.
+
+Thinking is off in its catalog entry, which matters for Hermes: a thinking
+variant spends hundreds of reasoning tokens before it emits a tool call, and
+Hermes pays that latency on every action it takes.

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -18,10 +18,11 @@ unplugged, no cluster).
 Every candidate was measured on this host against a dedicated isolated worker on
 a scratch port, with the loaded checkpoint confirmed by
 `lsof -i :PORT` → pid → `ps -p <pid>` reading `--model`. **That step is
-mandatory, not ceremony**: single-model mode aliases every other model's
-physical id onto the resident entry and the server echoes the requested name
-back, so a model id in a request or a response proves nothing about which
-weights answered.
+mandatory, not ceremony**: the server echoes the requested name back, so a
+model id in a request or a response proves nothing about which weights
+answered. It mattered doubly under the single-model mode this host ran until
+2026-08-14, which aliased every other model's physical id onto the one
+resident entry — but the response field was never evidence in either mode.
 
 Headline metric is cumulative tok/s — `(prompt + completion) / wall` — so
 prefill gains count. Identical 111–118 token prompt, 300 `max_tokens`, 3 timed
@@ -43,6 +44,50 @@ raw `<|channel|>` markup leaks into content.
 Thinking is off in its catalog entry, which matters for Hermes: a thinking
 variant spends hundreds of reasoning tokens before it emits a tool call, and
 Hermes pays that latency on every action it takes.
+
+## Two warm brains (2026-08-14) — supersedes single-model mode
+
+This host is the estate's **intelligence tier**; a GPU is planned to take
+fast-and-small. Throughput is no longer the objective here, so both brains stay
+warm and roles are split by cost rather than by preference:
+
+| Model | Roles | Shape | Thinking |
+| --- | --- | --- | --- |
+| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | bounded on (`reasoning_effort=low`) |
+| Qwen3.6-35B-A3B-4bit | quickest, large-context | 35B MoE, ~3B active, 20 KiB/token KV | off |
+
+`large-context` sits on the MoE deliberately: its KV costs roughly a third of
+the dense model's per token.
+
+**`singleModel` is gone, not repointed.** It aliased every role onto one entry
+and demoted the rest to `disabledModels`, which is exactly what made a second
+warm brain impossible. `alwaysAvailableModels` went with it — it had meaning
+only in single-model mode, and its group (`swap=true, persistent=false`) could
+never have held a second brain: always-available models evict each other and
+idle-unload at ttl 900.
+
+Two resident-class entries land in the `mlx-models` group, which at k_max = 2 is
+`swap=false, persistent=true`, so they hold weights simultaneously. Verified
+from the rendered `llama-swap-config.json`, not inferred:
+
+```json
+"mlx-models":      { "swap": false, "persistent": true,  "exclusive": true,
+                     "members": ["…Qwen3.6-35B-A3B-4bit", "…Qwen3.8-27B-4bit"] }
+"mlx-swap-models": { "swap": true,  "persistent": false, "exclusive": false,
+                     "members": ["…Qwen3.5-9B-MLX-4bit"] }
+```
+
+Everything else is `enable = false` — **not a new restriction**. Under
+`singleModel` those ids already 404'd; without it every compiled entry becomes
+servable again, and a stray physical-id request would cold-load 20–63 GB beside
+two residents. The 9B stays enabled because an hourly note-capture pipe requests
+its exact physical id.
+
+Measured before the switch (`vmmap`, 2026-08-14): peaks 30.9 GB (35B) + 16.6 GB
+(27B) = 44.2 GiB against the 100 GiB ceiling; 28.8 / 15.5 GiB steady against the
+48 GiB per-worker budget. Weights are private per-process Metal buffers —
+dirty, non-volatile, no shared pages — so two workers is a straight sum, never a
+discount.
 
 ## Residency budget (k_max = 2 since 2026-08-05)
 
@@ -167,13 +212,20 @@ llama-swap's scheduler and never reaches the worker.
 
 ## Preload
 
-`preload = [ "default" ]`. Every role alias resolves to the same 35B resident in
-single-model mode, so the name is cosmetic — but it used to read `[ "goal-judge" ]`,
+`preload = [ "default" "quickest" ]` — two genuinely different models since
+2026-08-14, where under single-model mode every role alias resolved to the same
+resident and the name was cosmetic. `default` (the 27B) is listed first because
+it is the slower of the two to warm. It used to read `[ "goal-judge" ]`,
 which reads as "warm a separate, smaller judge model" that does not exist on this
 host. That misreading cost a multi-hour misdiagnosis of a warmup-starvation
 incident on 2026-08-01; the actual cause was external (something kickstarting the
 warmup agent in a tight loop, force-reloading the same resident). See nix-ai's
 `mlx-warmup.py` re-invocation bound.
+
+The warmup deadline needs no adjustment for the second entry: nix-ai's
+`warmup-timeout.nix` derives it as `healthCheckTimeout * len(preload) + 60`,
+which is 180 × 2 + 60 = 420 s here. Restart *count* is bounded separately by
+`mlx-warmup.py`, which is the actual livelock fix.
 
 ## No serving watchdog on this host
 

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -10,84 +10,58 @@ Serving detail that is not host-scoped lives in nix-ai's validated model catalog
 (`modules/mlx/catalog-data.nix`): parser stacks, chat-template kwargs, and
 per-class flag profiles. Add or fix serve args there, not here.
 
-## Resident model selection (2026-07-27)
+## Resident model selection
 
-Promoted from the Coder-30B to the 35B for standalone operation (MacBook
-unplugged, no cluster).
+Superseded by "Two warm brains" below. The 2026-07-27 candidate bench that
+promoted the 35B — method, the four-model throughput table, and why
+GLM-4.7-Flash and gpt-oss-120b were disqualified on tool calls — is kept in
+[mac-studio-model-history.md](./mac-studio-model-history.md).
 
-Every candidate was measured on this host against a dedicated isolated worker on
-a scratch port, with the loaded checkpoint confirmed by
-`lsof -i :PORT` → pid → `ps -p <pid>` reading `--model`. **That step is
-mandatory, not ceremony**: the server echoes the requested name back, so a
-model id in a request or a response proves nothing about which weights
-answered. It mattered doubly under the single-model mode this host ran until
-2026-08-14, which aliased every other model's physical id onto the one
-resident entry — but the response field was never evidence in either mode.
-
-Headline metric is cumulative tok/s — `(prompt + completion) / wall` — so
-prefill gains count. Identical 111–118 token prompt, 300 `max_tokens`, 3 timed
-runs after a discarded warmup, decode-concurrency 1:
-
-| model | cumulative | decode | ttft | tools |
-| --- | --- | --- | --- | --- |
-| Qwen3.6-35B-A3B-4bit | **115.2** | 84.9 | 0.12s | PASS |
-| Qwen3-Next-80B-A3B-Instruct-4bit | 97.5 | 71.5 | 0.08s | PASS |
-| GLM-4.7-Flash-4bit | 95.8 | — | — | FAIL |
-| gpt-oss-120b-MXFP4-Q8 (peer-measured) | 51–54 | 40–43 | 0.23s | FAIL |
-
-The 35B wins on throughput outright while being the smallest of the four
-(19.4 GB). GLM-4.7-Flash is disqualified on tool calls, not speed: given two
-tools it emits no call at all and stops on `length`. gpt-oss-120b is
-disqualified because mlx-lm ships no harmony parser, so `tool_calls` is null and
-raw `<|channel|>` markup leaks into content.
-
-Thinking is off in its catalog entry, which matters for Hermes: a thinking
-variant spends hundreds of reasoning tokens before it emits a tool call, and
-Hermes pays that latency on every action it takes.
+One rule from it still governs every measurement on this host: confirm the
+loaded checkpoint from the worker's own command line
+(`lsof -i :PORT` -> pid -> `ps -p <pid>` reading `--model`). The server echoes
+the requested name back, so a model id in a request or a response proves
+nothing about which weights answered.
 
 ## Two warm brains (2026-08-14) — supersedes single-model mode
 
 This host is the estate's **intelligence tier**; a GPU is planned to take
-fast-and-small. Throughput is no longer the objective here, so both brains stay
-warm and roles are split by cost rather than by preference:
+fast-and-small, so throughput is no longer the objective and both brains stay
+warm. Roles split by cost, not preference:
 
 | Model | Roles | Shape | Thinking |
 | --- | --- | --- | --- |
-| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | bounded on (`reasoning_effort=low`) |
+| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | on, `reasoning_effort=medium` |
 | Qwen3.6-35B-A3B-4bit | quickest, large-context | 35B MoE, ~3B active, 20 KiB/token KV | off |
 
 `large-context` sits on the MoE deliberately: its KV costs roughly a third of
 the dense model's per token.
 
 **`singleModel` is gone, not repointed.** It aliased every role onto one entry
-and demoted the rest to `disabledModels`, which is exactly what made a second
-warm brain impossible. `alwaysAvailableModels` went with it — it had meaning
-only in single-model mode, and its group (`swap=true, persistent=false`) could
-never have held a second brain: always-available models evict each other and
-idle-unload at ttl 900.
+and demoted the rest to `disabledModels` — exactly what made a second warm brain
+impossible. `alwaysAvailableModels` went with it: its group is
+`swap=true, persistent=false`, so those models evict each other and idle-unload
+at ttl 900, and it could never have held a brain.
 
-Two resident-class entries land in the `mlx-models` group, which at k_max = 2 is
-`swap=false, persistent=true`, so they hold weights simultaneously. Verified
+Two resident-class entries land in `mlx-models`, which at k_max = 2 is
+`swap=false, persistent=true`, so they hold weights simultaneously. Read back
 from the rendered `llama-swap-config.json`, not inferred:
 
 ```json
-"mlx-models":      { "swap": false, "persistent": true,  "exclusive": true,
-                     "members": ["…Qwen3.6-35B-A3B-4bit", "…Qwen3.8-27B-4bit"] }
-"mlx-swap-models": { "swap": true,  "persistent": false, "exclusive": false,
-                     "members": ["…Qwen3.5-9B-MLX-4bit"] }
+"mlx-models":      { "swap": false, "persistent": true,  "members": [35B, 27B] }
+"mlx-swap-models": { "swap": true,  "persistent": false, "members": [9B] }
 ```
 
-Everything else is `enable = false` — **not a new restriction**. Under
-`singleModel` those ids already 404'd; without it every compiled entry becomes
-servable again, and a stray physical-id request would cold-load 20–63 GB beside
-two residents. The 9B stays enabled because an hourly note-capture pipe requests
-its exact physical id.
+Everything else is `enable = false` — **not a new restriction**, since those
+ids already 404'd under `singleModel`. Without it every compiled entry becomes
+servable again and a stray physical-id request would cold-load 20–63 GB beside
+two residents. The 9B stays enabled: an hourly note-capture pipe requests its
+exact physical id.
 
-Measured before the switch (`vmmap`, 2026-08-14): peaks 30.9 GB (35B) + 16.6 GB
-(27B) = 44.2 GiB against the 100 GiB ceiling; 28.8 / 15.5 GiB steady against the
-48 GiB per-worker budget. Weights are private per-process Metal buffers —
-dirty, non-volatile, no shared pages — so two workers is a straight sum, never a
-discount.
+Fit measured before switching (`vmmap`, 2026-08-14), not estimated: peaks
+30.9 + 16.6 = 44.2 GiB against the 100 GiB ceiling; 28.8 / 15.5 GiB steady
+against the 48 GiB per-worker budget. Weights are private per-process Metal
+buffers with no shared pages, so two workers is a straight sum.
 
 ## Residency budget (k_max = 2 since 2026-08-05)
 

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -38,38 +38,34 @@ in
   # model ids stay centralized in nix-ai's validated catalog.
 
   mlx = {
-    # SINGLE-MODEL MODE (2026-07-23, supersedes the earlier
-    # single-resident-brain-group posture): only one model is servable.
-    # Every alias — every logical role below AND every other catalog
-    # model's own physical id — routes to it (programs.mlx.singleModel
-    # aliases every other compiled model's id onto the resident entry).
-    # Verified live: a request naming mlx-community/Qwen3.5-9B-OptiQ-4bit by
-    # its own id was answered by the resident entry ("ROUTED").
+    # TWO-RESIDENT MODE (2026-08-14, supersedes single-model mode). This host
+    # is the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
+    # so throughput stops being the objective here and both brains stay warm.
     #
-    # 2026-08-14: switched to Qwen3.8-27B-4bit by operator decision — adopt the
-    # newest generation now, revert only on measured evidence.
+    #   Qwen3.8-27B  — deliberate work. Dense 27B. Thinking is off in the
+    #                  catalog entry at the currently pinned nix-ai; it becomes
+    #                  bounded-on (reasoning_effort=low, ~220 s/response) when
+    #                  the pin advances past nix-ai#1627.
+    #   Qwen3.6-35B  — routine work. 35B MoE, ~3B active/token, thinking off,
+    #                  and 20 KiB/token of KV against the 27B's 64 KiB.
     #
-    # THIS OVERRIDES AN EXISTING BENCHMARK VERDICT, deliberately. The previous
-    # pin, mlx-community/Qwen3.6-35B-A3B-4bit, won the 2026-07-27 standalone
-    # bench on cumulative tok/s (115.2, smallest of four candidates at 19.4 GB;
-    # method and results table in ./mac-studio.md). That model is a 35B MoE with
-    # ~3B active parameters per token; Qwen3.8-27B activates all 27B, offset by
-    # hybrid attention (48 of 64 layers linear). Net throughput is therefore
-    # UNMEASURED on this host and could regress.
+    # singleModel is GONE, not repointed. It aliased every role onto one entry
+    # and demoted everything else to disabledModels, which is precisely what
+    # made a second warm brain impossible. Two resident-class entries land in
+    # the mlx-models group, which is swap=false + persistent=true at
+    # maxResidentWorkers = 2 — so they hold weights simultaneously and never
+    # evict one another (nix-ai llama-swap-topology.nix tieredGroups).
     #
-    # The throughput suite runs first in the mlx-benchmarks sweep specifically
-    # to produce that number. If it regresses materially, revert is this one
-    # line plus the AI_MODEL_LOCAL_LLM Doppler variable.
-    singleModel = "mlx-community/Qwen3.8-27B-4bit";
-
-    # Small always-loadable 9B (~5.2 GB) for trivial local tasks (Gemini-CLI
-    # path). singleModel would otherwise demote every non-resident to
-    # disabledModels; this keeps it servable as a swap tier (nix-ai
-    # alwaysAvailableModels; no alias onto its roles).
+    # alwaysAvailableModels is gone with it: it only ever had meaning in
+    # singleModel mode, and its group (swap=true, persistent=false) is the
+    # reason it could not have carried a second brain anyway — always-available
+    # models evict each other and idle-unload at ttl 900.
     #
-    # It no longer evicts the resident: that was the k_max = 1 collapsed-group
-    # behaviour, corrected below. See ./mac-studio.md "Residency budget".
-    alwaysAvailableModels = [ "mlx-community/Qwen3.5-9B-MLX-4bit" ];
+    # Measured before switching (jevans-ms, vmmap, 2026-08-14): peaks 30.9 GB
+    # (35B) + 16.6 GB (27B) = 44.2 GiB against the 100 GiB ceiling, and 28.8 /
+    # 15.5 GiB steady against the 48 GiB per-worker budget. Weights are private
+    # per-process Metal buffers — nothing is shared between the two workers, so
+    # this is a straight sum, not an estimate.
 
     # RESIDENCY BUDGET — these two move together or the host over-commits.
     #
@@ -101,48 +97,80 @@ in
     maxResidentWorkers = 2;
 
     # Validated catalog selections (profiles in nix-ai catalog-data.nix).
-    # Every logical role resolves to the 35B — required so it's the only entry
-    # the module's role-coverage assertion needs satisfied in single-model
-    # mode. The Coder-30B, the 80B and the 27B judge are configured but carry
-    # no roles (disable-not-delete): swap-class, kept in the tree, and — like
-    # every other non-resident entry — demoted to disabledModels by
-    # singleModel rather than deleted.
+    #
+    # ROLES SPLIT ACROSS THE TWO RESIDENTS, and a role may be assigned only
+    # once (options-catalog.nix asserts uniqueness). The split follows cost,
+    # not preference: the dense 27B is the one worth waiting on, the MoE is the
+    # one worth asking often.
+    #
+    # `enable = false` on the rest is NOT a new restriction — it preserves
+    # exactly what singleModel did. Under singleModel every unlisted entry was
+    # demoted to disabledModels and a request naming its id 404'd. Without
+    # singleModel every compiled entry becomes servable again, so a stray
+    # physical-id request would cold-load 20-63 GB beside two residents.
+    # Disable-not-delete: they stay in the tree, ready to re-enable.
     catalog = {
-      # Current-generation resident that every role resolves to; must stay in
-      # step with singleModel above (the role-coverage assertion enforces it).
-      # Thinking is off in its catalog entry, which matters for Hermes: a
-      # thinking variant spends hundreds of reasoning tokens before it emits a
-      # tool call, and Hermes pays that latency on every single action it takes.
+      # Deliberate tier. Its chat-template kwarg lives in the nix-ai catalog,
+      # not here. Do not "fix" it by dropping the kwarg to let it think freely:
+      # unset, the template defaults reasoning_effort to xhigh, and at xhigh
+      # this model emitted 0 answer characters with finish_reason "length" on
+      # 3 of 3 measured runs. Bounded thinking (low) costs ~220 s per action,
+      # which is the trade this tier exists to make.
       qwen38-27b = {
         class = "resident";
         roles = [
           "default"
-          "quickest"
           "tool-calling"
-          "large-context"
           "most-capable"
           "oss"
           "coding"
           "goal-judge"
         ];
       };
-      qwen3-next-80b-instruct.class = "swap";
-      qwen3-coder-30b.class = "swap";
-      # Previous resident and 2026-07-27 throughput winner (115.2 tok/s
-      # cumulative). Kept swap-class as the revert target: if the Qwen3.8
-      # throughput measurement regresses, restore its roles here and repoint
-      # singleModel back at it.
-      qwen36-35b.class = "swap";
-      qwen35-9b-optiq.class = "swap";
-      # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
-      # Gemini-CLI path — on-demand swap tier, idle-unloaded. Addressable by its
-      # physical id (mlx-community/Qwen3.5-9B-MLX-4bit). It DOES evict the
-      # resident at k_max = 1 — see the alwaysAvailableModels note above.
+      # Routine tier, and the 2026-07-27 throughput winner (115.2 tok/s
+      # cumulative). Thinking off. Takes "large-context" as well as "quickest":
+      # at 20 KiB/token of KV against the dense 27B's 64 KiB, a long context
+      # costs roughly a third as much unified memory here.
+      qwen36-35b = {
+        class = "resident";
+        roles = [
+          "quickest"
+          "large-context"
+        ];
+      };
+      # Small on-demand 9B (5.2 GB) for trivial local tasks via the Gemini-CLI
+      # path. STAYS ENABLED: an hourly note-capture pipe requests this exact
+      # physical id, and disabling it would 404 that pipe. Swap tier, so it
+      # loads beside the residents rather than evicting one (k_max = 2).
       qwen35-9b-mlx.class = "swap";
-      qwen36-optiq.class = "swap";
-      gpt-oss-120b.class = "swap";
+
+      # Configured, compiled, and not servable. Re-enable deliberately, one at
+      # a time, with the residency budget re-checked.
+      qwen3-next-80b-instruct = {
+        class = "swap";
+        enable = false;
+      };
+      qwen3-coder-30b = {
+        class = "swap";
+        enable = false;
+      };
+      qwen35-9b-optiq = {
+        class = "swap";
+        enable = false;
+      };
+      qwen36-optiq = {
+        class = "swap";
+        enable = false;
+      };
+      gpt-oss-120b = {
+        class = "swap";
+        enable = false;
+      };
       # Thinking sibling: the deep-analysis escalation tier, on demand.
-      qwen3-next-80b.class = "swap";
+      qwen3-next-80b = {
+        class = "swap";
+        enable = false;
+      };
     };
 
     cacheMemoryMb = 8192;
@@ -165,12 +193,18 @@ in
       concurrencyLimit = serveConcurrency;
     };
 
-    # Resident brain warmed at boot. Every role alias resolves to the same 35B
-    # in singleModel mode, so this name is cosmetic — but it must not name a
-    # role that reads as a separate model. It used to say `[ "goal-judge" ]`,
-    # which cost a multi-hour misdiagnosis on 2026-08-01; see ./mac-studio.md
-    # "Preload". "default" says what actually happens here.
-    preload = [ "default" ];
+    # Both residents warmed at boot — these now name two genuinely different
+    # models, where in singleModel mode every role alias resolved to the same
+    # weights and the name was cosmetic. Order matters: "default" is the
+    # deliberate 27B and takes longest to warm, so it goes first.
+    #
+    # A preload entry must name a role, not a model that reads as one. This
+    # used to say `[ "goal-judge" ]`, which cost a multi-hour misdiagnosis on
+    # 2026-08-01; see ./mac-studio.md "Preload".
+    preload = [
+      "default"
+      "quickest"
+    ];
 
     # Clustered mode: this Mac is rank 0 (coordinator) of the two-Mac JACCL
     # brain when the Thunderbolt cable is in — it binds the cluster endpoint on

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -46,10 +46,21 @@ in
     # Verified live: a request naming mlx-community/Qwen3.5-9B-OptiQ-4bit by
     # its own id was answered by the resident entry ("ROUTED").
     #
-    # 2026-07-27 standalone bench winner on cumulative tok/s (115.2, and the
-    # smallest of the four candidates at 19.4 GB). Full method, results table
-    # and the disqualifications: ./mac-studio.md.
-    singleModel = "mlx-community/Qwen3.6-35B-A3B-4bit";
+    # 2026-08-14: switched to Qwen3.8-27B-4bit by operator decision — adopt the
+    # newest generation now, revert only on measured evidence.
+    #
+    # THIS OVERRIDES AN EXISTING BENCHMARK VERDICT, deliberately. The previous
+    # pin, mlx-community/Qwen3.6-35B-A3B-4bit, won the 2026-07-27 standalone
+    # bench on cumulative tok/s (115.2, smallest of four candidates at 19.4 GB;
+    # method and results table in ./mac-studio.md). That model is a 35B MoE with
+    # ~3B active parameters per token; Qwen3.8-27B activates all 27B, offset by
+    # hybrid attention (48 of 64 layers linear). Net throughput is therefore
+    # UNMEASURED on this host and could regress.
+    #
+    # The throughput suite runs first in the mlx-benchmarks sweep specifically
+    # to produce that number. If it regresses materially, revert is this one
+    # line plus the AI_MODEL_LOCAL_LLM Doppler variable.
+    singleModel = "mlx-community/Qwen3.8-27B-4bit";
 
     # Small always-loadable 9B (~5.2 GB) for trivial local tasks (Gemini-CLI
     # path). singleModel would otherwise demote every non-resident to
@@ -97,12 +108,12 @@ in
     # every other non-resident entry — demoted to disabledModels by
     # singleModel rather than deleted.
     catalog = {
-      # 2026-07-27 standalone bench winner on cumulative throughput, and the
-      # resident that every role resolves to. Thinking is off in its catalog
-      # entry, which matters for Hermes: a thinking variant spends hundreds
-      # of reasoning tokens before it emits a tool call, and Hermes pays that
-      # latency on every single action it takes.
-      qwen36-35b = {
+      # Current-generation resident that every role resolves to; must stay in
+      # step with singleModel above (the role-coverage assertion enforces it).
+      # Thinking is off in its catalog entry, which matters for Hermes: a
+      # thinking variant spends hundreds of reasoning tokens before it emits a
+      # tool call, and Hermes pays that latency on every single action it takes.
+      qwen38-27b = {
         class = "resident";
         roles = [
           "default"
@@ -117,7 +128,11 @@ in
       };
       qwen3-next-80b-instruct.class = "swap";
       qwen3-coder-30b.class = "swap";
-      qwen36-27b-mxfp4.class = "swap";
+      # Previous resident and 2026-07-27 throughput winner (115.2 tok/s
+      # cumulative). Kept swap-class as the revert target: if the Qwen3.8
+      # throughput measurement regresses, restore its roles here and repoint
+      # singleModel back at it.
+      qwen36-35b.class = "swap";
       qwen35-9b-optiq.class = "swap";
       # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
       # Gemini-CLI path — on-demand swap tier, idle-unloaded. Addressable by its

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -38,34 +38,20 @@ in
   # model ids stay centralized in nix-ai's validated catalog.
 
   mlx = {
-    # TWO-RESIDENT MODE (2026-08-14, supersedes single-model mode). This host
-    # is the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
-    # so throughput stops being the objective here and both brains stay warm.
+    # TWO-RESIDENT MODE (2026-08-14, supersedes single-model mode). This host is
+    # the estate's INTELLIGENCE tier: a GPU is planned to take fast-and-small,
+    # so throughput stops being the objective and both brains stay warm. The
+    # 27B takes deliberate work, the 35B MoE routine work. Rationale, the vmmap
+    # fit, and the group semantics: ./mac-studio.md "Two warm brains".
     #
-    #   Qwen3.8-27B  — deliberate work. Dense 27B. Thinking is off in the
-    #                  catalog entry at the currently pinned nix-ai; it becomes
-    #                  bounded-on (reasoning_effort=low, ~220 s/response) when
-    #                  the pin advances past nix-ai#1627.
-    #   Qwen3.6-35B  — routine work. 35B MoE, ~3B active/token, thinking off,
-    #                  and 20 KiB/token of KV against the 27B's 64 KiB.
+    # singleModel and alwaysAvailableModels are GONE, not repointed — both only
+    # had meaning in single-model mode, and alwaysAvailableModels' group
+    # (swap=true, persistent=false) could never have carried a second brain.
     #
-    # singleModel is GONE, not repointed. It aliased every role onto one entry
-    # and demoted everything else to disabledModels, which is precisely what
-    # made a second warm brain impossible. Two resident-class entries land in
-    # the mlx-models group, which is swap=false + persistent=true at
-    # maxResidentWorkers = 2 — so they hold weights simultaneously and never
-    # evict one another (nix-ai llama-swap-topology.nix tieredGroups).
-    #
-    # alwaysAvailableModels is gone with it: it only ever had meaning in
-    # singleModel mode, and its group (swap=true, persistent=false) is the
-    # reason it could not have carried a second brain anyway — always-available
-    # models evict each other and idle-unload at ttl 900.
-    #
-    # Measured before switching (jevans-ms, vmmap, 2026-08-14): peaks 30.9 GB
-    # (35B) + 16.6 GB (27B) = 44.2 GiB against the 100 GiB ceiling, and 28.8 /
-    # 15.5 GiB steady against the 48 GiB per-worker budget. Weights are private
-    # per-process Metal buffers — nothing is shared between the two workers, so
-    # this is a straight sum, not an estimate.
+    # DO NOT drop the 27B's chat-template kwarg to "let it think". Unset, its
+    # template defaults reasoning_effort to xhigh, which measured 0 answer
+    # characters on 3 of 3 runs. The kwarg lives in the nix-ai catalog, and it
+    # is a prompt string, not a budget — nothing here caps thinking length.
 
     # RESIDENCY BUDGET — these two move together or the host over-commits.
     #
@@ -104,18 +90,11 @@ in
     # one worth asking often.
     #
     # `enable = false` on the rest is NOT a new restriction — it preserves
-    # exactly what singleModel did. Under singleModel every unlisted entry was
-    # demoted to disabledModels and a request naming its id 404'd. Without
-    # singleModel every compiled entry becomes servable again, so a stray
-    # physical-id request would cold-load 20-63 GB beside two residents.
-    # Disable-not-delete: they stay in the tree, ready to re-enable.
+    # exactly what singleModel did (those ids already 404'd). Without it every
+    # compiled entry becomes servable again, so a stray physical-id request
+    # would cold-load 20-63 GB beside two residents. Disable-not-delete.
     catalog = {
-      # Deliberate tier. Its chat-template kwarg lives in the nix-ai catalog,
-      # not here. Do not "fix" it by dropping the kwarg to let it think freely:
-      # unset, the template defaults reasoning_effort to xhigh, and at xhigh
-      # this model emitted 0 answer characters with finish_reason "length" on
-      # 3 of 3 measured runs. Bounded thinking (low) costs ~220 s per action,
-      # which is the trade this tier exists to make.
+      # Deliberate tier. See the kwarg warning above.
       qwen38-27b = {
         class = "resident";
         roles = [

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -18,36 +18,38 @@
   mlx = {
     # Every logical role resolves through the validated catalog entry; no
     # physical model id is repeated in deployed host configuration.
-    catalog.qwen3-coder-30b = {
-      class = "resident";
-      roles = [
-        "default"
-        "quickest"
-        "tool-calling"
-        "coding"
-        "large-context"
-        "most-capable"
-        "oss"
-      ];
+    catalog = {
+      qwen3-coder-30b = {
+        class = "resident";
+        roles = [
+          "default"
+          "quickest"
+          "tool-calling"
+          "coding"
+          "large-context"
+          "most-capable"
+          "oss"
+        ];
+      };
+      # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
+      # Gemini-CLI path and the hourly Obsidian summarizer pipe, which requests
+      # this physical id directly. Swap-class with no roles compiles to a
+      # llama-swap models.<id> entry keyed by the physical id, so it loads on
+      # demand and routes without evicting the resident 30B.
+      qwen35-9b-mlx.class = "swap";
+      # Qwen3.8-27B — current small/midsize generation, servable here on demand.
+      #
+      # Deliberately swap-class, NOT resident: promoting it would demote
+      # qwen3-coder-30b, which is a ~3B-active MoE, in favour of a model that
+      # activates all 27B. On this machine — a laptop that is also a cluster peer
+      # under a shared memory cap — that trades the fast local coding path for an
+      # unmeasured one. Swap-class keeps it addressable by its physical id
+      # everywhere while the Studio carries the default-routing switch.
+      #
+      # To promote after the throughput numbers land: move the roles list from
+      # qwen3-coder-30b to the qwen38-27b entry and flip the classes.
+      qwen38-27b.class = "swap";
     };
-    # Small always-loadable 9B (5.2 GB) for trivial local tasks via the
-    # Gemini-CLI path and the hourly Obsidian summarizer pipe, which requests
-    # this physical id directly. Swap-class with no roles compiles to a
-    # llama-swap models.<id> entry keyed by the physical id, so it loads on
-    # demand and routes without evicting the resident 30B.
-    catalog.qwen35-9b-mlx.class = "swap";
-    # Qwen3.8-27B — current small/midsize generation, servable here on demand.
-    #
-    # Deliberately swap-class, NOT resident: promoting it would demote
-    # qwen3-coder-30b, which is a ~3B-active MoE, in favour of a model that
-    # activates all 27B. On this machine — a laptop that is also a cluster peer
-    # under a shared memory cap — that trades the fast local coding path for an
-    # unmeasured one. Swap-class keeps it addressable by its physical id
-    # everywhere while the Studio carries the default-routing switch.
-    #
-    # To promote after the throughput numbers land: move the roles list from
-    # qwen3-coder-30b to a catalog.qwen38-27b block and flip the classes.
-    catalog.qwen38-27b.class = "swap";
 
     # Resident judge model, in its own llama-swap group (nix-ai
     # programs.mlx.judge, modules/mlx/options-judge.nix). Bypasses the

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -36,6 +36,18 @@
     # llama-swap models.<id> entry keyed by the physical id, so it loads on
     # demand and routes without evicting the resident 30B.
     catalog.qwen35-9b-mlx.class = "swap";
+    # Qwen3.8-27B — current small/midsize generation, servable here on demand.
+    #
+    # Deliberately swap-class, NOT resident: promoting it would demote
+    # qwen3-coder-30b, which is a ~3B-active MoE, in favour of a model that
+    # activates all 27B. On this machine — a laptop that is also a cluster peer
+    # under a shared memory cap — that trades the fast local coding path for an
+    # unmeasured one. Swap-class keeps it addressable by its physical id
+    # everywhere while the Studio carries the default-routing switch.
+    #
+    # To promote after the throughput numbers land: move the roles list from
+    # qwen3-coder-30b to a catalog.qwen38-27b block and flip the classes.
+    catalog.qwen38-27b.class = "swap";
 
     cacheMemoryMb = 8192;
     prefillBatchSize = 2048;

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -49,8 +49,30 @@
     # qwen3-coder-30b to a catalog.qwen38-27b block and flip the classes.
     catalog.qwen38-27b.class = "swap";
 
+    # Resident judge model, in its own llama-swap group (nix-ai
+    # programs.mlx.judge, modules/mlx/options-judge.nix). Bypasses the
+    # catalog/maxResidentWorkers topology entirely: persistent + non-exclusive
+    # means it is never evicted by the main brain's exclusive group and never
+    # evicts that group itself, so it answers even while the main brain is
+    # busy serving a long request. Physical id is already cached under
+    # HF_HOME (2.1 GB weights) — see hosts/common/residency-budget.nix for the
+    # memoryHardLimitGb halving this needs.
+    judge = {
+      enable = true;
+      model = "mlx-community/Qwen3-4B-Instruct-2507-4bit";
+    };
+
     cacheMemoryMb = 8192;
     prefillBatchSize = 2048;
+
+    # Two workers can be resident at once now (the catalog brain plus the
+    # judge above), so the single-worker budget hosts/common/residency-budget.nix
+    # derives (kMax still 1 there — the judge sits outside maxResidentWorkers)
+    # must be halved by hand: (100 GiB ceiling - 4 GiB baseline reserve) / 2
+    # workers = 48 GiB, rounded down for cushion. Applies to every worker
+    # equally (MLX_L1_MEMORY_LIMIT_BYTES is one shared wrapper-level export),
+    # including the judge, whose real usage (~2-3 GiB) sits nowhere near it.
+    memoryHardLimitGb = 46;
 
     # MLX retained free-buffer pool. The host wired-memory ceiling is the
     # Metal guardrail; this limits reclaimable framework buffers below it.

--- a/lib/hosts/macbook-m4.nix
+++ b/lib/hosts/macbook-m4.nix
@@ -62,6 +62,18 @@
       model = "mlx-community/Qwen3-4B-Instruct-2507-4bit";
     };
 
+    # persistent:true only protects the judge from eviction — it does NOT
+    # preload it. The warmup LaunchAgent (native to nix-ai, mlx-warmup.py)
+    # is the actual preload mechanism: it sends a real completion to every
+    # role in this list right after llama-swap comes up, so the first REAL
+    # request never pays the cold-load cost. "judge" listed BEFORE "default":
+    # the list warms sequentially and the judge (2.1 GB, seconds to load)
+    # must not sit queued behind the 30B's slower cold load.
+    preload = [
+      "judge"
+      "default"
+    ];
+
     cacheMemoryMb = 8192;
     prefillBatchSize = 2048;
 


### PR DESCRIPTION
Promotion of develop to main. This host family deploys from `main`, so the Studio serving changes are unreachable until this lands.

Contents:

- Two resident MLX models on the Mac Studio: the Qwen3.8-27B for deliberate work and the Qwen3.6-35B-A3B MoE for routine work, with logical roles split between them (#2140). `singleModel` and `alwaysAvailableModels` are removed — they aliased every role onto one entry, which is what prevented a second warm model.
- nix-ai pin advanced to its current main, which serves the 27B with `reasoning_effort=medium` (#2141, nix-ai#1627).
- Qwen3.8-27B-4bit as the default model (#2139), resident judge model (#2107).
- Host files split for the per-file size limit, and `macbook-m4.nix` catalog assignments merged into a single attrset to satisfy statix (#2141).
- flake.lock maintenance (#2142), a CI build time cap (#2137), vendor binary source docs.

**Why `medium` rather than unset or `low`.** The 27B's chat template defaults `reasoning_effort` to `xhigh` when the kwarg is absent, and at `xhigh` it exhausts the token budget without emitting an answer — 0 answer characters, `finish_reason: length`, 3 of 3 runs. Measured on an isolated worker with weights confirmed from its process command line:

| effort | finish_reason | tokens | answer chars | reasoning chars |
| --- | --- | --- | --- | --- |
| unset (`xhigh`) | `length` 3/3 | 4096 (cap) | 0 | 16399 |
| `low` | `stop` 3/3 | 3842 | 10079 | 5051 |
| `medium` | `stop` | 4243 | 13456 | 2334 |

`medium` injects no steering string at all (89 prompt tokens against `low`'s 119), so it is the model's own baseline rather than a step up a dial.

Rendered `llama-swap-config.json` at this pin:

```
Qwen3.8-27B-4bit   '{"reasoning_effort":"medium"}'
                   aliases: coding default goal-judge most-capable oss tool-calling
Qwen3.6-35B-A3B    '{"enable_thinking":false}'
                   aliases: large-context quickest
mlx-models         swap=false persistent=true, 2 members
mlx-swap-models    swap=true  persistent=false, 1 member
```

No tok/s figures are quoted: decode measured 17.4–27.3 across runs producing byte-identical output, so single-run throughput here is noise.

Deploying to the Studio is a separate operator-gated step requiring a maintenance window.