### PR TITLE
docs(mac-studio): make the llama-swap group excerpt valid JSON

### DIFF
--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -48,8 +48,12 @@ Two resident-class entries land in `mlx-models`, which at k_max = 2 is
 from the rendered `llama-swap-config.json`, not inferred:
 
 ```json
-"mlx-models":      { "swap": false, "persistent": true,  "members": [35B, 27B] }
-"mlx-swap-models": { "swap": true,  "persistent": false, "members": [9B] }
+{
+  "mlx-models":      { "swap": false, "persistent": true,
+                       "members": ["…Qwen3.6-35B-A3B-4bit", "…Qwen3.8-27B-4bit"] },
+  "mlx-swap-models": { "swap": true,  "persistent": false,
+                       "members": ["…Qwen3.5-9B-MLX-4bit"] }
+}
 ```
 
 Everything else is `enable = false` — **not a new restriction**, since those


### PR DESCRIPTION
The block was fenced as `json` but used bare `35B` / `27B` / `9B` as member values, which does not parse. Introduced while compressing this file under the per-file size limit (#2141).

Restores quoted, elided model ids and wraps the two groups in an object. Validated by parsing the fenced block with `json.loads`, not by eye.

Raised by gemini-code-assist on #2143 — correct call.