### PR TITLE
fix(cribl): match bench-events.jsonl file source glob to its flat layout

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -112,7 +112,9 @@ in
               interval: 10
               path: ${userConfig.user.homeDir}/.local/state/mlx-benchmarks/
               filenames:
-                - "*/bench-events.jsonl"
+                # Flat file directly under path (see comment above), not
+                # nested in a subdirectory — a "*/…" glob never matches it.
+                - "bench-events.jsonl"
               tailOnly: false
               sendToRoutes: false
               connections:


### PR DESCRIPTION
## Summary
- `hosts/common/cribl.nix`'s `in_bench_events` file source glob required a subdirectory (`*/bench-events.jsonl`) that the actual file layout does not have — `mlx-bench-publish` writes one flat `bench-events.jsonl` directly under the benchmarks state directory. The glob is corrected to `bench-events.jsonl`.

## Test plan
- [x] `nix fmt` — no changes needed
- [x] `nix flake check` — all checks green (darwinConfigurations for both hosts, packages, devShells)
- [ ] Operator: `darwin-rebuild switch` on jevans-mbp and confirm a new benchmark run's events reach Splunk (`index=llm sourcetype=mlx:bench`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)