### PR TITLE
chore(deps): bump the AI inputs for the config-merge fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1787660126,
-        "narHash": "sha256-WfDHncSsj3JHxb79F5UbQZYse2FtyXhr/5sZNzWHdvs=",
+        "lastModified": 1787663206,
+        "narHash": "sha256-caI3JZ+V1Vn8fPPB1IvbeTeZS/N6kiqiIkyrgdZZx/E=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "50bc71b059bbe7a9db1016992281bf800f17ad40",
+        "rev": "b0559e1231276b480f21b25c6ef9f6b4add5d483",
         "type": "github"
       },
       "original": {
@@ -1174,11 +1174,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787577939,
-        "narHash": "sha256-xuPuiy/ga5SGd6VHLU5f6w1LMIIGgANxPe+9XPd/h5E=",
+        "lastModified": 1787661629,
+        "narHash": "sha256-a099I2GsDxI7d2HRNIOiPYLej5dHHPVnOrBZ6Ukp3UE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "bd66034269e6966c83c8c4df41891ad96c73f20c",
+        "rev": "2423379182826f346686ed772e2c55b56e6d57de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up the activation-merge fixes: a variable or profile removed from configuration is now cleared from the runtime file instead of persisting, and the Codex profile moves into its own per-profile file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how AI assistant configs are materialized at activation time, which can alter on-disk Codex/Claude settings after rebuild though the intent is corrective merge behavior.
> 
> **Overview**
> Updates **`flake.lock`** only, advancing the pinned **`nix-ai`** and transitive **`nix-claude-code`** inputs to newer commits on `main`.
> 
> That upstream release carries **activation/config-merge fixes** for the AI tooling wired through this flake: values or profiles removed from Nix configuration are **cleared from the generated runtime files** instead of lingering, and **Codex profile settings** are written to a **dedicated per-profile file** rather than the previous layout.
> 
> After merge, the next **`home-manager` / darwin rebuild** will pick up the new module behavior; no local Nix source changes are required beyond the lock bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42bf72d8e632e673e39d3bf25f2f5b14b5b17c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->