### PR TITLE
fix(activation): treat DRY_RUN/dryRun as booleans, not mere presence

### DIFF
--- a/modules/darwin/hm-activation-assert.nix
+++ b/modules/darwin/hm-activation-assert.nix
@@ -35,7 +35,11 @@ in
     hmGenLink="${homeDir}/.local/state/home-manager/gcroots/current-home"
     hmParentArgs="$(ps -p "$PPID" -ww -o args= || true)"
 
-    if [[ -v DRY_RUN || -v dryRun || "$hmParentArgs" == *" --dry-run"* ]]; then
+    isDryRunFlag() {
+      [ -n "$1" ] && [ "$1" != "false" ] && [ "$1" != "0" ]
+    }
+
+    if isDryRunFlag "''${DRY_RUN-}" || isDryRunFlag "''${dryRun-}" || [[ "$hmParentArgs" == *" --dry-run"* ]]; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] dry run — skipping home-manager generation check"
     elif [ "$(readlink "$hmGenLink" 2>/dev/null)" = "${hmGeneration}" ]; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] ✓ home-manager generation verified: ${hmGeneration}"

--- a/modules/darwin/hm-activation-assert.nix
+++ b/modules/darwin/hm-activation-assert.nix
@@ -35,7 +35,7 @@ in
     hmGenLink="${homeDir}/.local/state/home-manager/gcroots/current-home"
     hmParentArgs="$(ps -p "$PPID" -ww -o args= || true)"
 
-    if [[ -v DRY_RUN || "$hmParentArgs" == *" --dry-run"* ]]; then
+    if [[ -v DRY_RUN || -v dryRun || "$hmParentArgs" == *" --dry-run"* ]]; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] dry run — skipping home-manager generation check"
     elif [ "$(readlink "$hmGenLink" 2>/dev/null)" = "${hmGeneration}" ]; then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] ✓ home-manager generation verified: ${hmGeneration}"


### PR DESCRIPTION
## Summary
Resolves gemini-code-assist review feedback on the develop→main promotion PR (#2249): `hm-activation-assert.nix`'s dry-run detection now checks both `DRY_RUN` and `dryRun` (camelCase) env vars, and treats them as booleans (must be set AND not `false`/`0`) rather than merely checking presence with `-v`.

## Changes
- `modules/darwin/hm-activation-assert.nix`: add a local `isDryRunFlag` helper and use it for both variable spellings, alongside the existing `ps`-based `--dry-run` arg detection.

## Why
Verified against the fetched nix-darwin upstream source that neither `DRY_RUN` nor `dryRun` is ever set by nix-darwin itself (`--dry-run` on `darwin-rebuild` is purely a `nix build` flag, never reaching `system.activationScripts`), so this is defensive widening for a future/external caller, not a fix to an observed failure. The truthiness check prevents a caller that explicitly sets `DRY_RUN=false` from accidentally triggering the skip.

## Test plan
- [x] `nix fmt` / `statix check` / `deadnix` — clean
- [x] `nix flake check` — clean
- [x] CI green, CodeQL clean, both review threads resolved