### PR TITLE
chore(flake): bump nix-ai for token-meter and Claude settings validator fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1787480951,
-        "narHash": "sha256-6ebFhsQnTw2D69alug7wKeJjQkq39MEB+fcaafXZdbE=",
+        "lastModified": 1787482612,
+        "narHash": "sha256-r3BaO0Zg5FR4jDnLup2JrZzOEk2bOhkmwDmRIUH9jIU=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c8c451dba86ec8fb4679ef9a181591f4bab04af8",
+        "rev": "cefc38747e5c587ad5dfad1630c0002b4c030803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps the `nix-ai` flake input to pick up two upstream fixes discovered during a full end-to-end promotion validation of this repo:

1. `token-meter-cleanup.sh` had lost its git executable bit, causing `Permission denied` during home-manager activation whenever `programs.token-meter.enable = false`. Fixed upstream by removing the script and its activation entry entirely (no replacement — an explicit, deliberate decision).
2. A duplicate `home.activation.validateClaudeSettings` definition in nix-ai's `modules/default.nix` collided with nix-claude-code's own entry of the same name, breaking home-manager evaluation with a conflicting-definition error. Fixed upstream by removing nix-ai's redundant copy (nix-claude-code's implementation already covers it, more safely).

## Test plan
- [x] `nix flake check` — clean
- [x] `nix fmt` / `statix check` / `deadnix` — clean
- [x] Full real-lock `sudo darwin-rebuild switch --flake ".#jevans-mbp"` — exit 0
- [x] Full real-lock `sudo darwin-rebuild switch --flake "github:dryvist/nix-darwin/develop#jevans-ms" --override-input nix-ai github:dryvist/nix-ai/main` over SSH — exit 0
- [x] Both rebuild logs reviewed line-by-line for any error/warning/failed/denied string; the only matches present are long-standing, pre-existing, and unrelated to this diff (nix-ai's deliberately non-fatal MLX notification-url activation warning from #1387/#1389 merged weeks before this session; a jevans-ms-only Homebrew internal trust-store ownership quirk unrelated to nix-ai; a `tmutil addexclusion` warning dating to nix-darwin #1056)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> flake.lock-only pin update; no local module or auth changes. Risk is limited to whatever those two upstream activation removals do on rebuild.
> 
> **Overview**
> Bumps the `nix-ai` flake input on `main` (`c8c451d` → `cefc387`) so this repo picks up two upstream home-manager activation fixes.
> 
> The new lock drops the broken `token-meter-cleanup.sh` activation (executable bit lost, `Permission denied` when token-meter is disabled) and removes nix-ai’s duplicate `home.activation.validateClaudeSettings`, which collided with nix-claude-code and broke evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9d9ba530ca733173a805c6f453e7fc18d9c94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->