### PR TITLE
fix(cribl): temporary boot-time probe for the cribl-edge store-path race

### DIFF
--- a/modules/darwin/apps/cribl-edge-boot-race-probe.nix
+++ b/modules/darwin/apps/cribl-edge-boot-race-probe.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.cribl-edge;
+
+  # ponytail: temporary evidence-gathering for Vikunja nix-ai#1603. Delete
+  # this module and its script once that ticket is resolved.
+  probeScript = pkgs.writeShellApplication {
+    name = "cribl-edge-boot-race-probe";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.perl
+    ];
+    text = builtins.readFile ./scripts/cribl-edge-boot-race-probe.sh;
+  };
+in
+{
+  config = lib.mkIf cfg.enable {
+    launchd.daemons.cribl-edge-boot-race-probe.serviceConfig = {
+      Label = "com.nix-darwin.cribl-edge-boot-race-probe";
+      ProgramArguments = [
+        "${probeScript}/bin/cribl-edge-boot-race-probe"
+        (lib.head config.launchd.daemons.cribl-edge.serviceConfig.ProgramArguments)
+      ];
+      RunAtLoad = true;
+      KeepAlive.PathState."/nix/store" = true;
+      StandardOutPath = "/var/log/cribl-boot-race-probe.log";
+      StandardErrorPath = "/var/log/cribl-boot-race-probe.log";
+    };
+  };
+}

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -60,6 +60,18 @@ let
     text = builtins.readFile ./scripts/cribl-edge-deploy-pack.sh;
   };
 
+  # ponytail: temporary evidence-gathering for Vikunja nix-ai#1603. Delete
+  # this derivation and the launchd.daemons entry below once that ticket is
+  # resolved — see the script's own header for what it answers and why.
+  bootRaceProbeScript = pkgs.writeShellApplication {
+    name = "cribl-edge-boot-race-probe";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.perl
+    ];
+    text = builtins.readFile ./scripts/cribl-edge-boot-race-probe.sh;
+  };
+
   startScript = pkgs.writeShellApplication {
     name = "cribl-edge-start";
     runtimeInputs = [ pkgs.coreutils ];
@@ -252,6 +264,26 @@ in
           CODEX_HOME = "${userConfig.user.homeDir}/.codex";
           GEMINI_HOME = userConfig.user.homeDir;
         };
+      };
+    };
+
+    # ponytail: temporary, see bootRaceProbeScript's definition above and its
+    # own header. Gated on the SAME KeepAlive.PathState the fixed cribl-edge
+    # daemon uses, so this probe launches under identical conditions and
+    # measures the thing the ticket actually needs: once that gate fires, how
+    # long (if any) until the specific store path resolves? RunAtLoad with no
+    # extra KeepAlive beyond the path gate, so it fires once and never again.
+    launchd.daemons.cribl-edge-boot-race-probe = {
+      serviceConfig = {
+        Label = "com.nix-darwin.cribl-edge-boot-race-probe";
+        ProgramArguments = [
+          "${bootRaceProbeScript}/bin/cribl-edge-boot-race-probe"
+          "${startScript}/bin/cribl-edge-start"
+        ];
+        RunAtLoad = true;
+        KeepAlive.PathState."/nix/store" = true;
+        StandardOutPath = "/var/log/cribl-boot-race-probe.log";
+        StandardErrorPath = "/var/log/cribl-boot-race-probe.log";
       };
     };
 

--- a/modules/darwin/apps/cribl-edge.nix
+++ b/modules/darwin/apps/cribl-edge.nix
@@ -60,18 +60,6 @@ let
     text = builtins.readFile ./scripts/cribl-edge-deploy-pack.sh;
   };
 
-  # ponytail: temporary evidence-gathering for Vikunja nix-ai#1603. Delete
-  # this derivation and the launchd.daemons entry below once that ticket is
-  # resolved — see the script's own header for what it answers and why.
-  bootRaceProbeScript = pkgs.writeShellApplication {
-    name = "cribl-edge-boot-race-probe";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.perl
-    ];
-    text = builtins.readFile ./scripts/cribl-edge-boot-race-probe.sh;
-  };
-
   startScript = pkgs.writeShellApplication {
     name = "cribl-edge-start";
     runtimeInputs = [ pkgs.coreutils ];
@@ -264,26 +252,6 @@ in
           CODEX_HOME = "${userConfig.user.homeDir}/.codex";
           GEMINI_HOME = userConfig.user.homeDir;
         };
-      };
-    };
-
-    # ponytail: temporary, see bootRaceProbeScript's definition above and its
-    # own header. Gated on the SAME KeepAlive.PathState the fixed cribl-edge
-    # daemon uses, so this probe launches under identical conditions and
-    # measures the thing the ticket actually needs: once that gate fires, how
-    # long (if any) until the specific store path resolves? RunAtLoad with no
-    # extra KeepAlive beyond the path gate, so it fires once and never again.
-    launchd.daemons.cribl-edge-boot-race-probe = {
-      serviceConfig = {
-        Label = "com.nix-darwin.cribl-edge-boot-race-probe";
-        ProgramArguments = [
-          "${bootRaceProbeScript}/bin/cribl-edge-boot-race-probe"
-          "${startScript}/bin/cribl-edge-start"
-        ];
-        RunAtLoad = true;
-        KeepAlive.PathState."/nix/store" = true;
-        StandardOutPath = "/var/log/cribl-boot-race-probe.log";
-        StandardErrorPath = "/var/log/cribl-boot-race-probe.log";
       };
     };
 

--- a/modules/darwin/apps/default.nix
+++ b/modules/darwin/apps/default.nix
@@ -16,6 +16,7 @@ _:
     ./auto-update-prevention.nix
     ./claude-continuity.nix
     ./cribl-edge.nix
+    ./cribl-edge-boot-race-probe.nix
     ./cribl-stream.nix
     ./git-apfs-volume.nix
     ./github-runner-container.nix

--- a/modules/darwin/apps/scripts/cribl-edge-boot-race-probe.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-boot-race-probe.sh
@@ -13,22 +13,21 @@
 # launchd.daemons.cribl-edge-boot-race-probe entry once the ticket is
 # resolved.
 
-log="/var/log/cribl-boot-race-probe.log"
-cribl_path="$1"
+cribl_path="${1:?cribl_path required}"
 
 store_seen=""
 cribl_seen=""
-deadline=$(($(date +%s) + 60))
+deadline=$((SECONDS + 60))
 
-while [ "$(date +%s)" -lt "$deadline" ]; do
-  now="$(/usr/bin/perl -MTime::HiRes=time -e 'printf "%.3f", time')"
+while [ "$SECONDS" -lt "$deadline" ]; do
+  now="${EPOCHREALTIME:0:-3}"
   if [ -z "$store_seen" ] && [ -e /nix/store ]; then
     store_seen="$now"
-    echo "store_visible=$now" >> "$log"
+    echo "store_visible=$now"
   fi
   if [ -z "$cribl_seen" ] && [ -x "$cribl_path" ]; then
     cribl_seen="$now"
-    echo "cribl_resolvable=$now" >> "$log"
+    echo "cribl_resolvable=$now"
   fi
   if [ -n "$store_seen" ] && [ -n "$cribl_seen" ]; then
     break
@@ -37,5 +36,5 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 done
 
 if [ -z "$store_seen" ] || [ -z "$cribl_seen" ]; then
-  echo "timed_out store_seen=${store_seen:-never} cribl_seen=${cribl_seen:-never}" >> "$log"
+  echo "timed_out store_seen=${store_seen:-never} cribl_seen=${cribl_seen:-never}"
 fi

--- a/modules/darwin/apps/scripts/cribl-edge-boot-race-probe.sh
+++ b/modules/darwin/apps/scripts/cribl-edge-boot-race-probe.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ponytail: one-shot boot-time evidence for nix-ai Vikunja #1603 (the
+# cribl-edge cold-boot race). This daemon is gated on the SAME
+# KeepAlive.PathState("/nix/store") the fixed cribl-edge daemon uses, so it
+# spawns under identical conditions. Once spawned, it polls whether the
+# specific cribl-edge executable is ALREADY resolvable (gap ~0, meaning
+# PathState firing already implies the target is ready) or takes further
+# iterations to resolve (a real gap between the mount point transitioning and
+# the specific store path becoming usable) — the open question the ticket
+# needs answered before a third fix attempt. Self-limiting: 60s hard
+# deadline, writes once per boot (RunAtLoad, no other KeepAlive condition so
+# it never re-fires after this boot). Delete this script and its
+# launchd.daemons.cribl-edge-boot-race-probe entry once the ticket is
+# resolved.
+
+log="/var/log/cribl-boot-race-probe.log"
+cribl_path="$1"
+
+store_seen=""
+cribl_seen=""
+deadline=$(($(date +%s) + 60))
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  now="$(/usr/bin/perl -MTime::HiRes=time -e 'printf "%.3f", time')"
+  if [ -z "$store_seen" ] && [ -e /nix/store ]; then
+    store_seen="$now"
+    echo "store_visible=$now" >> "$log"
+  fi
+  if [ -z "$cribl_seen" ] && [ -x "$cribl_path" ]; then
+    cribl_seen="$now"
+    echo "cribl_resolvable=$now" >> "$log"
+  fi
+  if [ -n "$store_seen" ] && [ -n "$cribl_seen" ]; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [ -z "$store_seen" ] || [ -z "$cribl_seen" ]; then
+  echo "timed_out store_seen=${store_seen:-never} cribl_seen=${cribl_seen:-never}" >> "$log"
+fi


### PR DESCRIPTION
## Summary
- Adds a temporary companion LaunchDaemon, gated on the same `/nix/store` path state as `cribl-edge`.
- Records when the existing Cribl Edge launch program becomes resolvable after the gate is met.
- Keeps the probe self-limiting: it runs for at most 60 seconds and does not re-fire after that boot.

## Test plan
- [x] `shellcheck --shell=bash --severity=style modules/darwin/apps/scripts/cribl-edge-boot-race-probe.sh`
- [x] `nix fmt`
- [x] `nix flake check`
- [x] `git diff --check`