### PR TITLE
docs: record the nix-ai promotion contract for reaching a Mac

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,12 +105,19 @@ flake.nix
 | Host | Machine-specific | `hosts/<name>/` | Both |
 | Shared | Variables, defaults | `lib/` | Imported |
 
-## Getting a nix-ai (or nix-home) change onto a Mac: the promotion contract
+## Getting a nix-ai change onto a Mac: the promotion contract
 
 This repo's `nix-ai` input tracks nix-ai's **`main`** branch, not `develop`
 (`github:dryvist/nix-ai/main` in `flake.nix`). Merging a PR into nix-ai's
 `develop` does not make that change reachable by any Mac here — three
 separate steps have to happen, in order:
+
+**This is `nix-ai`-specific, not a general flake-input rule.** The
+`nix-home` input (`github:dryvist/nix-home`, no `/main` suffix) tracks
+whatever GitHub reports as that repo's default branch — currently
+`develop` — so a nix-home change needs only step 2 and step 3 below, never
+a develop→main promotion of its own. Check an input's `flake.lock` entry
+for a `ref` before assuming either contract applies.
 
 1. **Promote nix-ai `develop` → `main`.** Only commits on nix-ai's `main`
    exist as far as this repo's `nix-ai` input is concerned.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,4 +105,34 @@ flake.nix
 | Host | Machine-specific | `hosts/<name>/` | Both |
 | Shared | Variables, defaults | `lib/` | Imported |
 
+## Getting a nix-ai (or nix-home) change onto a Mac: the promotion contract
+
+This repo's `nix-ai` input tracks nix-ai's **`main`** branch, not `develop`
+(`github:dryvist/nix-ai/main` in `flake.nix`). Merging a PR into nix-ai's
+`develop` does not make that change reachable by any Mac here — three
+separate steps have to happen, in order:
+
+1. **Promote nix-ai `develop` → `main`.** Only commits on nix-ai's `main`
+   exist as far as this repo's `nix-ai` input is concerned.
+2. **Bump this repo's `flake.lock`** (`nix flake update nix-ai` or
+   equivalent) to pin the new nix-ai `main` revision.
+3. **Promote this repo's own `develop` → `main`**, since a Mac converges
+   from `main`.
+
+Skipping any one of the three produces the exact same symptom: the change
+looks merged (visible in nix-ai's `develop`, or even its `main`) but no
+`darwin-rebuild switch` on any Mac ever picks it up. This gap has caused a
+real merged-but-not-deployed incident more than once — treat "merged" and
+"deployed" as separate questions and verify both.
+
+**Operational note:** step 1's `main` promotion may or may not trigger a
+release-please version-bump follow-on PR in nix-ai, depending on whether the
+promoted commits carry a releasable conventional-commit type (`feat`/`fix`
+bump; `docs`/`chore`/`refactor`/`test`/`ci` do not). When it does, `main`
+gains a further commit after the promotion lands. **Converging to "the tip
+of nix-ai's main" means converging to whatever tip exists after that PR
+resolves, not the tip at the moment the promotion PR merged** — check
+`main`'s actual head before pinning step 2, not the promotion PR's merge
+commit.
+
 For a complete list of installed packages and managed settings, see [MANIFEST.md](MANIFEST.md).


### PR DESCRIPTION
## Summary
- Documents the three-step chain a nix-ai (or nix-home) change needs to actually reach a Mac: nix-ai develop->main, this repo's flake.lock bump, then this repo's own develop->main.
- Notes the release-please follow-on-PR caveat: converge to nix-ai main's actual current tip when pinning, not the tip at the moment a promotion PR merged.

Found no existing doc covering this (checked ARCHITECTURE.md, CONTRIBUTING.md, and searched recent commits/PRs in both nix-ai and nix-darwin) — writing it fresh rather than assuming prior work landed.

## Test plan
- [x] `pre-commit run --files ARCHITECTURE.md` passed (includes file-size and link checks)
- [x] Verified `flake.nix` pins `github:dryvist/nix-ai/main` and nix-ai's `release-please-config.json` conventional-commit type gating

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01R438Ytsn7PLsnDUUTbexp3