### PR TITLE
feat(homebrew): add Timemator, disable Toggl Track and neat casks

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -193,12 +193,12 @@ All casks use `greedy = true` so that `brew upgrade --greedy` always installs th
 | orbstack | yes | Container/Linux VM runtime — cask for TCC permission stability |
 | microsoft-teams | yes | Teams desktop app (not available on Mac App Store) |
 | firefox | yes | Mozilla Firefox browser — cask for TCC permission stability |
+| timemator | yes | Automatic time tracking (replaces Toggl Track) |
 
 ### Mac App Store
 
 | App | ID |
 | --- | --- |
-| Toggl Track | 1291898086 |
 | Monarch Money Tweaks | 6753774259 |
 | Windows App | 1295203466 |
 | Microsoft Word | 462054704 |
@@ -207,6 +207,11 @@ All casks use `greedy = true` so that `brew upgrade --greedy` always installs th
 | Microsoft Outlook | 985367838 |
 | Microsoft OneNote | 784801555 |
 | OneDrive | 823766827 |
+
+Toggl Track (1291898086) is disabled via `togglTrackDisabled` in
+`modules/darwin/homebrew.nix` — the vendor pushes Enterprise/paid tiers hard
+and gates core features behind an expensive paywall; Timemator (Casks, above)
+replaces it.
 
 ---
 

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -46,7 +46,9 @@ in
       "/Applications/Ghostty.app"
     ]
     ++ lib.optionals enableWorkstationApps [
-      # "/Applications/Toggl Track.app" # DISABLED - see togglTrackDisabled in homebrew.nix
+      # "/Applications/Toggl Track.app" # DISABLED - togglTrackDisabled in
+      # homebrew.nix gates the masApps install only; re-enabling it there does
+      # NOT restore this line automatically, uncomment it too.
       "/Applications/Timemator.app"
 
       # Knowledge & Notes

--- a/modules/darwin/dock/persistent-apps.nix
+++ b/modules/darwin/dock/persistent-apps.nix
@@ -46,7 +46,8 @@ in
       "/Applications/Ghostty.app"
     ]
     ++ lib.optionals enableWorkstationApps [
-      "/Applications/Toggl Track.app"
+      # "/Applications/Toggl Track.app" # DISABLED - see togglTrackDisabled in homebrew.nix
+      "/Applications/Timemator.app"
 
       # Knowledge & Notes
       "/Applications/Obsidian.app"

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -144,7 +144,10 @@ let
 
   # Toggl Track: DISABLED. The vendor is pushing Enterprise/paid tiers hard
   # and gating core features behind an expensive paywall; Timemator
-  # (workstationCasks, above) replaces it. Flip to false to reinstall.
+  # (workstationCasks, above) replaces it. Flip to false to stop excluding it
+  # from masApps, then also uncomment its entry in
+  # modules/darwin/dock/persistent-apps.nix — that Dock entry does not read
+  # this flag.
   togglTrackDisabled = true;
 
   # Mac App Store apps; requires a signed-in App Store account.

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -80,10 +80,15 @@ let
       greedy = true;
     } # Voice-to-text app (local whisper)
     # GitHub and Linear menu-bar notifications.
+    # DISABLED - delete this cask entirely on or after 2026-09-01.
+    # {
+    #   name = "neat";
+    #   greedy = true;
+    # }
     {
-      name = "neat";
+      name = "timemator";
       greedy = true;
-    }
+    } # Automatic time tracking (Toggl Track replacement, see togglTrackDisabled)
 
     # --- Local Inference ---
     # Local LLM inference UI and OpenAI-compatible API server.
@@ -137,18 +142,26 @@ let
     }
   ];
 
+  # Toggl Track: DISABLED. The vendor is pushing Enterprise/paid tiers hard
+  # and gating core features behind an expensive paywall; Timemator
+  # (workstationCasks, above) replaces it. Flip to false to reinstall.
+  togglTrackDisabled = true;
+
   # Mac App Store apps; requires a signed-in App Store account.
-  workstationMasApps = {
-    "Toggl Track" = 1291898086; # Time tracking
-    "Monarch Money Tweaks" = 6753774259; # Personal finance enhancements
-    "Windows App" = 1295203466; # Microsoft Remote Desktop / Windows 365 / AVD client
-    # Microsoft 365 applications.
-    "Microsoft Word" = 462054704;
-    "Microsoft Excel" = 462058435;
-    "Microsoft PowerPoint" = 462062816;
-    "Microsoft Outlook" = 985367838;
-    "Microsoft OneNote" = 784801555;
-  };
+  workstationMasApps =
+    lib.optionalAttrs (!togglTrackDisabled) {
+      "Toggl Track" = 1291898086; # Time tracking
+    }
+    // {
+      "Monarch Money Tweaks" = 6753774259; # Personal finance enhancements
+      "Windows App" = 1295203466; # Microsoft Remote Desktop / Windows 365 / AVD client
+      # Microsoft 365 applications.
+      "Microsoft Word" = 462054704;
+      "Microsoft Excel" = 462058435;
+      "Microsoft PowerPoint" = 462062816;
+      "Microsoft Outlook" = 985367838;
+      "Microsoft OneNote" = 784801555;
+    };
 in
 {
   homebrew = {

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -161,6 +161,10 @@ let
       "Microsoft PowerPoint" = 462062816;
       "Microsoft Outlook" = 985367838;
       "Microsoft OneNote" = 784801555;
+      # OneDrive (823766827) is intentionally NOT managed via masApps: its
+      # first-time install needs an admin-password TTY, unavailable during a
+      # non-interactive `darwin-rebuild switch` ("sudo: a terminal is
+      # required"), so brew bundle failed on every rebuild (#1324).
     };
 in
 {


### PR DESCRIPTION
## Summary

- Add Timemator (Homebrew cask) as a Toggl Track replacement — no nixpkgs package exists
- Disable Toggl Track via `togglTrackDisabled` flag for later reinstallation without reconfiguring masApps
- Disable the `neat` cask with a 2026-09-01 delete-by date
- Update Dock persistent-apps list and MANIFEST.md to match

## Changes

- `modules/darwin/homebrew.nix`: Add Timemator cask, disable Toggl Track and neat with notes
- `modules/darwin/dock/persistent-apps.nix`: Replace Toggl Track with Timemator in Dock pins, restore OneDrive exclusion comment
- `MANIFEST.md`: Update package and configuration inventory

## Test Plan

- [x] `nix fmt`
- [x] `statix check`
- [x] `deadnix`
- [x] `nix flake check`
- [ ] `sudo darwin-rebuild switch --flake .` on a workstation host to verify Timemator installs and Toggl Track/neat are removed from Homebrew management