### PR TITLE
feat(power): restart servers automatically after a power failure

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -56,6 +56,14 @@ in
   # trip to the physical console. See modules/darwin/apps/screen-sharing.nix.
   programs.screenSharing.enable = true;
 
+  # Restart automatically once mains power returns, so an always-on host needs
+  # no console visit after an outage. Servers only, and deliberately left null
+  # (not false) elsewhere: portables report "Not supported" for
+  # `systemsetup -getRestartPowerFailure`, and nix-darwin's own preflight check
+  # aborts the activation whenever this is set on such a machine — so setting
+  # it either way on a laptop breaks every rebuild there.
+  power.restartAfterPowerFailure = lib.mkIf hostConfig.isServer (lib.mkDefault true);
+
   # Application firewall on every host. The MBP had this enabled by hand; the
   # Studio shipped disabled, which left the firewall-log-shipping feed with
   # nothing to say (its `log stream` daemon was alive but the ALF subsystem

--- a/hosts/macbook-m4/default.nix
+++ b/hosts/macbook-m4/default.nix
@@ -149,7 +149,6 @@ in
       # This ensures optimal power state transition on battery (Safe Sleep requires this)
       disksleep = 10; # Disk optimizes power after 10 minutes (before system sleep at 60)
       wakeOnMagicPacket = true;
-      autoRestartOnPowerLoss = true;
     };
   };
 }

--- a/modules/darwin/energy.nix
+++ b/modules/darwin/energy.nix
@@ -14,7 +14,6 @@
 #   sleep N          - System sleep timer (minutes, 0 = never)
 #   disksleep N      - Disk spindown timer (minutes, 0 = never)
 #   womp 0/1         - Wake on Magic Packet (Ethernet)
-#   autorestart 0/1  - Restart after power failure
 #   lidwake 0/1      - Wake on lid open (laptops)
 #   acwake 0/1       - Wake on AC power connect
 
@@ -65,11 +64,11 @@ in
       description = "Wake on Magic Packet (Wake-on-LAN)";
     };
 
-    autoRestartOnPowerLoss = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Automatically restart after power failure";
-    };
+    # Restart-after-power-failure is NOT here: it is nix-darwin's native
+    # `power.restartAfterPowerFailure`, set by host class in
+    # hosts/common/default.nix. Carrying it as a `pmset -a autorestart` flag
+    # bundled into the invocation below meant one knob that a portable rejects
+    # could take the other three down with it.
   };
 
   config = lib.mkIf cfg.enable {
@@ -80,8 +79,7 @@ in
       if sudo pmset -a \
         displaysleep ${toString cfg.displaysleep} \
         disksleep ${toString cfg.disksleep} \
-        womp ${if cfg.wakeOnMagicPacket then "1" else "0"} \
-        autorestart ${if cfg.autoRestartOnPowerLoss then "1" else "0"}; then
+        womp ${if cfg.wakeOnMagicPacket then "1" else "0"}; then
         echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Common energy settings applied"
       else
         echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to apply common energy settings (attempted: display ${toString cfg.displaysleep}m, disk ${toString cfg.disksleep}m)" >&2


### PR DESCRIPTION
## What

Sets nix-darwin's native `power.restartAfterPowerFailure` from the host
class: `true` on server-class hosts, left unset on every other class.

Removes the repo-local `system.energy.autoRestartOnPowerLoss` option and
the `autorestart` flag it appended to the bundled `pmset -a` invocation in
`modules/darwin/energy.nix`, along with its workstation call site. The
native option supersedes it.

## Why unset rather than false off the server class

The option is tri-state (`null` by default). Portable Macs report
`systemsetup -getRestartPowerFailure` as "Not supported", and nix-darwin's
activation preflight (`modules/system/checks.nix`) aborts the run whenever
the option is set on such a machine — with either value. Omitting it there
is what keeps activation working, so the class gate is load-bearing rather
than cosmetic.

Bundling the flag into a single `pmset -a` call also meant a knob one
machine rejects could take the other flags in that invocation with it.

`womp` (wake on network access) already defaults on for server-class hosts
in `hosts/common/default.nix` and is set explicitly on the workstation, so
it needs no change here.

## Verification

`power.restartAfterPowerFailure` evaluates to `true` for the server host
and `null` for the workstation. Both `darwinConfigurations` evaluate to a
derivation path, and pre-commit passes on all changed files.

Applying the setting on the target machine happens at the next activation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-class power setting only; leaving the option unset on portables avoids nix-darwin activation abort. No auth or data-path changes.
> 
> **Overview**
> Always-on **server** hosts now set nix-darwin's `power.restartAfterPowerFailure` so they come back after an outage without a console visit. The option stays **unset** (not `false`) on other classes: portables reject `systemsetup` for this, and nix-darwin's preflight aborts activation if it is set either way.
> 
> Removes the local `system.energy.autoRestartOnPowerLoss` option and the bundled `pmset -a autorestart` flag so a rejected knob cannot fail the rest of the energy settings. The MacBook no longer sets that option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a7c5b4adba9abd6f607ad66e973a80090d63fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->