### PR TITLE
feat(telemetry): wire Claude Code spans to the collector

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,11 +1054,11 @@
         "vct-splunk-cli": "vct-splunk-cli"
       },
       "locked": {
-        "lastModified": 1787827433,
-        "narHash": "sha256-Pm+mt5cf4BrndXLqXT59mo1P8vJq4K6MsHfwLxx53Dg=",
+        "lastModified": 1787912447,
+        "narHash": "sha256-155dkeTNHsB1iDU56thnnIHqShNN+IKIuZymvEO7IL0=",
         "owner": "dryvist",
         "repo": "nix-ai",
-        "rev": "c7872b9626567e273ee47f6ac9f95c3b041f1738",
+        "rev": "67d45859d8854901c2566a1a0b6cfb203779fee1",
         "type": "github"
       },
       "original": {
@@ -1174,11 +1174,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787826818,
-        "narHash": "sha256-I90XKzjD61EHZlJ0ZJt49F6VBlaFMxGmGXH1rwvPyOw=",
+        "lastModified": 1787907038,
+        "narHash": "sha256-iJU5VFoT4VDuNBieQzkRA3wDOfqZqwwSl2xCd2bEEYM=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "6ab5a501100eed68c9878dae532da1ecc53e7767",
+        "rev": "3199c92110e5864a4a7be8c92aea530b5ebaf113",
         "type": "github"
       },
       "original": {
@@ -1223,11 +1223,11 @@
         "orbstack-kubernetes": "orbstack-kubernetes"
       },
       "locked": {
-        "lastModified": 1787480674,
-        "narHash": "sha256-K+GKVSi0M/rENIyMxkxr4RCMT7MHtZ8jvx/PK86fFNo=",
+        "lastModified": 1787911814,
+        "narHash": "sha256-oEhK6hPQmj6inZSpDrzUGkH45bpItB9YMcOZVxR2TxU=",
         "owner": "dryvist",
         "repo": "nix-home",
-        "rev": "04c9eed4716564e1b6aa1c6773cd56e4a0054c8f",
+        "rev": "50e03dcc15b79fd0f031300dc0ba783f7e53406f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,7 @@
           # host-specific: without host.name every Mac reporting to the shared
           # collector is indistinguishable in the backend.
           hostUserConfig = userConfig // {
-            telemetry = userConfig.telemetry // {
+            telemetry = (userConfig.telemetry or { }) // {
               resourceAttributes = (userConfig.telemetry.resourceAttributes or { }) // {
                 "host.name" = hostConfig.hostName;
               };

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,16 @@
               isServer = class == "server";
             }
           );
+          # Telemetry resource attributes are the one part of userConfig that is
+          # host-specific: without host.name every Mac reporting to the shared
+          # collector is indistinguishable in the backend.
+          hostUserConfig = userConfig // {
+            telemetry = userConfig.telemetry // {
+              resourceAttributes = (userConfig.telemetry.resourceAttributes or { }) // {
+                "host.name" = hostConfig.hostName;
+              };
+            };
+          };
         in
         darwin.lib.darwinSystem {
           # nix-darwin is Darwin-only and every host is Apple Silicon, so the
@@ -214,12 +224,13 @@
                 # `hostConfig` threads the per-host attrset to home-manager modules.
                 extraSpecialArgs = {
                   inherit
-                    userConfig
                     dotgithub
                     hostConfig
                     nix-ai
                     nix-openwhispr
                     ;
+                  # Host-stamped: see hostUserConfig above.
+                  userConfig = hostUserConfig;
                 };
                 users.${userConfig.user.name} = import ./hosts/${label}/home.nix;
 

--- a/hosts/common/home.nix
+++ b/hosts/common/home.nix
@@ -90,15 +90,11 @@ in
   monitoring = {
     enable = true;
     kubernetes.enable = true;
-    otel = {
-      enable = true;
-      # endpoint defaults to http://localhost:30317 (NodePort gRPC)
-      logPrompts = true;
-      logToolDetails = true;
-      resourceAttributes = {
-        "host.name" = hostConfig.hostName;
-      };
-    };
+    # Claude Code's OTEL variables come from nix-ai (userConfig.telemetry),
+    # which owns AI-tool configuration. This module would set the same
+    # variables a second time through the login shell, and two sources for one
+    # set of variables drift. Left off so there is exactly one.
+    otel.enable = false;
     cribl.enable = true;
   };
 

--- a/lib/user-config.nix
+++ b/lib/user-config.nix
@@ -167,9 +167,35 @@ in
     ];
   };
 
-  # Claude Code OpenTelemetry → local OrbStack k8s OTEL collector. nix-ai
-  # resolves the endpoint port from its registry (nodeports.otel_grpc).
-  telemetry.enable = true;
+  # Claude Code OpenTelemetry. Endpoints compose from internalDomain, never
+  # re-spelled — see the let-binding above.
+  #
+  # Traces only. The collector behind that name extracts spans and forwards
+  # them on; it does not extract metrics or logs, so pointing those signals at
+  # it would hand over data the pipeline discards. nix-ai gates each signal on
+  # its own endpoint and pins the unused exporters to `none`, so leaving
+  # otlpEndpoint unset means metrics and logs are not emitted at all rather
+  # than emitted to a conventional default address.
+  #
+  # Spans are also the signal worth having: session transcripts already carry
+  # per-message token counts, while latency, tool duration, and subagent
+  # structure exist nowhere else.
+  telemetry = {
+    enable = true;
+
+    # Signal-specific, so it carries the full path — nothing is appended.
+    # Setting it is also what turns span emission on at all.
+    tracesEndpoint = "https://otel.${internalDomain}/v1/traces";
+
+    serviceName = "claude-code";
+    # host.name is per-host, so flake.nix's mkHost merges it in — this file is
+    # host-agnostic and every host would otherwise report the same identity.
+
+    # Ships full prompt and tool content. Deliberate, and only sound because
+    # the collector and every hop past it are self-hosted on the internal zone.
+    logUserPrompts = true;
+    logToolDetails = true;
+  };
 
   # Personal directories Claude Code may read without per-prompt approval.
   extraTrustedPaths = [ "~/.claude/skills/retrospecting/reports/" ];


### PR DESCRIPTION
## Summary

Sets the traces endpoint, service name, and content flags for Claude Code
telemetry, and stamps `host.name` per host.

## Changes

- `telemetry.tracesEndpoint` composes from `internalDomain`, following the
  existing rule that internal FQDNs are never re-spelled at a use site.
- `flake.nix` merges `host.name` into the telemetry resource attributes in
  `mkHost`. That attribute is the one host-specific part of `userConfig`;
  without it every Mac reporting to one collector is indistinguishable.
- Traces only. `otlpEndpoint` is left unset: nix-ai gates each signal on its
  own endpoint and pins the unused exporters to `none`, so metrics and logs are
  not emitted rather than emitted to a conventional default address.
- `logUserPrompts` and `logToolDetails` are on. These ship prompt and tool
  content to the collector, which is sound only because every hop is
  self-hosted.
- Turns off nix-home's `monitoring.otel`. It set the same `OTEL_*` variables a
  second time through the login shell; two sources for one set of variables
  drift without anything surfacing it. nix-ai owns AI-tool configuration.
- Bumps `nix-ai` and `nix-home` for the option surface above.

## Test Plan

- `nix build .#darwinConfigurations.<host>.system` from the locked inputs (no
  `--override-input`) succeeds.
- Converged on the target host (`darwin-rebuild switch`, exit 0), then a fresh
  session emitted spans that were observed arriving in both backends:
  `claude_code.interaction`, `claude_code.llm_request`,
  `claude_code.tool.execution`, `claude_code.tool.blocked_on_user`.
- The deployed generation's `hm-session-vars.sh` carries no `OTEL_*`,
  confirming the second source is gone.

Related: dryvist/nix-ai#1801, dryvist/nix-home#451.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables full prompt/tool payload export to the internal collector and changes which module sets OTEL env vars on every host rebuild; misconfiguration could leak sensitive session content or break span export until converged.
> 
> **Overview**
> Routes **Claude Code OpenTelemetry through nix-ai** (`userConfig.telemetry`): traces go to `https://otel.${internalDomain}/v1/traces`, with `serviceName`, prompt/tool content flags, and **traces only** (no metrics/logs endpoint so unused signals stay off).
> 
> **Per-host identity:** `flake.nix` builds `hostUserConfig` that merges `host.name` from each host’s `hostName` into telemetry resource attributes and passes that into Home Manager instead of the shared `userConfig`.
> 
> **Single OTEL source:** `monitoring.otel` in nix-home is turned off so login-shell `OTEL_*` vars are not duplicated alongside nix-ai’s AI-tool telemetry.
> 
> **Lockfile:** bumps `nix-ai`, `nix-claude-code`, and `nix-home` for the new telemetry option surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef48b2c20bbcfda40eafa71b11ab914505181a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->