### PR TITLE
feat(mac-studio): move the goal-judge role to the routine tier

### DIFF
--- a/lib/hosts/mac-studio-model-history.md
+++ b/lib/hosts/mac-studio-model-history.md
@@ -41,3 +41,24 @@ raw `<|channel|>` markup leaks into content.
 Thinking is off in its catalog entry, which matters for Hermes: a thinking
 variant spends hundreds of reasoning tokens before it emits a tool call, and
 Hermes pays that latency on every action it takes.
+
+## Serving concurrency: why the 2026-07-27 4× override was harmful
+
+Kept because it is the measurement that makes the current `serveConcurrency = 2`
+defensible, and it is easy to misread as evidence against concurrency itself.
+
+That test was 4-way *admission* against a worker whose `--decode-concurrency`
+was still hard-coded 1 (pre-unification). The proxy time-sliced one serialized
+GPU: 12.5 tok/s per stream, gate p90 194s with a 1298s tail, 429 to 52% of
+requests, and a wedged worker.
+
+Since the unification, admission and served width derive from one number, and
+mlx-lm 0.31.3's `--decode-concurrency` feeds a real batch scheduler
+(`BatchGenerator`; upstream defaults are 32 decode / 8 prompt, so 2 is
+conservative). The resident `qwen3_5_moe` is batchable in 0.31.3: no draft
+model, and both cache classes its `make_cache` returns (`KVCache`,
+`ArraysCache`) implement `merge`.
+
+The note that once lived in `mac-studio.md` — "`mlx_lm.server` serializes decode
+internally regardless" — described that hard-coded-1 state, not 0.31.3 with the
+flag set.

--- a/lib/hosts/mac-studio-residency.md
+++ b/lib/hosts/mac-studio-residency.md
@@ -1,0 +1,89 @@
+# mac-studio residency budget
+
+How `maxResidentWorkers` and `memoryHardLimitGb` are chosen for this host, and
+what the limit does and does not enforce. Split out of
+[mac-studio.md](./mac-studio.md) when that file reached the 12 KiB error limit
+(`.file-size.yml`, which recommends splitting rather than extending the
+ceiling) — this is one self-contained topic and reads better alone.
+
+## The budget (k_max = 2 since 2026-08-05)
+
+The invariant, from nix-ai `modules/mlx/options-residency.nix`:
+
+```text
+maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
+```
+
+The ceiling here is 100 GiB (`appleSiliconTunables.maxLocalLlmGb = 100` →
+`wiredLimitMb = 102400`, in `hosts/mac-studio/default.nix`).
+
+**At the previous k_max = 1**, the resident and the always-available 9B
+collapsed into one exclusive swapping group, so loading the 9B evicted the 35B —
+verified by measurement on 2026-08-05, not inferred. That was the memory bound
+working as designed, not a bug, and it is why the earlier "the 9B never evicts
+the resident" comment was wrong and had to be corrected (#2043).
+
+**At k_max = 2** the tiered topology returns: a persistent resident plus a
+non-exclusive small tier hold weights simultaneously. `memoryHardLimitGb` must
+drop in the same change or the product over-commits the ceiling — 2 workers at
+the old 99 GiB would permit 198 GiB against 100 GiB.
+
+Chosen: `memoryHardLimitGb = 48`, so `2 × 48 = 96 GiB` against a 100 GiB ceiling.
+
+**The cushion is not 4 GiB.** 96 vs 100 ignores the non-MLX wired baseline,
+measured at ~3.4 GiB host-wide while one worker decodes. Strict worst case is
+`96 + 3.4 = 99.4 GiB`, so the honest cushion is **~0.6 GiB**. It still holds, and
+overshoot spills to pageable memory rather than failing, but do not read 4 GiB as
+spare capacity.
+
+Per-worker budget for the resident, using measurements rather than the catalog's
+declared `weightGb`:
+
+| quantity | value | source |
+| --- | --- | --- |
+| weights, live RSS mid-decode | 18.72 GiB | `ps` on the running worker |
+| weights, RSS recorded 2026-07-24 | 21.31 GiB | docs-starlight memory-ceilings |
+| prompt cache | **16 GiB** | live `--prompt-cache-bytes 17179869184` |
+| buffer cache (shedable) | up to 12 GiB | `bufferCacheLimitGb` default |
+
+So roughly `48 − 21.3 − 16 ≈ 10.7 GiB` is left for KV and scratch — not the ~28
+GiB an earlier draft of this file claimed. That draft also called 19.4 GB and
+5.2 GB "measured": they are **declared** catalog `weightGb` values
+(`catalog-data.nix`), they match neither disk (19.03 / 5.57 GiB) nor live RSS,
+and the unit they are expressed in is undocumented. Measure W; never take it
+from a spec sheet.
+
+Note the prompt cache is 16 GiB for the **resident**, not the host-wide 8 GiB:
+the resident class overrides `cacheMemoryMb = 16384` in the nix-ai catalog. The
+9B runs at the host default, 8 GiB.
+
+The worst constructible single-worker set therefore EXCEEDS 48 GiB. That is not
+a defect, because `memoryHardLimitGb` refuses nothing — see below.
+
+`suppressWiredLimit` defaults true (it avoids an IOGPUFamily kernel panic), which
+leaves weights pageable and makes this budget load-bearing: exceed the ceiling
+and the trade is a kernel panic for swap thrash. Do not raise `maxResidentWorkers`
+again without lowering `memoryHardLimitGb` to match.
+
+`memoryHardLimitGb` is applied by the `mlx_lm` launcher via `mx.set_memory_limit`.
+It is wired up on this host because `modelServerBackend` is `mlx-lm` — nix-ai
+`modules/mlx/assertions.nix` asserts that outright — and inert under `vllm-mlx`.
+
+**It is a sizing guideline, not an enforcement.** Upstream MLX raises only when
+RAM *and swap* are exhausted; crossing the limit sheds the free-buffer cache and
+otherwise proceeds. So a worker can transiently exceed 48 GiB with nothing
+refused, and `k_max × memoryHardLimitGb ≤ ceiling` is a budget you choose to
+respect, not one the runtime imposes.
+
+This matters for reading the numbers above: the worst constructible resident set
+(~21.3 weights + 16 prompt cache + up to 12 shedable buffer cache) is larger than
+48 GiB, and that is fine precisely because the limit sheds rather than fails. The
+practical effect of lowering 99 → 48 is *earlier buffer-cache shedding under
+long-context load*, costing some re-allocation latency — not allocation failure.
+
+nix-ai's own prose still says this limit "forces … allocation failure ahead of
+the host wired ceiling" (`options-residency.nix`, `mlx-lm-launch.py`). That
+contradicts upstream semantics — failure arrives at RAM+swap exhaustion, which is
+*behind* the ceiling, not ahead of it. Pre-existing defect in that repo, tracked
+separately; docs-starlight already states it correctly.
+

--- a/lib/hosts/mac-studio-residency.md
+++ b/lib/hosts/mac-studio-residency.md
@@ -86,4 +86,3 @@ the host wired ceiling" (`options-residency.nix`, `mlx-lm-launch.py`). That
 contradicts upstream semantics — failure arrives at RAM+swap exhaustion, which is
 *behind* the ceiling, not ahead of it. Pre-existing defect in that repo, tracked
 separately; docs-starlight already states it correctly.
-

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -31,11 +31,33 @@ warm. Roles split by cost, not preference:
 
 | Model | Roles | Shape | Thinking |
 | --- | --- | --- | --- |
-| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding, goal-judge | dense 27B, 64 KiB/token KV | on, `reasoning_effort=medium` |
-| Qwen3.6-35B-A3B-4bit | quickest, large-context | 35B MoE, ~3B active, 20 KiB/token KV | off |
+| Qwen3.8-27B-4bit | default, tool-calling, most-capable, oss, coding | dense 27B, 64 KiB/token KV | on, `reasoning_effort=medium` |
+| Qwen3.6-35B-A3B-4bit | quickest, large-context, goal-judge | 35B MoE, ~3B active, 20 KiB/token KV | off |
 
 `large-context` sits on the MoE deliberately: its KV costs roughly a third of
 the dense model's per token.
+
+### The judge
+
+`goal-judge` moved here from the 27B on 2026-08-15, and before that it lived on
+the swap-class 9B. Three reasons, in order of what actually broke:
+
+1. **Residency.** The 9B is swap-class at ttl=900 with a measured ~79s cold
+   load. At the 2-3 goal cards/hour the fabric drains it evicted between nearly
+   every card, so almost every judge call paid that in full. This entry is
+   ttl=0 and cannot be evicted, so the cold load is gone rather than shortened.
+2. **No self-judging.** A judge scoring its own model's output is
+   self-preference bias by construction, so it cannot sit on `default`.
+3. **Cost shape.** A verdict is a short, well-specified classification. The
+   deliberate model's minutes buy nothing there and take the slot the real work
+   wants — and the two would contend for one serving slot besides.
+
+**Two resolvers, one name.** `goal-judge` is resolved independently by
+llama-swap here and by LiteLLM in the router's registry
+(`dryvist/ansible-proxmox-ai` `llm-models.yml`). Those pointed at different
+models for a stretch, which is why a warmup log showing climbing cold-load
+times was once read as evidence about the judge when it was about the worker.
+Move both together or the ambiguity returns.
 
 **`singleModel` is gone, not repointed.** It aliased every role onto one entry
 and demoted the rest to `disabledModels` — exactly what made a second warm brain
@@ -67,86 +89,12 @@ Fit measured before switching (`vmmap`, 2026-08-14), not estimated: peaks
 against the 48 GiB per-worker budget. Weights are private per-process Metal
 buffers with no shared pages, so two workers is a straight sum.
 
-## Residency budget (k_max = 2 since 2026-08-05)
+## Residency budget
 
-The invariant, from nix-ai `modules/mlx/options-residency.nix`:
-
-```text
-maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
-```
-
-The ceiling here is 100 GiB (`appleSiliconTunables.maxLocalLlmGb = 100` →
-`wiredLimitMb = 102400`, in `hosts/mac-studio/default.nix`).
-
-**At the previous k_max = 1**, the resident and the always-available 9B
-collapsed into one exclusive swapping group, so loading the 9B evicted the 35B —
-verified by measurement on 2026-08-05, not inferred. That was the memory bound
-working as designed, not a bug, and it is why the earlier "the 9B never evicts
-the resident" comment was wrong and had to be corrected (#2043).
-
-**At k_max = 2** the tiered topology returns: a persistent resident plus a
-non-exclusive small tier hold weights simultaneously. `memoryHardLimitGb` must
-drop in the same change or the product over-commits the ceiling — 2 workers at
-the old 99 GiB would permit 198 GiB against 100 GiB.
-
-Chosen: `memoryHardLimitGb = 48`, so `2 × 48 = 96 GiB` against a 100 GiB ceiling.
-
-**The cushion is not 4 GiB.** 96 vs 100 ignores the non-MLX wired baseline,
-measured at ~3.4 GiB host-wide while one worker decodes. Strict worst case is
-`96 + 3.4 = 99.4 GiB`, so the honest cushion is **~0.6 GiB**. It still holds, and
-overshoot spills to pageable memory rather than failing, but do not read 4 GiB as
-spare capacity.
-
-Per-worker budget for the resident, using measurements rather than the catalog's
-declared `weightGb`:
-
-| quantity | value | source |
-| --- | --- | --- |
-| weights, live RSS mid-decode | 18.72 GiB | `ps` on the running worker |
-| weights, RSS recorded 2026-07-24 | 21.31 GiB | docs-starlight memory-ceilings |
-| prompt cache | **16 GiB** | live `--prompt-cache-bytes 17179869184` |
-| buffer cache (shedable) | up to 12 GiB | `bufferCacheLimitGb` default |
-
-So roughly `48 − 21.3 − 16 ≈ 10.7 GiB` is left for KV and scratch — not the ~28
-GiB an earlier draft of this file claimed. That draft also called 19.4 GB and
-5.2 GB "measured": they are **declared** catalog `weightGb` values
-(`catalog-data.nix`), they match neither disk (19.03 / 5.57 GiB) nor live RSS,
-and the unit they are expressed in is undocumented. Measure W; never take it
-from a spec sheet.
-
-Note the prompt cache is 16 GiB for the **resident**, not the host-wide 8 GiB:
-the resident class overrides `cacheMemoryMb = 16384` in the nix-ai catalog. The
-9B runs at the host default, 8 GiB.
-
-The worst constructible single-worker set therefore EXCEEDS 48 GiB. That is not
-a defect, because `memoryHardLimitGb` refuses nothing — see below.
-
-`suppressWiredLimit` defaults true (it avoids an IOGPUFamily kernel panic), which
-leaves weights pageable and makes this budget load-bearing: exceed the ceiling
-and the trade is a kernel panic for swap thrash. Do not raise `maxResidentWorkers`
-again without lowering `memoryHardLimitGb` to match.
-
-`memoryHardLimitGb` is applied by the `mlx_lm` launcher via `mx.set_memory_limit`.
-It is wired up on this host because `modelServerBackend` is `mlx-lm` — nix-ai
-`modules/mlx/assertions.nix` asserts that outright — and inert under `vllm-mlx`.
-
-**It is a sizing guideline, not an enforcement.** Upstream MLX raises only when
-RAM *and swap* are exhausted; crossing the limit sheds the free-buffer cache and
-otherwise proceeds. So a worker can transiently exceed 48 GiB with nothing
-refused, and `k_max × memoryHardLimitGb ≤ ceiling` is a budget you choose to
-respect, not one the runtime imposes.
-
-This matters for reading the numbers above: the worst constructible resident set
-(~21.3 weights + 16 prompt cache + up to 12 shedable buffer cache) is larger than
-48 GiB, and that is fine precisely because the limit sheds rather than fails. The
-practical effect of lowering 99 → 48 is *earlier buffer-cache shedding under
-long-context load*, costing some re-allocation latency — not allocation failure.
-
-nix-ai's own prose still says this limit "forces … allocation failure ahead of
-the host wired ceiling" (`options-residency.nix`, `mlx-lm-launch.py`). That
-contradicts upstream semantics — failure arrives at RAM+swap exhaustion, which is
-*behind* the ceiling, not ahead of it. Pre-existing defect in that repo, tracked
-separately; docs-starlight already states it correctly.
+Moved to [mac-studio-residency.md](./mac-studio-residency.md): the
+`maxResidentWorkers x memoryHardLimitGb <= ceiling` invariant, the measured
+per-worker figures behind 48 GiB, why the cushion is ~0.6 GiB rather than 4,
+and why the limit sheds cache rather than refusing allocations.
 
 ## Serving concurrency (2 since 2026-08-06)
 
@@ -159,20 +107,12 @@ queueing delay — not failure rate — dominated the latency tail. Two in-fligh
 requests let the server batch-decode them instead of queueing one behind the
 other.
 
-**Why 2 is safe where the 2026-07-27 4× override was harmful.** That
-measurement was 4-way *admission* against a worker whose
-`--decode-concurrency` was still hard-coded 1 (pre-unification): the proxy
-time-sliced one serialized GPU, gave 12.5 tok/s per stream, drove gate p90 to
-194 s with a 1298 s tail, returned 429 to 52% of requests, and wedged the
-worker. Since the unification, admission and served width derive from one
-number, and mlx-lm 0.31.3's `--decode-concurrency` feeds a real batch
-scheduler (`BatchGenerator`; upstream defaults are 32 decode / 8 prompt, so 2
-is conservative). The resident qwen3_5_moe is batchable in 0.31.3: no draft
-model, and both cache classes its `make_cache` returns (`KVCache`,
-`ArraysCache`) implement `merge`. The old note here that "`mlx_lm.server`
-serializes decode internally regardless" described that hard-coded-1 state,
-not 0.31.3 with the flag set. Still true: concurrency is not the lever for
-*rejection* rates.
+**Why 2 is safe where the 2026-07-27 4× override was harmful** — that
+measurement predates the admission/served-width unification and ran against a
+worker hard-coded to serialize decode. Figures and the batchability check for
+0.31.3 are in
+[mac-studio-model-history.md](./mac-studio-model-history.md). Still true:
+concurrency is not the lever for *rejection* rates.
 
 **Memory cost of the second stream.** The 35B is hybrid-attention
 (config.json: 10 of 40 layers full attention, 2 KV heads, head_dim 256), so
@@ -193,12 +133,17 @@ llama-swap's scheduler and never reaches the worker.
 `preload = [ "default" "quickest" ]` — two genuinely different models since
 2026-08-14, where under single-model mode every role alias resolved to the same
 resident and the name was cosmetic. `default` (the 27B) is listed first because
-it is the slower of the two to warm. It used to read `[ "goal-judge" ]`,
-which reads as "warm a separate, smaller judge model" that does not exist on this
-host. That misreading cost a multi-hour misdiagnosis of a warmup-starvation
-incident on 2026-08-01; the actual cause was external (something kickstarting the
-warmup agent in a tight loop, force-reloading the same resident). See nix-ai's
-`mlx-warmup.py` re-invocation bound.
+it is the slower of the two to warm. It used to read `[ "goal-judge" ]`, which
+read as "warm a separate, smaller judge model" when no such model existed —
+every role alias resolved to the same resident. That misreading cost a
+multi-hour misdiagnosis of a warmup-starvation incident on 2026-08-01; the
+actual cause was external (something kickstarting the warmup agent in a tight
+loop, force-reloading the same resident). See nix-ai's `mlx-warmup.py`
+re-invocation bound.
+
+A separate judge model does exist now, but `goal-judge` still does not belong
+in this list: it resolves to the same entry as `quickest`, so naming it would
+warm nothing extra and reintroduce exactly the ambiguity above.
 
 The warmup deadline needs no adjustment for the second entry: nix-ai's
 `warmup-timeout.nix` derives it as `healthCheckTimeout * len(preload) + 60`,

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -79,7 +79,7 @@ in
     #
     # suppressWiredLimit defaults true, so weights are pageable and overshoot
     # spills to swap rather than panicking. Rationale and the measurements
-    # behind the reserve: ./mac-studio.md.
+    # behind the reserve: ./mac-studio-residency.md.
     maxResidentWorkers = 2;
 
     # Validated catalog selections (profiles in nix-ai catalog-data.nix).
@@ -103,18 +103,23 @@ in
           "most-capable"
           "oss"
           "coding"
-          "goal-judge"
         ];
       };
       # Routine tier, and the 2026-07-27 throughput winner (115.2 tok/s
       # cumulative). Thinking off. Takes "large-context" as well as "quickest":
       # at 20 KiB/token of KV against the dense 27B's 64 KiB, a long context
       # costs roughly a third as much unified memory here.
+      #
+      # AND "goal-judge" since 2026-08-15 — a verdict is a short classification
+      # and must not run on the worker's own weights. KEEP IN STEP WITH THE
+      # ROUTER: llama-swap and LiteLLM resolve that alias independently and
+      # once named different models. Rationale: ./mac-studio.md "The judge".
       qwen36-35b = {
         class = "resident";
         roles = [
           "quickest"
           "large-context"
+          "goal-judge"
         ];
       };
       # Small on-demand 9B (5.2 GB) for trivial local tasks via the Gemini-CLI


### PR DESCRIPTION
## Summary

`goal-judge` shared an entry with `default`, so every verdict ran on the worker's own weights and paid the deliberate model's thinking cost. It moves to the resident 35B MoE — thinking off, cross-generation to the worker, pinned `ttl=0` so a verdict never pays a cold load.

This is the serving-host half of a two-sided change. `goal-judge` is resolved independently by llama-swap here and by the router's model registry in `dryvist/ansible-proxmox-ai`; both now name the same model. The router half is [ansible-proxmox-ai#430](https://github.com/dryvist/ansible-proxmox-ai/pull/430).

## Changes

- **`lib/hosts/mac-studio.nix`** — `goal-judge` moves from `qwen38-27b` to `qwen36-35b`; a note that the two resolvers must move together.
- **`lib/hosts/mac-studio.md`** — new "The judge" section with the residency, self-judging and cost-shape reasoning; the Preload note corrected (it said a separate judge model "does not exist on this host", true when written and false now).
- **`lib/hosts/mac-studio-residency.md`** (new) — the residency-budget section, split out because `mac-studio.md` was 12,714 bytes against the 12,288 error limit. Splitting is what `.file-size.yml` recommends.
- **`lib/hosts/mac-studio-model-history.md`** — takes the 2026-07-27 concurrency-override figures.

`mac-studio.md` is now 8.4 KB and the module 12.0 KB, both with headroom.

## Test Plan

Full system closure built for `jevans-ms`, and the rendered `llama-swap-config.json` read back out of that closure — not inferred from source, not read from evaluated options:

```text
Qwen3.6-35B-A3B-4bit -> ['goal-judge', 'large-context', 'quickest']
Qwen3.8-27B-4bit     -> ['coding', 'default', 'most-capable', 'oss', 'tool-calling']
groups: mlx-models = [Qwen3.6-35B-A3B-4bit, Qwen3.8-27B-4bit]
        mlx-swap-models = [Qwen3.5-9B-MLX-4bit]
```

The residency topology is unchanged: both brains stay in the persistent group, the 9B stays swap-class.

File-size gate: every touched file measured under its limit.