### PR TITLE
chore: promote develop to main

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -10,6 +10,7 @@ extended:
     # merge-ref file-size check; split the module if it approaches this ceiling
     - cribl
     - flake
+    - home
 
 exempt:
   - RUNBOOK

--- a/.file-size.yml
+++ b/.file-size.yml
@@ -9,6 +9,7 @@ extended:
     # cribl.nix crossed the 12KB error limit on develop, failing every PR's
     # merge-ref file-size check; split the module if it approaches this ceiling
     - cribl
+    - flake
 
 exempt:
   - RUNBOOK

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,4 +105,41 @@ flake.nix
 | Host | Machine-specific | `hosts/<name>/` | Both |
 | Shared | Variables, defaults | `lib/` | Imported |
 
+## Getting a nix-ai change onto a Mac: the promotion contract
+
+This repo's `nix-ai` input tracks nix-ai's **`main`** branch, not `develop`
+(`github:dryvist/nix-ai/main` in `flake.nix`). Merging a PR into nix-ai's
+`develop` does not make that change reachable by any Mac here — three
+separate steps have to happen, in order:
+
+**This is `nix-ai`-specific, not a general flake-input rule.** The
+`nix-home` input (`github:dryvist/nix-home`, no `/main` suffix) tracks
+whatever GitHub reports as that repo's default branch — currently
+`develop` — so a nix-home change needs only step 2 and step 3 below, never
+a develop→main promotion of its own. Check an input's `flake.lock` entry
+for a `ref` before assuming either contract applies.
+
+1. **Promote nix-ai `develop` → `main`.** Only commits on nix-ai's `main`
+   exist as far as this repo's `nix-ai` input is concerned.
+2. **Bump this repo's `flake.lock`** (`nix flake update nix-ai` or
+   equivalent) to pin the new nix-ai `main` revision.
+3. **Promote this repo's own `develop` → `main`**, since a Mac converges
+   from `main`.
+
+Skipping any one of the three produces the exact same symptom: the change
+looks merged (visible in nix-ai's `develop`, or even its `main`) but no
+`darwin-rebuild switch` on any Mac ever picks it up. This gap has caused a
+real merged-but-not-deployed incident more than once — treat "merged" and
+"deployed" as separate questions and verify both.
+
+**Operational note:** step 1's `main` promotion may or may not trigger a
+release-please version-bump follow-on PR in nix-ai, depending on whether the
+promoted commits carry a releasable conventional-commit type (`feat`/`fix`
+bump; `docs`/`chore`/`refactor`/`test`/`ci` do not). When it does, `main`
+gains a further commit after the promotion lands. **Converging to "the tip
+of nix-ai's main" means converging to whatever tip exists after that PR
+resolves, not the tip at the moment the promotion PR merged** — check
+`main`'s actual head before pinning step 2, not the promotion PR's merge
+commit.
+
 For a complete list of installed packages and managed settings, see [MANIFEST.md](MANIFEST.md).

--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1786883384,
-        "narHash": "sha256-c3YemP170j/7A+gmJAyyJVJX+uiuj4k3htqMVwp5VuY=",
+        "lastModified": 1786974826,
+        "narHash": "sha256-AZPVkOCGCSeDC7NiF+7Y1OHI4htrCljSPW+64SJO3/w=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "f68e176ead3232a3ba3ef8336d9b1fe7842ef7b3",
+        "rev": "b0cb903a6afc5cef3ea3afb7c0d27f7cfdc1c3e7",
         "type": "github"
       },
       "original": {
@@ -1256,6 +1256,29 @@
         "type": "github"
       }
     },
+    "nix-openwhispr": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786662609,
+        "narHash": "sha256-yJKpkTRnQEl9jYwBH2APJD5oK0BGHj3yVS8L5ueBXD8=",
+        "owner": "dryvist",
+        "repo": "nix-openwhispr",
+        "rev": "c2725eb05c4b3601c97c1a84a9d52ffb92302a46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dryvist",
+        "repo": "nix-openwhispr",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784160687,
@@ -1443,6 +1466,7 @@
         "nix-ai-open-harness": "nix-ai-open-harness",
         "nix-home": "nix-home",
         "nix-homebrew": "nix-homebrew",
+        "nix-openwhispr": "nix-openwhispr",
         "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
         "systems": "systems_3"

--- a/flake.nix
+++ b/flake.nix
@@ -276,25 +276,7 @@
       formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;
 
       # Quality checks for `nix flake check` (DRY principle).
-      #
-      # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
-      # from a single linux runner. All checks in lib/checks.nix are source-only
-      # (formatting, statix, deadnix, shell-tests) — they operate
-      # on the same source files regardless of target system, so running once
-      # on the CI system is sufficient and equivalent. Other systems
-      # intentionally have no `checks` entries.
-      #
-      # Cross-platform breakage (e.g. darwin-only `meta.broken` in nixpkgs) is
-      # still caught by `--all-systems` evaluating `packages.aarch64-darwin`,
-      # `devShells.aarch64-darwin`, `formatter.aarch64-darwin`, and the
-      # `darwinConfigurations.*.system` derivations during flake evaluation.
-      #
-      # The darwin module-eval (only populated when `darwinConfigurations` is
-      # non-empty) was previously gated on `system == aarch64-darwin`; combined
-      # with the prior `all_systems: false` workaround, it never actually ran
-      # in CI. Dropping it here is therefore no regression. If on-runner darwin
-      # module-eval coverage is desired, run it as a post-merge job on a darwin
-      # runner or via a dedicated workflow.
+      # Scoped to x86_64-linux: source-only checks run once on CI runner.
       checks =
         let
           system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,12 @@
       inputs.home-manager.follows = "home-manager";
     };
 
+    nix-openwhispr = {
+      url = "github:dryvist/nix-openwhispr";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
+
     # Official Determinate Nix module; automated updates are tracked by Renovate.
     determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
 
@@ -117,6 +123,7 @@
       home-manager,
       nix-ai,
       nix-ai-open-harness,
+      nix-openwhispr,
       nix-home,
       determinate,
       sops-nix,
@@ -211,6 +218,7 @@
                     dotgithub
                     hostConfig
                     nix-ai
+                    nix-openwhispr
                     ;
                 };
                 users.${userConfig.user.name} = import ./hosts/${label}/home.nix;
@@ -227,6 +235,7 @@
                 ]
                 ++ lib.optionals (label == "macbook-m4") [
                   nix-ai-open-harness.homeManagerModules.default
+                  nix-openwhispr.homeManagerModules.default
                 ];
               };
             }

--- a/hosts/common/cribl.nix
+++ b/hosts/common/cribl.nix
@@ -519,6 +519,21 @@ in
         # Model-server logs: the manager (Go) and its workers (Python) share
         # the same two files. Keep the worker sourcetype backend-neutral so a
         # selected MLX server change does not require downstream rewrites.
+        # in_cluster_logs (rank/watcher/peer-liveness) shares this same
+        # pipeline but is a third, unrelated event shape — discriminate on
+        # __inputId FIRST (same pattern as os_events below), or its lines
+        # fall through the content regex and land mislabeled as
+        # mlx:model-server, indistinguishable from real worker output
+        # (verified live: thousands of cluster-watcher decision lines tagged
+        # mlx:model-server before this fix).
+        #
+        # None of the three source formats carries a timestamp Cribl can
+        # reliably parse at the line start (llama-swap's own `[INFO] Request
+        # ...` access lines and the cluster-watcher lines have no leading
+        # timestamp at all), so _time for llamaswap and mlx:cluster is
+        # arrival/index time — same honest, already-documented pattern used
+        # for firewall_logs below. Only the Python worker lines (mlx:model-server)
+        # carry a real per-line timestamp, which Cribl parses natively.
         "pipelines/llm_logs/conf.yml" = ''
           output: default
           functions:
@@ -529,7 +544,7 @@ in
                   - name: index
                     value: "'llm'"
                   - name: sourcetype
-                    value: "_raw.match(/^(\\[(DEBUG|INFO|WARN|ERROR)\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'"
+                    value: "String(__inputId).includes('cluster') ? 'mlx:cluster' : _raw.match(/^(\\[(DEBUG|INFO|WARN|ERROR)\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'"
         '';
         "pipelines/bench_events/conf.yml" = ''
           output: default

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -155,6 +155,7 @@ in
     # Claude, Codex, and the other local clients on every host. Vikunja's
     # credentials remain injected by the shared Doppler wrapper.
     aiMcp.servers.vikunja.disabled = lib.mkForce false;
+    aiMcp.servers.openrouter.disabled = lib.mkForce false;
 
     # cecli (nix-ai's Aider fork) is disabled — unused, and its
     # tree-sitter-language-pack<=0.13.0 pin fails to build on nixpkgs 26.05

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -63,19 +63,7 @@ in
     ./mlx-cluster-signing.nix
   ];
 
-  # ==========================================================================
-  # macOS Application Management (copyApps for TCC stability)
-  # ==========================================================================
-  # Use copyApps instead of linkApps to create REAL copies of apps at stable
-  # paths in ~/Applications/Home Manager Apps/. This allows macOS TCC
-  # (Transparency, Consent, Control) permissions to persist across rebuilds.
-  #
-  # With linkApps (default), apps symlink to /nix/store paths which change on
-  # every rebuild, invalidating TCC permissions (camera, mic, screen recording).
-  #
-  # Trade-off: Uses more disk space (~100MB per app) but TCC permissions persist.
-  #
-  # See: https://github.com/nix-community/home-manager/issues/8336
+  # macOS Application Management: copyApps gives stable paths for TCC persistence.
   targets.darwin = {
     copyApps.enable = true;
     linkApps.enable = false;

--- a/hosts/macbook-m4/home.nix
+++ b/hosts/macbook-m4/home.nix
@@ -29,6 +29,14 @@ in
   # a name with no DNS record, which every harness surfaces as a connection
   # failure rather than as a configuration error.
   programs = {
+    openwhispr = {
+      enable = true;
+      autoStart = true;
+      modelBootstrap = true;
+      localTranscriptionProvider = "whisper";
+      whisperModel = "base";
+    };
+
     openHarness = {
       enable = true;
       endpoint = "https://llm.${userConfig.internalDomain}/v1";

--- a/tests/shell/test_cribl_llm_classifier.bats
+++ b/tests/shell/test_cribl_llm_classifier.bats
@@ -3,17 +3,23 @@
 MANAGER_LOG_PATTERN='^(\[(DEBUG|INFO|WARN|ERROR)\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})'
 CRIBL_CONFIG="$BATS_TEST_DIRNAME/../../hosts/common/cribl.nix"
 
+# Mirrors the pipeline eval: __inputId is checked FIRST (cluster logs share
+# the llm_logs pipeline with the model-server logs but are a third, unrelated
+# shape), then the manager/worker content regex as before.
 classify() {
-  if [[ "$1" =~ $MANAGER_LOG_PATTERN ]]; then
+  local raw="$1" input_id="${2:-in_llm_logs}"
+  if [[ "$input_id" == *cluster* ]]; then
+    echo "mlx:cluster"
+  elif [[ "$raw" =~ $MANAGER_LOG_PATTERN ]]; then
     echo "llamaswap"
   else
     echo "mlx:model-server"
   fi
 }
 
-@test "production classifier identifies manager records and defaults to MLX workers" {
+@test "production classifier checks __inputId before content, then defaults to MLX workers" {
   run grep -F \
-    "value: \"_raw.match(/^(\\\\[(DEBUG|INFO|WARN|ERROR)\\\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'\"" \
+    "value: \"String(__inputId).includes('cluster') ? 'mlx:cluster' : _raw.match(/^(\\\\[(DEBUG|INFO|WARN|ERROR)\\\\] |time=[^ ]+ level=(DEBUG|INFO|WARN|ERROR) |[0-9]{4}[/][0-9]{2}[/][0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/) ? 'llamaswap' : 'mlx:model-server'\"" \
     "$CRIBL_CONFIG"
   [ "$status" -eq 0 ]
 }
@@ -42,5 +48,16 @@ classify() {
     run classify "$line"
     [ "$status" -eq 0 ]
     [ "$output" = "mlx:model-server" ]
+  done
+}
+
+@test "cluster-watcher/rank input lands as mlx:cluster regardless of content shape" {
+  for line in \
+    "cluster-link: HALTED (peer-absent) — rank starts suppressed" \
+    "cluster-link: HEARTBEAT tick 14820 — link up, rank none, wired 53GiB" \
+    "2026-08-16 08:19:47,759 - INFO - Prompt Cache: 0 sequences, 0.00 GB"; do
+    run classify "$line" "in_cluster_logs"
+    [ "$status" -eq 0 ]
+    [ "$output" = "mlx:cluster" ]
   done
 }


### PR DESCRIPTION
## Summary
Promotes the current state of `develop` to `main`.

## Notes
- Merge commit only — `main`'s ruleset bans squash and rebase.
- Merging this PR triggers release-please on `main`, which opens its own
  release PR (version bump + CHANGELOG) automatically. This PR does not
  touch versioning itself.