### PR TITLE
chore(deps): bump nix-ai for the haiku-tier default

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1787658065,
-        "narHash": "sha256-GFqZ6r90EE2GOQ24CbTdOV4b/Idg+I8vPBQUCR11q9o=",
+        "lastModified": 1787660126,
+        "narHash": "sha256-WfDHncSsj3JHxb79F5UbQZYse2FtyXhr/5sZNzWHdvs=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "b73126e1ca7206f7ae6513fdce52e435ac48aa83",
+        "rev": "50bc71b059bbe7a9db1016992281bf800f17ad40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pins nix-ai to the ref where the haiku tier uses the account default model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no local code changes; risk is limited to upstream nix-ai model-selection behavior for haiku-tier usage.
> 
> **Overview**
> Updates the locked **`nix-ai`** flake input from `b73126e` to `50bc71b` on `dryvist/nix-ai` `main`. **`flake.nix`** still follows `github:dryvist/nix-ai/main`; only **`flake.lock`** changes.
> 
> This pulls in upstream behavior where the **haiku tier** uses the **account default model** instead of a fixed haiku model, affecting how AI tooling in this flake resolves models for haiku-tier calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622332cc62f1c825df2999b687610a39bdc25d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->