### PR TITLE
feat: add OpenWhispr to nix-darwin and Home Manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786883384,
-        "narHash": "sha256-c3YemP170j/7A+gmJAyyJVJX+uiuj4k3htqMVwp5VuY=",
+        "lastModified": 1786974826,
+        "narHash": "sha256-AZPVkOCGCSeDC7NiF+7Y1OHI4htrCljSPW+64SJO3/w=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "f68e176ead3232a3ba3ef8336d9b1fe7842ef7b3",
+        "rev": "b0cb903a6afc5cef3ea3afb7c0d27f7cfdc1c3e7",
         "type": "github"
       },
       "original": {
@@ -1256,6 +1256,29 @@
         "type": "github"
       }
     },
+    "nix-openwhispr": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786662609,
+        "narHash": "sha256-yJKpkTRnQEl9jYwBH2APJD5oK0BGHj3yVS8L5ueBXD8=",
+        "owner": "dryvist",
+        "repo": "nix-openwhispr",
+        "rev": "c2725eb05c4b3601c97c1a84a9d52ffb92302a46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dryvist",
+        "repo": "nix-openwhispr",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784160687,
@@ -1443,6 +1466,7 @@
         "nix-ai-open-harness": "nix-ai-open-harness",
         "nix-home": "nix-home",
         "nix-homebrew": "nix-homebrew",
+        "nix-openwhispr": "nix-openwhispr",
         "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
         "systems": "systems_3"

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,12 @@
       inputs.home-manager.follows = "home-manager";
     };
 
+    nix-openwhispr = {
+      url = "github:dryvist/nix-openwhispr";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
+
     # Official Determinate Nix module; automated updates are tracked by Renovate.
     determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
 
@@ -117,6 +123,7 @@
       home-manager,
       nix-ai,
       nix-ai-open-harness,
+      nix-openwhispr,
       nix-home,
       determinate,
       sops-nix,
@@ -211,6 +218,7 @@
                     dotgithub
                     hostConfig
                     nix-ai
+                    nix-openwhispr
                     ;
                 };
                 users.${userConfig.user.name} = import ./hosts/${label}/home.nix;
@@ -227,6 +235,7 @@
                 ]
                 ++ lib.optionals (label == "macbook-m4") [
                   nix-ai-open-harness.homeManagerModules.default
+                  nix-openwhispr.homeManagerModules.default
                 ];
               };
             }

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -29,6 +29,14 @@ in
   # a name with no DNS record, which every harness surfaces as a connection
   # failure rather than as a configuration error.
   programs = {
+    openwhispr = {
+      enable = true;
+      autoStart = true;
+      modelBootstrap = true;
+      localTranscriptionProvider = "whisper";
+      whisperModel = "base";
+    };
+
     openHarness = {
       enable = true;
       endpoint = "https://llm.${userConfig.internalDomain}/v1";


### PR DESCRIPTION
## Summary
- Adds `nix-openwhispr` flake input to `flake.nix`
- Injects `nix-openwhispr` into `extraSpecialArgs` and `sharedModules` for `macbook-m4`
- Enables and configures `programs.openwhispr` on `macbook-m4` home configuration

## Validation
- `nix flake check` passed locally