### PR TITLE
fix(cribl): split cluster-watcher/rank logs into their own sourcetype

### DIFF
--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -519,6 +519,21 @@ in
         # Model-server logs: the manager (Go) and its workers (Python) share
         # the same two files. Keep the worker sourcetype backend-neutral so a
         # selected MLX server change does not require downstream rewrites.
+        # in_cluster_logs (rank/watcher/peer-liveness) shares this same
+        # pipeline but is a third, unrelated event shape — discriminate on
+        # __inputId FIRST (same pattern as os_events below), or its lines
+        # fall through the content regex and land mislabeled as
+        # mlx:model-server, indistinguishable from real worker output
+        # (verified live: thousands of cluster-watcher decision lines tagged
+        # mlx:model-server before this fix).
+        #
+        # None of the three source formats carries a timestamp Cribl can
+        # reliably parse at the line start (llama-swap's own `[INFO] Request
+        # ...` access lines and the cluster-watcher lines have no leading
+        # timestamp at all), so _time for llamaswap and mlx:cluster is
+        # arrival/index time — same honest, already-documented pattern used
+        # for firewall_logs below. Only the Python worker lines (mlx:model-server)
+        # carry a real per-line timestamp, which Cribl parses natively.
         "pipelines/llm_logs/conf.yml" = ''
           output: default
           functions:
@@ -529,7 +544,7 @@ in
                   - name: index
                     value: "'llm'"
                   - name: sourcetype
-                    value: "_raw.match(/^(\\[(DEBUG|INFO|WARN|ERROR)\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'"
+                    value: "String(__inputId).includes('cluster') ? 'mlx:cluster' : _raw.match(/^(\\[(DEBUG|INFO|WARN|ERROR)\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'"
         '';
         "pipelines/bench_events/conf.yml" = ''
           output: default

--- a/tests/shell/test_cribl_llm_classifier.bats
+++ b/tests/shell/test_cribl_llm_classifier.bats
@@ -3,17 +3,23 @@
 MANAGER_LOG_PATTERN='^(\[(DEBUG|INFO|WARN|ERROR)\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})'
 CRIBL_CONFIG="$BATS_TEST_DIRNAME/../../hosts/common/cribl.nix"
 
+# Mirrors the pipeline eval: __inputId is checked FIRST (cluster logs share
+# the llm_logs pipeline with the model-server logs but are a third, unrelated
+# shape), then the manager/worker content regex as before.
 classify() {
-  if [[ "$1" =~ $MANAGER_LOG_PATTERN ]]; then
+  local raw="$1" input_id="${2:-in_llm_logs}"
+  if [[ "$input_id" == *cluster* ]]; then
+    echo "mlx:cluster"
+  elif [[ "$raw" =~ $MANAGER_LOG_PATTERN ]]; then
     echo "llamaswap"
   else
     echo "mlx:model-server"
   fi
 }
 
-@test "production classifier identifies manager records and defaults to MLX workers" {
+@test "production classifier checks __inputId before content, then defaults to MLX workers" {
   run grep -F \
-    "value: \"_raw.match(/^(\\\\[(DEBUG|INFO|WARN|ERROR)\\\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'\"" \
+    "value: \"String(__inputId).includes('cluster') ? 'mlx:cluster' : _raw.match(/^(\\\\[(DEBUG|INFO|WARN|ERROR)\\\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'\"" \
     "$CRIBL_CONFIG"
   [ "$status" -eq 0 ]
 }
@@ -42,5 +48,16 @@ classify() {
     run classify "$line"
     [ "$status" -eq 0 ]
     [ "$output" = "mlx:model-server" ]
+  done
+}
+
+@test "cluster-watcher/rank input lands as mlx:cluster regardless of content shape" {
+  for line in \
+    "cluster-link: HALTED (peer-absent) — rank starts suppressed" \
+    "cluster-link: HEARTBEAT tick 14820 — link up, rank none, wired 53GiB" \
+    "2026-08-16 08:19:47,759 - INFO - Prompt Cache: 0 sequences, 0.00 GB"; do
+    run classify "$line" "in_cluster_logs"
+    [ "$status" -eq 0 ]
+    [ "$output" = "mlx:cluster" ]
   done
 }


### PR DESCRIPTION
## Summary
- The `llm_logs` Cribl pipeline's sourcetype classifier only recognizes two content shapes (llama-swap access lines vs. everything else), and the cluster-watcher/rank/peer-liveness input shares that same pipeline — so every cluster-log line fell into the `mlx:model-server` catch-all, indistinguishable from real MLX worker output.
- Discriminate on `__inputId` first (same pattern already used by `os_events` in this file), tagging the cluster input's events as their own `mlx:cluster` sourcetype before falling back to the existing content-based classifier for the other two inputs.
- Updated `tests/shell/test_cribl_llm_classifier.bats` to cover the new branch and the changed production-string assertion.

## Test plan
- [x] `nix shell nixpkgs#bats -c bats tests/shell/test_cribl_llm_classifier.bats` — 4/4 pass
- [x] `nix fmt` — no changes
- [x] `nix flake check` — green
- [ ] After deploy, confirm `index=llm sourcetype=mlx:cluster` starts populating and `sourcetype=mlx:model-server` no longer contains cluster-watcher content

🤖 Generated with [Claude Code](https://claude.com/claude-code)