### PR TITLE
fix(deps): bump nix-openwhispr for the app-install build fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1266,11 +1266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787186826,
-        "narHash": "sha256-7AzEXjFbNdQzrlte0EC17VB7nDkPl2/e6BbgEK3ZTNg=",
+        "lastModified": 1787436192,
+        "narHash": "sha256-niwU2qrCydDKaHctoZpVbMjs82jPtky+V5HMtXyrR/A=",
         "owner": "dryvist",
         "repo": "nix-openwhispr",
-        "rev": "63b5ba9b9b323994869fb16a516eceb31a31a33e",
+        "rev": "06bb12b8d4ba70310618a002a6edefcb5952a1ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the nix-openwhispr flake input to its latest main revision, which includes the fix for the application install phase that previously failed the darwin build. Single-input flake.lock bump; no other changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single flake.lock pin update for a downstream package input; no local logic, auth, or data-handling changes.
> 
> **Overview**
> Bumps the `nix-openwhispr` flake input to `06bb12b8` so this repo picks up the upstream application install-phase fix that was failing the Darwin build.
> 
> Lockfile-only change; no local Nix or module edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c7994fe470d955df07f1e5088d3c50f6ffe784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->