### PR TITLE
chore: promote develop to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786831956,
-        "narHash": "sha256-Ycjg/Krw+U2tz3A41QMFSChBy6JlA2nkEQv2ZrgjMnE=",
+        "lastModified": 1786850139,
+        "narHash": "sha256-Kms3g8wm1CfQM4GeY12zRBu3DIP1apZJ4ZrKqVC7ql8=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6c0fcdcdd7d992fe7695884ac481a7d6461e2ffb",
+        "rev": "bfae037b20df2be17177cec7bbbfdd4b65c11a81",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1786844204,
-        "narHash": "sha256-TV5LCQX6wIKiEM/oEx0H6XpTBQYbyJJFAxOp0/6NcGg=",
+        "lastModified": 1786857872,
+        "narHash": "sha256-4YMnVluBxvc38k1w7+6oE4rKFHp6iTmQW0pgS/KLx+M=",
         "owner": "dryvist",
         "repo": "claude-code-plugins",
-        "rev": "092ae41637afc750d1483de93f788e38d95f7e21",
+        "rev": "a4ced7b2a81ee0451587c870169a37459b56c285",
         "type": "github"
       },
       "original": {
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786850927,
-        "narHash": "sha256-gyT2fwjKE5Dk9yvoI0nnuzwnbVtonHcSZpA2WIz7JG4=",
+        "lastModified": 1786877092,
+        "narHash": "sha256-2g3o5k4PJX2EEfVUlPHYjobbYKokBWJxjpvbYEBijEg=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "199ee2a6bc6fe9231fe8b4a6dc33269a58ac3a6e",
+        "rev": "10e8e5ea55322db54d7ce36e180d652f4300a2b5",
         "type": "github"
       },
       "original": {

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -152,11 +152,19 @@ in
     # the module defaults already match the laptop.
     # Both hosts are cluster-mode nodes: keep every RDMA-capable Thunderbolt
     # port out of bridge0 and converge the role link address onto whichever
-    # port the cable is in. Role follows machine class: the headless desktop
-    # is the coordinator (rank 0), the laptop the worker.
-    clusterLinkPrep = {
+    # port the cable is in. Read from hostConfig.mlx.clusterMode.role (the same
+    # field nix-ai's programs.mlx.clusterMode.role is spliced from — see
+    # hosts/common/cluster-quiesce.nix's identical `hostConfig.mlx.clusterMode.role
+    # or null` read) rather than re-deriving from isServer: they coincided only
+    # by accident of machine class, and deriving role here from a DIFFERENT
+    # source than the one nix-ai's rank env reads let this pin the Thunderbolt
+    # static IPs to the wrong Mac the moment anyone changed just one of the two.
+    # Attribute-existence gate (repo convention, matches cluster-quiesce.nix):
+    # non-inference hosts have no `mlx` at all, so a bare `hostConfig.mlx.…`
+    # read would crash eval on them.
+    clusterLinkPrep = lib.mkIf (hostConfig ? mlx && hostConfig.mlx ? clusterMode) {
       enable = true;
-      role = if hostConfig.isServer then "coordinator" else "worker";
+      role = hostConfig.mlx.clusterMode.role;
       # Clustered wired ceilings, applied around rank start/stop by the cluster
       # watcher (standalone value restored at link-down). Raised 2026-07-19 per
       # user decision: the old 90000/80000 caps were low enough to force swap

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -96,37 +96,58 @@ Moved to [mac-studio-residency.md](./mac-studio-residency.md): the
 per-worker figures behind 48 GiB, why the cushion is ~0.6 GiB rather than 4,
 and why the limit sheds cache rather than refusing allocations.
 
-## Serving concurrency (2 since 2026-08-06)
+## Serving concurrency (4 since 2026-08-16)
 
-`proxy.concurrencyLimit` inherits `serveConcurrency = 2`. The host sets no
-per-model override; catalog pins hold the 9B and every 40B+ entry at
-`concurrencyLimit = 1` (nix-ai's 40B+ single-slot policy, flake-check
-enforced), so only the resident 35B serves two-wide. Raised from 1 because a
-single slot serializes every caller: with several uncoordinated callers,
-queueing delay — not failure rate — dominated the latency tail. Two in-flight
-requests let the server batch-decode them instead of queueing one behind the
-other.
+`proxy.concurrencyLimit` inherits `serveConcurrency = 4`. No per-model
+override on either resident; `qwen35-9b-mlx` keeps its own catalog
+`concurrencyLimit = 1` (40B+ single-slot policy, flake-check enforced) and
+does **not** inherit `serveConcurrency`, so this raise never touches the 9B.
 
-**Why 2 is safe where the 2026-07-27 4× override was harmful** — that
-measurement predates the admission/served-width unification and ran against a
-worker hard-coded to serialize decode. Figures and the batchability check for
-0.31.3 are in
-[mac-studio-model-history.md](./mac-studio-model-history.md). Still true:
-concurrency is not the lever for *rejection* rates.
+**Why 4, derived from architecture.** Hybrid attention only grows a KV cache
+on `full_attention` layers — `linear_attention` layers carry fixed-size
+recurrent state — confirmed from each model's own `config.json` on jevans-ms:
 
-**Memory cost of the second stream.** The 35B is hybrid-attention
-(config.json: 10 of 40 layers full attention, 2 KV heads, head_dim 256), so
-KV costs `2 × 10 × 2 × 256 × 2 B = 20 KiB/token` — 1.25 GiB per
-65,536-token stream, 5.0 GiB at the architectural max 262,144. The second
-in-flight stream therefore adds ~1.3–5 GiB plus ~0.25 GiB of fixed
-linear-attention state. `mlx_lm.server` trims the stored prompt cache to
-`prompt-cache-bytes − active batch KV`, so stored + in-flight KV stays inside
-the 16 GiB cache budget. Worst constructible worker at 2 is ~21.3 (weights) +
-≤16 (KV + prompt cache) + ~0.5 (state) + ≤12 (shedable buffer cache) ≈ 50 GiB
-against the 48 GiB per-worker budget — sheds cache rather than failing, and
-the residency invariant is untouched: `maxResidentWorkers` counts workers,
-not in-flight requests. A third request per model is parked or 429'd by
-llama-swap's scheduler and never reaches the worker.
+- 27B (`qwen38-27b`, `qwen3_5_text`): 64 layers, `full_attention_interval=4`
+  → 16 full-attention, `kvHeads=4`, `headDim=256`. KV/token =
+  `2 × 16 × 4 × 256 × 2 B = 64 KiB`.
+- 35B (`qwen36-35b`, `qwen3_5_moe_text`): 40 layers → 10 full-attention,
+  `kvHeads=2`, `headDim=256`. KV/token = `2 × 10 × 2 × 256 × 2 B = 20 KiB`
+  (independently re-derived, matches the prior generation's figure).
+
+Both carry `cacheMemoryMb = 16384` (16 GiB `--prompt-cache-bytes`).
+`mlx_lm.server` trims stored cache to `prompt-cache-bytes − active batch KV`,
+so worst case stays at 16 GiB as long as active-batch KV alone doesn't exceed
+it. 27B (binding constraint): active-batch KV(N) = `N × 65536 × 64 KiB` =
+**N × 4 GiB** — N=2→8, N=3→12, N=4→16 (exactly saturates the budget), N=5→20
+(first overflow). **N=2/3/4 share an identical worst-case peak**:
+`16.1 (weights) + 16 (cache) + ~0.3 (state) ≈ 32.4 GB`. 35B's KV(N) =
+`N × 1.25 GiB`, never binding below N≈13. Raising 2→4 costs nothing extra;
+N=5 is the first genuinely new territory.
+
+**Cross-checked against measured `footprint` peaks**, all three models
+loaded (9B's `concurrencyLimit=1` keeps it a fixed ~13.4 GB worst case: 5.2
+weights + 8 GiB cache + ~0.15 state): 27B 34 GB observed peak (~32.4 GB
+theoretical, close), 35B 30 GB observed. System-wide worst case against the
+real `iogpu.wired_limit_mb=100 GiB` (one shared pool): `32.4 + 35.65 (35B) +
+13.4 (9B) + 3.4 (baseline) ≈ 84.85 GB` → **~15.15 GB margin**, identical at
+N=2 and N=4.
+
+**nix-ai#915 (hybrid-attention batching crash) verified not to apply, not
+just read.** The bug (`mlx_lm/models/qwen3_5.py`'s
+`mx.concatenate([conv_state, qkv], ...)` throwing on a batch-size mismatch,
+aborting every in-flight request) is specific to vllm-mlx's scheduler;
+`modules/mlx/assertions.nix` hard-fails eval unless `mlx-lm` is the sole
+backend (`docs/architecture/mlx-stack.md`). Tested directly too: the
+production-pinned `mlx-lm-server` binary on a side port serving
+`Qwen3.5-9B-MLX-4bit` (same `qwen3_5` family), 4 truly concurrent requests
+plus a staggered-length round to force batch composition to change
+mid-generation — the bug's actual trigger. Zero crashes either run.
+
+Distinct from residency: `maxResidentWorkers` counts workers, not in-flight
+requests. A fifth request per resident is parked or 429'd by llama-swap's
+scheduler, never reaching the worker. (Older 0.31.3-era rejection-rate
+figures, predating admission/served-width unification, are in
+[mac-studio-model-history.md](./mac-studio-model-history.md).)
 
 ## Preload
 

--- a/lib/hosts/mac-studio.md
+++ b/lib/hosts/mac-studio.md
@@ -96,14 +96,21 @@ Moved to [mac-studio-residency.md](./mac-studio-residency.md): the
 per-worker figures behind 48 GiB, why the cushion is ~0.6 GiB rather than 4,
 and why the limit sheds cache rather than refusing allocations.
 
-## Serving concurrency (4 since 2026-08-16)
+## Serving concurrency
 
-`proxy.concurrencyLimit` inherits `serveConcurrency = 4`. No per-model
+`proxy.concurrencyLimit` inherits `serveConcurrency = 2`. No per-model
 override on either resident; `qwen35-9b-mlx` keeps its own catalog
 `concurrencyLimit = 1` (40B+ single-slot policy, flake-check enforced) and
-does **not** inherit `serveConcurrency`, so this raise never touches the 9B.
+does **not** inherit `serveConcurrency`.
 
-**Why 4, derived from architecture.** Hybrid attention only grows a KV cache
+**Why not higher, despite memory headroom.** The arithmetic below shows
+`serveConcurrency` up to 4 is memory-safe. A 2026-08-16 raise to 4 tested
+that in production and was reverted the same day: MLX batches concurrent
+sequences on shared GPU compute, so on a compute-bound dense model more
+slots stretches latency instead of adding throughput. Memory was never the
+binding constraint.
+
+**KV-cache arithmetic, still valid.** Hybrid attention only grows a KV cache
 on `full_attention` layers — `linear_attention` layers carry fixed-size
 recurrent state — confirmed from each model's own `config.json` on jevans-ms:
 

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -24,7 +24,7 @@ let
   # fetches dryvist/tofu-proxmox's published constant and fails the build
   # when it disagrees with the value below. Raise both together; the check
   # enforces that now, not this comment.
-  serveConcurrency = 4;
+  serveConcurrency = 2;
 in
 {
   # Network identity. `system` omitted (mkHost defaults to aarch64-darwin).

--- a/lib/hosts/mac-studio.nix
+++ b/lib/hosts/mac-studio.nix
@@ -24,7 +24,7 @@ let
   # fetches dryvist/tofu-proxmox's published constant and fails the build
   # when it disagrees with the value below. Raise both together; the check
   # enforces that now, not this comment.
-  serveConcurrency = 2;
+  serveConcurrency = 4;
 in
 {
   # Network identity. `system` omitted (mkHost defaults to aarch64-darwin).

--- a/tests/shell/test_cluster_link_prep_role_source.bats
+++ b/tests/shell/test_cluster_link_prep_role_source.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# Guard that system.clusterLinkPrep.role and programs.mlx.clusterMode.role stay
+# sourced from the SAME field. They used to agree only by coincidence (isServer
+# happened to match clusterMode.role on both hosts); diverge them again and IP
+# pinning and the rank env disagree about which Mac is .1 while looking like an
+# inscrutable network fault, not a config error.
+#
+# ponytail: structural assertion over the source, not a full darwinConfigurations
+# eval — the fastest thing that actually catches a re-coupling regression. See
+# test_cluster_quiesce.bats for the same pattern in this repo.
+
+SOURCE_UNDER_TEST="$BATS_TEST_DIRNAME/../../hosts/common/default.nix"
+
+@test "clusterLinkPrep.role is read from hostConfig.mlx.clusterMode.role" {
+  run grep -nE '^\s*role = hostConfig\.mlx\.clusterMode\.role;' "$SOURCE_UNDER_TEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "clusterLinkPrep.role no longer re-derives from hostConfig.isServer" {
+  run grep -n 'role = if hostConfig.isServer' "$SOURCE_UNDER_TEST"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
Promotes the current state of `develop` to `main`.

## Notes
- Merge commit only — `main`'s ruleset bans squash and rebase.
- Merging this PR triggers release-please on `main`, which opens its own
  release PR (version bump + CHANGELOG) automatically. This PR does not
  touch versioning itself.